### PR TITLE
Handle rethrow

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -172,6 +172,9 @@ function evaluate_call!(stack, frame::JuliaStackFrame, call_expr::Expr, pc)
     fargs = collect_args(frame, call_expr)
     if fargs[1] === Core.eval
         return Core.eval(fargs[2], fargs[3])  # not a builtin, but worth treating specially
+    elseif fargs[1] === Base.rethrow
+        err = length(fargs) > 1 ? fargs[2] : frame.last_exception[]
+        throw(err)
     end
     framecode, lenv = get_call_framecode(fargs, frame.code, pc.next_stmt)
     if lenv === nothing

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -30,6 +30,55 @@ end
 fkw(x::Int8; y=0, z="hello") = y
 @test @interpret(fkw(Int8(1); y=22, z="world")) == fkw(Int8(1); y=22, z="world")
 
+# Throwing exceptions across frames
+function f_exc_inner()
+    error("inner")
+end
+
+f_exc_inner2() = f_exc_inner()
+
+const caught = Ref(false)
+function f_exc_outer1()
+    try
+        f_exc_inner()
+    catch err    # with an explicit err capture
+        caught[] = true
+        rethrow(err)
+    end
+end
+
+function f_exc_outer2()
+    try
+        f_exc_inner()
+    catch        # implicit err capture
+        caught[] = true
+        rethrow()
+    end
+end
+
+function f_exc_outer3(f)
+    try
+        f()
+    catch err
+        return err
+    end
+end
+
+@test !caught[]
+ret = @interpret f_exc_outer3(f_exc_outer1)
+@test ret == ErrorException("inner")
+@test caught[]
+
+caught[] = false
+ret = @interpret f_exc_outer3(f_exc_outer2)
+@test ret == ErrorException("inner")
+@test caught[]
+
+caught[] = false
+ret = @interpret f_exc_outer3(f_exc_inner2)
+@test ret == ErrorException("inner")
+@test !caught[]
+
 # issue #3
 @test @interpret(joinpath("/home/julia/base", "sysimg.jl")) == "/home/julia/base/sysimg.jl"
 @test @interpret(10.0^4) == 10.0^4

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -79,6 +79,15 @@ ret = @interpret f_exc_outer3(f_exc_inner2)
 @test ret == ErrorException("inner")
 @test !caught[]
 
+
+stc = try f_exc_outer1() catch
+    stacktrace(catch_backtrace())
+end
+sti = try @interpret(f_exc_outer1()) catch
+    stacktrace(catch_backtrace())
+end
+@test_broken stc == sti
+
 # issue #3
 @test @interpret(joinpath("/home/julia/base", "sysimg.jl")) == "/home/julia/base/sysimg.jl"
 @test @interpret(10.0^4) == 10.0^4


### PR DESCRIPTION
rethrow is only viable inside a `catch`, so we need to intercept it and convert it to an ordinary `throw`.

In my hands, this was perhaps the single biggest limitation of JuliaInterpreter. I frequently got
```julia
julia> @test ret == ErrorException("inner")
Test Failed at REPL[10]:1
  Expression: ret == ErrorException("inner")
   Evaluated: ErrorException("rethrow(exc) not allowed outside a catch block") == ErrorException("inner")
ERROR: There was an error during testing
```

I expect this to have a substantial positive impact on #13.