### PR TITLE
Add some precompile statements for faster startup

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -216,7 +216,7 @@ julia> JuliaInterpreter.prepare_args(mymethod, [mymethod, 1, 2], [:verbose=>true
 (getfield( Symbol("#kw##mymethod"))(), Any[#kw##mymethod(), (verbose = true,), mymethod, 1, 2])
 ```
 """
-function prepare_args(f, allargs, kwargs)
+function prepare_args(@nospecialize(f), allargs, kwargs)
     if !isempty(kwargs)
         of = f
         f = Core.kwfunc(f)
@@ -267,7 +267,7 @@ julia> argtypes
 Tuple{typeof(mymethod),Array{Float64,1}}
 ```
 """
-function prepare_call(f, allargs; enter_generated = false)
+function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     args = allargs[2:end]
     argtypes = Tuple{map(_Typeof,args)...}
     method = try
@@ -870,5 +870,8 @@ macro interpret(arg)
         finish_and_return!(stack, frame)
     end
 end
+
+include("precompile.jl")
+_precompile_()
 
 end # module

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -68,7 +68,7 @@ end
 # and hence our re-use of the `callargs` field of JuliaStackFrame would introduce
 # bugs. Since these nodes use a very limited repertoire of calls, we can special-case
 # this quite easily.
-function lookup_or_eval(stack, frame, node, pc)
+function lookup_or_eval(stack, frame, @nospecialize(node), pc)
     if isa(node, SSAValue)
         return lookup_var(frame, node)
     elseif isa(node, SlotNumber)
@@ -106,7 +106,7 @@ end
 instantiate_type_in_env(arg, spsig, spvals) =
     ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), arg, spsig, spvals)
 
-function resolvefc(expr)
+function resolvefc(@nospecialize expr)
     (isa(expr, Symbol) || isa(expr, String) || isa(expr, QuoteNode)) && return expr
     if isexpr(expr, :call)
         a = expr.args[1]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,47 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(maybe_evaluate_builtin), JuliaStackFrame, Expr})
+    precompile(Tuple{typeof(getargs), Vector{Any}, JuliaStackFrame})
+    precompile(Tuple{typeof(get_call_framecode), Vector{Any}, JuliaFrameCode, Int})
+    for f in (evaluate_call!,
+              evaluate_foreigncall!,
+              evaluate_methoddef!,
+              evaluate_structtype!,
+              evaluate_abstracttype!,
+              evaluate_primitivetype!)
+        precompile(Tuple{typeof(f), Compiled, JuliaStackFrame, Expr, JuliaProgramCounter})
+        precompile(Tuple{typeof(f), Vector{JuliaStackFrame}, JuliaStackFrame, Expr, JuliaProgramCounter})
+    end
+    precompile(Tuple{typeof(lookup_global_refs!), Expr})
+    precompile(Tuple{typeof(lookup_or_eval), Compiled, JuliaStackFrame, Any, JuliaProgramCounter})
+    precompile(Tuple{typeof(lookup_or_eval), Vector{JuliaStackFrame}, JuliaStackFrame, Any, JuliaProgramCounter})
+    precompile(Tuple{typeof(eval_rhs), Compiled, JuliaStackFrame, Expr, JuliaProgramCounter})
+    precompile(Tuple{typeof(eval_rhs), Vector{JuliaStackFrame}, JuliaStackFrame, Expr, JuliaProgramCounter})
+    precompile(Tuple{typeof(_step_expr!), Compiled, JuliaStackFrame, Any, JuliaProgramCounter, Bool})
+    precompile(Tuple{typeof(_step_expr!), Vector{JuliaStackFrame}, JuliaStackFrame, Any, JuliaProgramCounter, Bool})
+    for f in (finish!, finish_and_return!)
+        precompile(Tuple{typeof(f), Compiled, JuliaStackFrame, JuliaProgramCounter, Bool})
+        precompile(Tuple{typeof(f), Vector{JuliaStackFrame}, JuliaStackFrame, JuliaProgramCounter, Bool})
+    end
+    precompile(Tuple{typeof(prepare_toplevel), Module, Expr})
+    precompile(Tuple{typeof(prepare_thunk), Module, Expr})
+    precompile(Tuple{typeof(prepare_locals), JuliaFrameCode, Vector{Any}})
+    precompile(Tuple{typeof(prepare_args), Any, Vector{Any}, Vector{Any}})
+    precompile(Tuple{typeof(prepare_call), Any, Vector{Any}})
+    precompile(Tuple{typeof(build_frame), JuliaFrameCode, Vector{Any}, Core.SimpleVector})
+    precompile(Tuple{typeof(extract_args), Module, Expr})
+    precompile(Tuple{typeof(enter_call), Int, Int})
+    precompile(Tuple{typeof(enter_call_expr), Expr})
+    precompile(Tuple{typeof(copy_codeinfo), Core.CodeInfo})
+    precompile(Tuple{typeof(optimize!), Core.CodeInfo, Module})
+    precompile(Tuple{typeof(interpret!), Vector{JuliaStackFrame}, Module, Expr})
+    precompile(Tuple{typeof(set_structtype_const), Module, Symbol})
+    precompile(Tuple{typeof(namedtuple), Vector{Any}})
+    precompile(Tuple{typeof(resolvefc), Any})
+    precompile(Tuple{typeof(checkfor_head), typeof(cant_be_lowered), Expr})
+    precompile(Tuple{typeof(check_isdefined), JuliaStackFrame, Expr})
+    precompile(Tuple{typeof(check_isdefined), JuliaStackFrame, Symbol})
+    precompile(Tuple{typeof(find_used), Core.CodeInfo})
+    precompile(Tuple{typeof(do_assignment!), JuliaStackFrame, Int, Int})
+    precompile(Tuple{typeof(pc_expr), JuliaStackFrame, Nothing})
+end


### PR DESCRIPTION
This doesn't help a lot:
```julia
julia> using JuliaInterpreter

julia> @time @interpret sum(rand(5))
  5.571196 seconds (2.70 M allocations: 125.351 MiB, 0.40% gc time)
2.2449034191308073
```

but it does shave ~1s off on my machine. Most of the time is spent in LLVM, so until we can cache native code I don't think there's much we can do.