### PR TITLE
A grab-bag of correctness fixes

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -298,7 +298,7 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     args = allargs
     sig = method.sig
     isa(method, TypeMapEntry) && (method = method.func)
-    if method ∈ compiled_methods
+    if method.module == Core.Compiler || method ∈ compiled_methods
         return Compiled()
     end
     # Get static parameters

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -455,8 +455,8 @@ function renumber_ssa!(stmts::Vector{Any}, ssalookup)
             stmts[i] = SSAValue(stmt.id)
         elseif isa(stmt, Expr)
             replace_ssa!(stmt, ssalookup)
-            if stmt.head == :gotoifnot && isa(stmt.args[2], Int)
-                stmt.args[2] = ssalookup[stmt.args[2]]
+            if (stmt.head == :gotoifnot || stmt.head == :enter) && isa(stmt.args[end], Int)
+                stmt.args[end] = ssalookup[stmt.args[end]]
             end
         end
     end

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -464,6 +464,7 @@ function renumber_ssa!(stmts::Vector{Any}, ssalookup)
 end
 
 function lookup_global_refs!(ex::Expr)
+    isexpr(ex, :isdefined) && return nothing
     for (i, a) in enumerate(ex.args)
         if isa(a, GlobalRef)
             r = getfield(a.mod, a.name)
@@ -472,6 +473,7 @@ function lookup_global_refs!(ex::Expr)
             lookup_global_refs!(a)
         end
     end
+    return nothing
 end
 
 """

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -143,6 +143,15 @@ include("localmethtable.jl")
 include("interpret.jl")
 include("builtins.jl")
 
+function show_stackloc(io::IO, stack, frame, pc=frame.pc[])
+    indent = ""
+    for f in stack
+        println(io, indent, f.code.scope)
+        indent *= "  "
+    end
+    println(io, indent, frame.code.scope, ", pc = ", convert(Int, pc))
+end
+
 function moduleof(x)
     if isa(x, JuliaStackFrame)
         x = x.code.scope

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -540,9 +540,9 @@ function prepare_locals(framecode, argvals::Vector{Any})
             exception_frames, last_reference = oldframe.exception_frames, oldframe.last_reference
             callargs = oldframe.callargs
             last_exception, pc = oldframe.last_exception, oldframe.pc
-            # for check_isdefined to work properly, we need locals and sparams to start out unassigned
-            resize!(resize!(locals, 0), length(code.slotflags))
+            resize!(locals, length(code.slotflags))
             resize!(ssavalues, ng)
+            # for check_isdefined to work properly, we need sparams to start out unassigned
             resize!(resize!(sparams, 0), length(meth.sparam_syms))
             empty!(exception_frames)
             empty!(last_reference)
@@ -572,6 +572,7 @@ function prepare_locals(framecode, argvals::Vector{Any})
     else
         code = framecode.code
         locals = Vector{Union{Nothing,Some{Any}}}(undef, length(code.slotflags))
+        fill!(locals, nothing)
         ssavalues = Vector{Any}(undef, length(code.code))
         sparams = Any[]
         exception_frames = Int[]

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -10,7 +10,7 @@ lookup_var(frame, ref::GlobalRef) = getfield(ref.mod, ref.name)
 function lookup_var(frame, slot::SlotNumber)
     val = frame.locals[slot.id]
     val !== nothing && return val.value
-    error("slot ", slot, " not assigned")
+    error("slot ", slot, " with name ", frame.code.code.slotnames[slot.id], " not assigned")
 end
 
 function lookup_expr(frame, e::Expr)
@@ -313,7 +313,7 @@ end
 
 function check_isdefined(frame, node)
     if isa(node, SlotNumber)
-        return isassigned(frame.locals, slot.id)
+        return frame.locals[node.id] !== nothing
     elseif isexpr(node, :static_parameter)
         return isassigned(frame.sparams, node.args[1]::Int)
     elseif isa(node, GlobalRef)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -106,9 +106,15 @@ end
 instantiate_type_in_env(arg, spsig, spvals) =
     ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), arg, spsig, spvals)
 
-function resolvefc(@nospecialize expr)
-    (isa(expr, Symbol) || isa(expr, String) || isa(expr, QuoteNode)) && return expr
+function resolvefc(frame, @nospecialize expr)
+    if isa(expr, SlotNumber)
+        expr = lookup_var(frame, expr)
+    end
+    (isa(expr, Symbol) || isa(expr, String) || isa(expr, Ptr) || isa(expr, QuoteNode)) && return expr
     isa(expr, Tuple{Symbol,Symbol}) && return expr
+    isa(expr, Tuple{String,String}) && return expr
+    isa(expr, Tuple{Symbol,String}) && return expr
+    isa(expr, Tuple{String,Symbol}) && return expr
     if isexpr(expr, :call)
         a = expr.args[1]
         (isa(a, QuoteNode) && a.value == Core.tuple) || error("unexpected ccall to ", expr)
@@ -121,7 +127,7 @@ function collect_args(frame, call_expr; isfc=false)
     args = frame.callargs
     resize!(args, length(call_expr.args))
     mod = moduleof(frame)
-    args[1] = isfc ? resolvefc(call_expr.args[1]) : @lookup(mod, frame, call_expr.args[1])
+    args[1] = isfc ? resolvefc(frame, call_expr.args[1]) : @lookup(mod, frame, call_expr.args[1])
     for i = 2:length(args)
         args[i] = @lookup(mod, frame, call_expr.args[i])
     end
@@ -136,7 +142,7 @@ Evaluate a `:foreigncall` (from a `ccall`) statement `callexpr` in the context o
 """
 function evaluate_foreigncall!(stack, frame::JuliaStackFrame, call_expr::Expr, pc)
     args = collect_args(frame, call_expr; isfc=true)
