### PR TITLE
Check output type of `prepare_call` more carefully. Fixes #51.

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -789,7 +789,7 @@ See [`enter_call`](@ref) for a similar approach not based on expressions.
 """
 function enter_call_expr(expr; enter_generated = false)
     r = determine_method_for_expr(expr; enter_generated = enter_generated)
-    if r !== nothing
+    if isa(r, Tuple)
         return build_frame(r[1:end-1]...)
     end
     nothing
@@ -841,7 +841,7 @@ function enter_call(@nospecialize(finfo), @nospecialize(args...); kwargs...)
         error(f, " is a builtin or intrinsic")
     end
     r = prepare_call(f, allargs; enter_generated=enter_generated)
-    if r !== nothing
+    if isa(r, Tuple)
         return build_frame(r[1:end-1]...)
     end
     return nothing

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1,6 +1,6 @@
 using JuliaInterpreter
 using JuliaInterpreter: enter_call_expr
-using Test
+using Test, InteractiveUtils
 
 module Isolated end
 
@@ -214,3 +214,10 @@ frame = JuliaInterpreter.enter_call(f, 3)
 @test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(1)) == defline + 1
 @test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(3)) == defline + 4
 @test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(5)) == defline + 6
+
+# issue #51
+if isdefined(Core.Compiler, :SNCA)
+    ci = @code_lowered gcd(10, 20)
+    cfg = Core.Compiler.compute_basic_blocks(ci.code)
+    @test isa(@interpret(Core.Compiler.SNCA(cfg)), Vector{Int})
+end


### PR DESCRIPTION
This fix is of course a bit specious since all Core.Compiler methods are [fenced off](https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/2f5a96f3ca851561bb06354cf2249ee45239ee0c/src/JuliaInterpreter.jl#L318-L320). I did that because something in the package was confusing Base and Core methods of the same name. Presumably that's fixable, but I haven't tackled it yet.