### PR TITLE
Fix and test docstring extraction

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -455,7 +455,7 @@ function prepare_toplevel!(modexs, docexprs, lex::Expr, mod::Module, ex::Expr; e
         end
         push!(docexs, ex)
         body = ex.args[4]
-        if isa(body, Expr)
+        if isa(body, Expr) && body.head != :call
             prepare_toplevel!(modexs, docexprs, lex, mod, body; extract_docexprs=extract_docexprs, filename=filename)
         end
     else


### PR DESCRIPTION
Small fix to handle parsing Base signatures at statements like [this one](https://github.com/JuliaLang/julia/blob/f0d88dd12e9538a56f83695ba1662aa6357d721a/base/rounding.jl#L124-L135).