### PR TITLE
Run Julia tests with resource limits, with worker process, and collate the results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ failed.out
 src/builtins.jl
 deps/build.log
 docs/build/
+test/results.md

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,6 +3,10 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -10,3 +14,13 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,9 @@ version = "0.1.1"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [extras]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Distributed", "Random"]

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -151,6 +151,7 @@ function show_stackloc(io::IO, stack, frame, pc=frame.pc[])
     end
     println(io, indent, frame.code.scope, ", pc = ", convert(Int, pc))
 end
+show_stackloc(stack, frame, pc=frame.pc[]) = show_stackloc(stderr, stack, frame, pc)
 
 function moduleof(x)
     if isa(x, JuliaStackFrame)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -333,6 +333,8 @@ end
 
 function _step_expr!(stack, frame, @nospecialize(node), pc::JuliaProgramCounter, istoplevel::Bool)
     local rhs
+    # show_stackloc(stack, frame, pc)
+    # @show node
     try
         if isa(node, Expr)
             if node.head == :(=)

--- a/test/juliatests.jl
+++ b/test/juliatests.jl
@@ -1,5 +1,5 @@
 using JuliaInterpreter
-using Test, Random
+using Test, Random, InteractiveUtils
 
 if !isdefined(Main, :read_and_parse)
     include("utils.jl")
@@ -10,7 +10,20 @@ const testdir = joinpath(juliadir, "test")
 if isdir(testdir)
     include(joinpath(testdir, "choosetests.jl"))
 else
-    @warn "Julia's test/ directory not found, skipping Julia tests"
+    @error "Julia's test/ directory not found, can't run Julia tests"
+end
+
+nstmts = 10^4  # very quick, aborts a lot
+i = 1
+while i <= length(ARGS)
+    global i
+    a = ARGS[i]
+    if a == "--nstmts"
+        global nstmts = parse(Int, ARGS[i+1])
+        deleteat!(ARGS, i:i+1)
+    else
+        i += 1
+    end
 end
 
 module JuliaTests
@@ -22,10 +35,14 @@ end
     cm = JuliaInterpreter.compiled_methods
     empty!(cm)
     push!(cm, which(Test.eval_test, Tuple{Expr, Expr, LineNumberNode}))
-    push!(cm, which(Test.finish, Tuple{Test.DefaultTestSet}))
     push!(cm, which(Test.get_testset, Tuple{}))
     push!(cm, which(Test.push_testset, Tuple{Test.AbstractTestSet}))
     push!(cm, which(Test.pop_testset, Tuple{}))
+    for f in (Test.record, Test.finish)
+        for m in methods(f)
+            push!(cm, m)
+        end
+    end
     push!(cm, which(Random.seed!, Tuple{Union{Integer,Vector{UInt32}}}))
     push!(cm, which(copy!, Tuple{Random.MersenneTwister, Random.MersenneTwister}))
     push!(cm, which(copy, Tuple{Random.MersenneTwister}))
@@ -33,15 +50,14 @@ end
     push!(cm, which(Base.show_backtrace, Tuple{IO, Vector}))
     push!(cm, which(Base.show_backtrace, Tuple{IO, Vector{Any}}))
 
-    stack = JuliaStackFrame[]
-    function runtest(frame)
-        empty!(stack)
+    function runtest(frame, nstmts)
+        stack = JuliaStackFrame[]
         # empty!(JuliaInterpreter.framedict)
         # empty!(JuliaInterpreter.genframedict)
-        ret, nstmts = limited_finish_and_return!(stack, frame, 10^4, true)
+        ret, nstmts = limited_finish_and_return!(stack, frame, nstmts, true)
         return ret
     end
-    function dotest!(test)
+    function dotest!(test, nstmts)
         println("Working on ", test, "...")
         fullpath = joinpath(testdir, test)*".jl"
         ex = read_and_parse(fullpath)
@@ -50,28 +66,53 @@ end
         if isexpr(ex, :error)
             @error "error parsing $test: $ex"
         else
+            local ts, aborts
             try
                 current_task().storage[:SOURCE_PATH] = fullpath
-                lower_incrementally(runtest, JuliaTests, ex)
+                ts = Test.DefaultTestSet(test)
+                Test.push_testset(ts)
+                docexprs, aborts = lower_incrementally(frame->runtest(frame, nstmts), JuliaTests, ex)
                 # Core.eval(JuliaTests, ex)
                 println("Finished ", test)
             finally
                 current_task().storage[:SOURCE_PATH] = oldpath
             end
+            return ts, aborts
         end
     end