-    for i = 1:length(args)
+    for i = 2:length(args)
         arg = args[i]
         args[i] = isa(arg, Symbol) ? QuoteNode(arg) : arg
     end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -323,7 +323,7 @@ function check_isdefined(frame, node)
     elseif isexpr(node, :static_parameter)
         return isassigned(frame.sparams, node.args[1]::Int)
     elseif isa(node, GlobalRef)
-        return isdefined(ref.mod, ref.name)
+        return isdefined(node.mod, node.name)
     elseif isa(node, Symbol)
         return isdefined(moduleof(frame), node)
     end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -117,3 +117,20 @@ frame = JuliaInterpreter.prepare_toplevel(Main, ex)
 JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true)
 
 @test @interpret Base.Math.DoubleFloat64(-0.5707963267948967, 4.9789962508669555e-17).hi ≈ -0.5707963267948967
+
+# ccall with cfunction
+fcfun(x::Int, y::Int) = 1
+ex = quote   # in lowered code, cf is a Symbol
+    cf = @eval @cfunction(fcfun, Int, (Int, Int))
+    ccall(cf, Int, (Int, Int), 1, 2)
+end
+frame = JuliaInterpreter.prepare_toplevel(Main, ex)
+@test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) == 1
+ex = quote
+    let   # in lowered code, cf is a SlotNumber
+        cf = @eval @cfunction(fcfun, Int, (Int, Int))
+        ccall(cf, Int, (Int, Int), 1, 2)
+    end
+end
+frame = JuliaInterpreter.prepare_toplevel(Main, ex)
+@test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) == 1

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -134,3 +134,10 @@ ex = quote
 end
 frame = JuliaInterpreter.prepare_toplevel(Main, ex)
 @test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) == 1
+
+# Core.Compiler
+ex = quote
+    length(code_typed(fcfun, (Int, Int)))
+end
+frame = JuliaInterpreter.prepare_toplevel(Main, ex)
+@test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) == 1

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -98,7 +98,7 @@ module Toplevel end
     @test @interpret(Toplevel.f3(1, :hi)) == 2
     @test @interpret(Toplevel.f3(UInt16(1), :hi)) == Symbol
     @test @interpret(Toplevel.f3(rand(2, 2), :hi, :there)) == 2
-    @test_throws ErrorException("no unique matching method found for the specified argument types") @interpret(Toplevel.f3([1.0], :hi, :there))
+    @test_throws MethodError @interpret(Toplevel.f3([1.0], :hi, :there))
     @test @interpret(Toplevel.f4(1, 1.0)) == 1
     @test @interpret(Toplevel.f4(1, 1)) == @interpret(Toplevel.f4(1)) == 2
     @test @interpret(Toplevel.f4(UInt(1), "hey", 2)) == 3
@@ -127,7 +127,7 @@ module Toplevel end
     @test @interpret(Toplevel.fouter(1)) === 2
     @test @interpret(Toplevel.feval1(1.0)) === 1
     @test @interpret(Toplevel.feval1(1.0f0)) === 1
-    @test_throws ErrorException("no unique matching method found for the specified argument types") @interpret(Toplevel.feval1(1))
+    @test_throws MethodError @interpret(Toplevel.feval1(1))
     @test @interpret(Toplevel.feval2(1.0, Int8(1))) == 2
     @test @interpret(length(s)) === nothing
     @test @interpret(size(s)) === nothing


### PR DESCRIPTION
This collection of commits emerged from trying to address #13. With `julia --startup-file=no` (so no extraneous packages are loaded), we now get through `test/ambiguous.jl` and almost the first 1k lines of `strings/basic.jl`. I do not yet know if the failure to progress farther is a bug or just a performance problem.