### PR TITLE
add a function to extract local variables from a frame

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -73,4 +73,6 @@ JuliaInterpreter.iswrappercall
 JuliaInterpreter.isdocexpr
 JuliaInterpreter.isglobalref
 JuliaInterpreter.statementnumber
+JuliaInterpreter.Variable
+JuliaInterpreter.locals
 ```


### PR DESCRIPTION
This provides a way to extract the local variables from a frame. The output is in a structured format to make it easier for different frontends to present it in their chosen way (ref https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/34#issuecomment-464000838).

Happy with inputs regarding the API chosen. Is a Vector the correct thing to return, perhaps a `Set` is more correct?
Creating a new struct `LocalVariable` has a bit of cognitive overhad over e.g. a tuple but might make it easier to change the behavior in the future.