### PR TITLE
rethrow interrupt exceptions when testing julia

### DIFF
--- a/test/juliatests.jl
+++ b/test/juliatests.jl
@@ -35,6 +35,7 @@ end
                 lower_incrementally(runtest, JuliaTests, ex)
                 println("Succeeded on ", test)
             catch err
+                err isa InterruptException && rethrow(err)
                 @show test err
                 push!(failed, (test, err))
                 # rethrow(err)


### PR DESCRIPTION
Makes it a bit easier to stop the execution when running the julia tests.