+
+    allts = Test.DefaultTestSet[]
+    allaborts = Vector{LineNumberNode}[]
+    succeeded = Bool[]
     if isdir(testdir)
-        tests, _ = choosetests()
-        delayed = []
+        tests, _ = choosetests(ARGS)
         for test in tests
-            if startswith(test, "compiler") || test == "subarray"
-                push!(delayed, test)
-            else
-                dotest!(test)
+            try
+                ts, aborts = dotest!(test, nstmts)
+                push!(allts, ts)
+                push!(allaborts, aborts)
+                push!(succeeded, true)
+            catch err
+                push!(allts, Test.DefaultTestSet(test))
+                push!(allaborts, LineNumberNode[])
+                push!(succeeded, false)
             end
         end
-        for test in delayed
-            dotest!(failed, test)
+    end
+    open("results.md", "w") do io
+        versioninfo(io)
+        println(io, "Maximum number of statements per lowered expression: ", nstmts)
+        println(io)
+        println(io, "| Test file | Passes | Fails | Errors | Broken | Aborted blocks |")
+        println(io, "| --------- | ------:| -----:| ------:| ------:| --------------:|")
+        for (test, ts, aborts, succ) in zip(tests, allts, allaborts, succeeded)
+            if succ
+                passes, fails, errors, broken, c_passes, c_fails, c_errors, c_broken = Test.get_test_counts(ts)
+                naborts = length(aborts)
+                println(io, "| ", test, " | ", passes+c_passes, " | ", fails+c_fails, " | ", errors+c_errors, " | ", broken+c_broken, " | ", naborts, " |")
+            else
+                println(io, "| ", test, " | X | X | X | X | X |")
+            end
         end
     end
 end

--- a/test/juliatests.jl
+++ b/test/juliatests.jl
@@ -38,7 +38,8 @@ end
         empty!(stack)
         # empty!(JuliaInterpreter.framedict)
         # empty!(JuliaInterpreter.genframedict)
-        return JuliaInterpreter.finish_and_return!(stack, frame, true)
+        ret, nstmts = limited_finish_and_return!(stack, frame, 10^4, true)
+        return ret
     end
     function dotest!(test)
         println("Working on ", test, "...")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,6 +2,7 @@ using JuliaInterpreter: JuliaStackFrame, JuliaProgramCounter, @lookup
 using JuliaInterpreter: finish_and_return!, @lookup, evaluate_call!, _step_expr!,
                         do_assignment!, getlhs, isassign, pc_expr, handle_err
 using Base.Meta: isexpr
+using Test
 
 # Execute a frame using Julia's regular compiled-code dispatch for any :call expressions
 runframe(frame, pc=frame.pc[]) = Some{Any}(finish_and_return!(Compiled(), frame, pc))
