### PR TITLE
Support diversion of specific methods to Compiled

### DIFF
--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -60,7 +60,11 @@ function get_call_framecode(fargs, parentframe::JuliaFrameCode, idx::Int)
     if f === Base._return_type
         return Base._return_type(fargs[2:end]...), nothing
     end
-    framecode, args, env, argtypes = prepare_call(f, fargs)
+    ret = prepare_call(f, fargs)
+    if isa(ret, Compiled)
+        return ret, nothing
+    end
+    framecode, args, env, argtypes = ret
     # Store the results of the method lookup in the local method table
     tme = ccall(:jl_new_struct_uninit, Any, (Any,), TypeMapEntry)::TypeMapEntry
     tme.func = mi = ccall(:jl_new_struct_uninit, Any, (Any,), MethodInstance)::MethodInstance

--- a/test/juliatests.jl
+++ b/test/juliatests.jl
@@ -1,5 +1,5 @@
 using JuliaInterpreter
-using Test
+using Test, Random
 
 if !isdefined(Main, :read_and_parse)
     include("utils.jl")
@@ -18,6 +18,21 @@ using Test
 end
 
 @testset "Julia tests" begin
+    # To do this efficiently, certain methods must be run in Compiled mode
+    cm = JuliaInterpreter.compiled_methods
+    empty!(cm)
+    push!(cm, which(Test.eval_test, Tuple{Expr, Expr, LineNumberNode}))
+    push!(cm, which(Test.finish, Tuple{Test.DefaultTestSet}))
+    push!(cm, which(Test.get_testset, Tuple{}))
+    push!(cm, which(Test.push_testset, Tuple{Test.AbstractTestSet}))
+    push!(cm, which(Test.pop_testset, Tuple{}))
+    push!(cm, which(Random.seed!, Tuple{Union{Integer,Vector{UInt32}}}))
+    push!(cm, which(copy!, Tuple{Random.MersenneTwister, Random.MersenneTwister}))
+    push!(cm, which(copy, Tuple{Random.MersenneTwister}))
+    push!(cm, which(Base.include, Tuple{Module, String}))
+    push!(cm, which(Base.show_backtrace, Tuple{IO, Vector}))
+    push!(cm, which(Base.show_backtrace, Tuple{IO, Vector{Any}}))
+
     stack = JuliaStackFrame[]
     function runtest(frame)
         empty!(stack)


### PR DESCRIPTION
Some of the infrastructure in Test takes a long time to run in interpreted mode; we can speed things up by running specific items in compiled mode.