### PR TITLE
More correctness fixes

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -218,7 +218,7 @@ function evaluate_methoddef!(stack, frame, node, pc)
     end
     length(node.args) == 1 && return f
     sig = @lookup(frame, node.args[2])::SimpleVector
-    body = @lookup(frame, node.args[3])::CodeInfo
+    body = @lookup(frame, node.args[3])
     ccall(:jl_method_def, Cvoid, (Any, Any, Any), sig, body, moduleof(frame))
     return nothing
 end
@@ -303,8 +303,8 @@ function eval_rhs(stack, frame, node::Expr, pc)
     elseif head == :foreigncall
         return evaluate_foreigncall!(stack, frame, node, pc)
     elseif head == :copyast
-        qn = node.args[1]::QuoteNode
-        return copy(qn.value::Expr)
+        val = (node.args[1]::QuoteNode).value
+        return isa(val, Expr) ? copy(val) : val
     elseif head == :enter
         return length(frame.exception_frames)
     elseif head == :boundscheck

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -2,6 +2,7 @@ using JuliaInterpreter
 using JuliaInterpreter: enter_call_expr
 using Test
 
+module Isolated end
 
 function summer(A)
     s = zero(eltype(A))
@@ -156,3 +157,35 @@ ex = quote
 end
 frame = JuliaInterpreter.prepare_toplevel(Main, ex)
 @test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) == 1
+
+# copyast
+ex = quote
+    struct CodegenParams
+        cached::Cint
+
+        track_allocations::Cint
+        code_coverage::Cint
+        static_alloc::Cint
+        prefer_specsig::Cint
+
+        module_setup::Any
+        module_activation::Any
+        raise_exception::Any
+        emit_function::Any
+        emitted_function::Any
+
+        CodegenParams(;cached::Bool=true,
+                       track_allocations::Bool=true, code_coverage::Bool=true,
+                       static_alloc::Bool=true, prefer_specsig::Bool=false,
+                       module_setup=nothing, module_activation=nothing, raise_exception=nothing,
+                       emit_function=nothing, emitted_function=nothing) =
+            new(Cint(cached),
+                Cint(track_allocations), Cint(code_coverage),
+                Cint(static_alloc), Cint(prefer_specsig),
+                module_setup, module_activation, raise_exception,
+                emit_function, emitted_function)
+    end
+end
+frame = JuliaInterpreter.prepare_toplevel(Isolated, ex)
+JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true)
+@test Isolated.CodegenParams(cached=false).cached === Cint(false)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -191,3 +191,8 @@ end
 frame = JuliaInterpreter.prepare_toplevel(Isolated, ex)
 JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true)
 @test Isolated.CodegenParams(cached=false).cached === Cint(false)
+
+# cglobal
+val = @interpret(BigInt())
+@test isa(val, BigInt) && val == 0
+@test isa(@interpret(Base.GMP.version()), VersionNumber)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -97,6 +97,8 @@ end
 @test @interpret(Vararg.body.body.name) === Vararg.body.body.name
 frame = JuliaInterpreter.prepare_toplevel(Main, :(Vararg.body.body.name))
 @test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) === Vararg.body.body.name
+frame = JuliaInterpreter.prepare_toplevel(Base, :(Union{AbstractChar,Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}}))
+@test JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true) isa Union
 
 # issue #8
 ex = quote

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -153,6 +153,21 @@ module Toplevel end
    @test Toplevel.Testing.JuliaStackFrame === JuliaStackFrame
 end
 
+@testset "Enum" begin
+    ex = quote
+        @enum MPFRRoundingMode begin
+            MPFRRoundNearest
+            MPFRRoundToZero
+            MPFRRoundUp
+            MPFRRoundDown
+            MPFRRoundFromZero
+            MPFRRoundFaithful
+        end
+    end
+    frame = JuliaInterpreter.prepare_toplevel(Toplevel, ex)
+    @test_broken JuliaInterpreter.finish_and_return!(JuliaStackFrame[], frame, true)
+end
+
 module LowerAnon
 ret = Ref{Any}(nothing)
 end
@@ -176,4 +191,18 @@ end
     lower_incrementally(runtest, LowerAnon, ex2)
     @test isa(LowerAnon.ret[], Vector{Int16})
     LowerAnon.ret[] = nothing
+
+    ex3 = quote
+        const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...}
+    end
+    lower_incrementally(runtest, LowerAnon, ex3)
+    @test isa(LowerAnon.BitIntegerType, Union)
+
+    ex4 = quote
+        y = 3
+        z = map(x->x^2+y, [1,2,3])
+        y = 4
+    end
+    lower_incrementally(runtest, LowerAnon, ex4)
+    @test LowerAnon.z == [4,7,12]
 end


### PR DESCRIPTION
I discovered these while working on using this package to extract all method signatures from Base. Fixes #31 (though not enough to get the entire `tuple.jl` test running).