@@ -30,22 +31,23 @@ or one of its sub-modules) get returned in `docexprs[M]`.
 """
 function lower_incrementally(@nospecialize(f), mod::Module, ex::Expr)
     docexprs = Dict{Module,Vector{Expr}}()
-    lower_incrementally!(f, docexprs, mod, ex)
-    return docexprs
+    aborts = LineNumberNode[]
+    lower_incrementally!(f, docexprs, aborts, mod, ex)
+    return docexprs, aborts
 end
 
-lower_incrementally!(@nospecialize(f), docexprs, mod::Module, ex::Expr) =
-    lower_incrementally!(f, docexprs, Expr(:block), mod, ex)
+lower_incrementally!(@nospecialize(f), docexprs, aborts, mod::Module, ex::Expr) =
+    lower_incrementally!(f, docexprs, aborts, Expr(:block), mod, ex)
 
-function lower_incrementally!(@nospecialize(f), docexprs, lex:: Expr, mod::Module, ex::Expr)
+function lower_incrementally!(@nospecialize(f), docexprs, aborts, lex:: Expr, mod::Module, ex::Expr)
     # lex is the expression we'll lower; it will accumulate LineNumberNodes and a
     # single top-level expression. We split blocks, module defs, etc.
     if ex.head == :toplevel || ex.head == :block
-        lower_incrementally!(f, docexprs, lex, mod, ex.args)
+        lower_incrementally!(f, docexprs, aborts, lex, mod, ex.args)
     elseif ex.head == :module
         modname = ex.args[2]::Symbol
         newmod = isdefined(mod, modname) ? getfield(mod, modname) : Core.eval(mod, :(module $modname end))
-        lower_incrementally!(f, docexprs, lex, newmod, ex.args[3])
+        lower_incrementally!(f, docexprs, aborts, lex, newmod, ex.args[3])
     elseif isdocexpr(ex) && length(ex.args) >= 4
         docexs = get(docexprs, mod, nothing)
         if docexs === nothing
@@ -54,7 +56,7 @@ function lower_incrementally!(@nospecialize(f), docexprs, lex:: Expr, mod::Modul
         push!(docexs, ex)
         body = ex.args[4]
         if isa(body, Expr)
-            lower_incrementally!(f, docexprs, lex, mod, body)
+            lower_incrementally!(f, docexprs, aborts, lex, mod, body)
         end
     else
         # For map(x->x^2, a) we need to split out the anonymous function so that it
@@ -68,35 +70,44 @@ function lower_incrementally!(@nospecialize(f), docexprs, lex:: Expr, mod::Modul
             end
         end
         push!(lex.args, ex)
-        lower!(f, docexprs, mod, lex)
+        lower!(f, docexprs, aborts, mod, lex)
         empty!(lex.args)
     end
-    return docexprs
+    return docexprs, aborts
 end
 
-function lower_incrementally!(@nospecialize(f), docexprs, lex, mod::Module, args::Vector{Any})
+function lower_incrementally!(@nospecialize(f), docexprs, aborts, lex, mod::Module, args::Vector{Any})
     for a in args
         if isa(a, Expr)
-            lower_incrementally!(f, docexprs, lex, mod, a)
+            lower_incrementally!(f, docexprs, aborts, lex, mod, a)
         else
             push!(lex.args, a)
         end
     end
 end
 
-function lower!(@nospecialize(f), docexprs, mod::Module, ex::Expr)
+function lower!(@nospecialize(f), docexprs, aborts, mod::Module, ex::Expr)
     lwr = Meta.lower(mod, ex)
     if isexpr(lwr, :thunk)
         frame = JuliaInterpreter.prepare_thunk(mod, lwr)
+        cts = Test.get_testset()
         ret = Base.invokelatest(f, frame)  # if previous thunks define new methods, we need to update world age
-        isa(ret, Aborted) && abortwarn(ex)
+        if isa(ret, Aborted)
+            push!(aborts, abortline(ex))
+        end
+        tts = Test.get_testset()
+        while tts != cts
+            ttsinner = Test.pop_testset()
+            tts = Test.get_testset()
+            Test.record(tts, ttsinner)
+        end
     elseif isa(lwr, Expr) && (lwr.head == :export || lwr.head == :using || lwr.head == :import)
     elseif isa(lwr, Symbol) || isa(lwr, Nothing)
     else
         @show mod ex
         error("lowering did not produce a :thunk Expr")
     end
-    return docexprs
+    return docexprs, aborts
 end
 
 split_anonymous!(ex) = split_anonymous!(Expr[], ex)
@@ -115,25 +126,25 @@ function split_anonymous!(fs, ex)
     return fs
 end
 
-struct Aborted end  # for signaling that some statement or test blocks were interrupted
+struct Aborted end   # for signaling that some statement or test blocks were interrupted
 
-function abortwarn(ex::Expr)
+function abortline(ex::Expr)
     if ex.head == :macrocall
-        abortwarn(ex.args[2])
+        abortline(ex.args[2])
     elseif ex.head == :block
         i = findfirst(x->isa(x, LineNumberNode), ex.args)
         if i === nothing
-            length(ex.args) == 1 && return abortwarn(ex.args[1])
+            length(ex.args) == 1 && return abortline(ex.args[1])
             error("no LineNumberNodes in ", ex, "\nwith ", length(ex.args), " args")
         end
-        abortwarn(ex.args[i])
+        abortline(ex.args[i])
     elseif ex.head == :let || ex.head == :for
-        abortwarn(ex.args[2])
+        abortline(ex.args[2])
     else
         error("unhandled expr head ", ex.head, ":\n", ex)
     end
 end
-abortwarn(lnn::LineNumberNode) = @warn("Aborted at $lnn")
+abortline(lnn::LineNumberNode) = lnn
 
 """
     ret = limited_finish_and_return!(stack, frame, nstmts, istoplevel::Bool)


### PR DESCRIPTION
This makes it much more feasible to run "all" of Julia's tests. The key advance is the ability to run a specified maximum number of statements in the interpreter, and abort early when that number is reached. Choosing a number of statements, rather than execution time, should make it easier to compare results on machines with different performance. On my laptop, the default settings run all of Julia's tests in < 5 minutes. This is *not* a sign that the interpreter is really efficient (it's not), just that it aborts a lot of slow tests.

Sample output is now visible in #13.