### PR TITLE
also test Debugger.jl on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ branches:
 notifications:
   email: false
 
+script:
+    - export JULIA_PROJECT=""
+    - julia --project -e 'using Pkg; Pkg.build(); Pkg.test();'
+    - julia --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); 
+                                       Pkg.add(PackageSpec(url="https://github.com/JuliaDebug/Debugger.jl"));
+                                       Pkg.add(PackageSpec(url="https://github.com/Keno/TerminalRegressionTests.jl"));
+                                       Pkg.test("Debugger")'
+
 jobs:
   include:
     - stage: "Documentation"


### PR DESCRIPTION
For now, Debugger.jl is a bit too tightly coupled to the internals of JuliaInterpreter.jl. Therefore, test that Debugger keeps working on CI.