### PR TITLE
fix testing path for stdlibs

### DIFF
--- a/test/juliatests.jl
+++ b/test/juliatests.jl
@@ -81,7 +81,7 @@ move_to_node1("Distributed")
                     test = popfirst!(tests)
                     local resp
                     wrkr = p
-                    fullpath = test_path(test*".jl")
+                    fullpath = test_path(test) * ".jl"
                     try
                         resp = remotecall_fetch(dotest, p, test, fullpath, nstmts)
                     catch e


### PR DESCRIPTION
The `.*jl` argument made the test name not match against the STDLIB list.