### PR TITLE
Rename prepare_toplevel -> split_expressions

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -16,7 +16,7 @@ JuliaInterpreter.determine_method_for_expr
 JuliaInterpreter.prepare_args
 JuliaInterpreter.prepare_call
 JuliaInterpreter.prepare_thunk
-JuliaInterpreter.prepare_toplevel
+JuliaInterpreter.split_expressions
 JuliaInterpreter.get_call_framecode
 JuliaInterpreter.optimize!
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -246,7 +246,7 @@ Here's a more fine-grained look at what's happening under the hood (and a robust
 for more complex situations where there may be nested calls of new methods):
 
 ```julia
-modexs, _ = JuliaInterpreter.prepare_toplevel(Main, ex)
+modexs, _ = JuliaInterpreter.split_expressions(Main, ex)
 stack = JuliaStackFrame[]
 for (mod, e) in modexs
     frame = JuliaInterpreter.prepare_thunk(mod, e)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -380,7 +380,7 @@ function _step_expr!(stack, frame, @nospecialize(node), pc::JuliaProgramCounter,
                 elseif node.head == :primitive_type
                     evaluate_primitivetype!(stack, frame, node, pc)
                 elseif node.head == :module
-                    error("this should have been handled by prepare_toplevel")
+                    error("this should have been handled by split_expressions")
                 elseif node.head == :using || node.head == :import || node.head == :export
                     Core.eval(moduleof(frame), node)
                 elseif node.head == :const
@@ -409,7 +409,7 @@ function _step_expr!(stack, frame, @nospecialize(node), pc::JuliaProgramCounter,
                 elseif node.head == :toplevel
                     mod = moduleof(frame)
                     newstack = similar(stack, 0)
-                    modexs, _ = prepare_toplevel(mod, node)
+                    modexs, _ = split_expressions(mod, node)
                     Core.eval(mod, Expr(:toplevel,
                         :(for modex in $modexs
                               newframe = ($prepare_thunk)(modex)
@@ -477,7 +477,7 @@ function handle_err(frame, err)
         if (err.world != typemax(UInt) &&
             hasmethod(err.f, arg_types) &&
             !hasmethod(err.f, arg_types, world = err.world))
-            @warn "likely failure to return to toplevel, try JuliaInterpreter.prepare_toplevel"
+            @warn "likely failure to return to toplevel, try JuliaInterpreter.split_expressions"
             rethrow(err)
         end
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -23,7 +23,7 @@ function _precompile_()
         precompile(Tuple{typeof(f), Compiled, JuliaStackFrame, JuliaProgramCounter, Bool})
         precompile(Tuple{typeof(f), Vector{JuliaStackFrame}, JuliaStackFrame, JuliaProgramCounter, Bool})
     end
-    precompile(Tuple{typeof(prepare_toplevel), Module, Expr})
+    precompile(Tuple{typeof(split_expressions), Module, Expr})
     precompile(Tuple{typeof(prepare_thunk), Module, Expr})
     precompile(Tuple{typeof(prepare_locals), JuliaFrameCode, Vector{Any}})
     precompile(Tuple{typeof(prepare_args), Any, Vector{Any}, Vector{Any}})

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -15,7 +15,7 @@ using Test
     end
     @elapsed sum(rand(5))
     """; filename="fake.jl")
-    modexs, _ = JuliaInterpreter.prepare_toplevel(Main, ex; filename="fake.jl")
+    modexs, _ = JuliaInterpreter.split_expressions(Main, ex; filename="fake.jl")
     # find the 3rd assignment statement in the 2nd frame (corresponding to the x += 1 line)
     frame = JuliaInterpreter.prepare_thunk(modexs[2])
     i = 0
@@ -51,7 +51,7 @@ module EvalLimited end
         s += 1
     end
     """)
-    modexs, _ = JuliaInterpreter.prepare_toplevel(EvalLimited, ex)
+    modexs, _ = JuliaInterpreter.split_expressions(EvalLimited, ex)
     nstmts = 1000  # enough to ensure it finishes
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
@@ -78,7 +78,7 @@ module EvalLimited end
         insert!(ex.args, 2, LineNumberNode(2, Symbol("fake.jl")))
         insert!(ex.args, 1, LineNumberNode(1, Symbol("fake.jl")))
     end
-    modexs, _ = JuliaInterpreter.prepare_toplevel(EvalLimited, ex)
+    modexs, _ = JuliaInterpreter.split_expressions(EvalLimited, ex)
     nstmts = 100 # enough to ensure it gets into the loop but doesn't finish
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
@@ -96,7 +96,7 @@ module EvalLimited end
 
     # Now try again with recursive stack
     empty!(aborts)
-    modexs, _ = JuliaInterpreter.prepare_toplevel(EvalLimited, ex)
+    modexs, _ = JuliaInterpreter.split_expressions(EvalLimited, ex)
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         @test isa(frame, JuliaStackFrame)

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -17,7 +17,7 @@ module Toplevel end
 
 @testset "toplevel" begin
     stack = JuliaInterpreter.JuliaStackFrame[]
-    modexs, _ = JuliaInterpreter.prepare_toplevel(Toplevel, read_and_parse("toplevel_script.jl"))
+    modexs, _ = JuliaInterpreter.split_expressions(Toplevel, read_and_parse("toplevel_script.jl"))
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true
@@ -167,7 +167,7 @@ module Toplevel end
        end
        end
    end
-   modexs, _ = JuliaInterpreter.prepare_toplevel(Toplevel, ex)
+   modexs, _ = JuliaInterpreter.split_expressions(Toplevel, ex)
    for modex in modexs
        frame = JuliaInterpreter.prepare_thunk(modex)
        while true
@@ -208,7 +208,7 @@ ex = quote
         test_15703()
     end
 end
-modexs, _ = JuliaInterpreter.prepare_toplevel(IncTest, ex)
+modexs, _ = JuliaInterpreter.split_expressions(IncTest, ex)
 stack = JuliaStackFrame[]
 for (i, modex) in enumerate(modexs)
     frame = JuliaInterpreter.prepare_thunk(modex)
@@ -226,7 +226,7 @@ end
               EnumChild0
               EnumChild1
           end))
-    modexs, _ = JuliaInterpreter.prepare_toplevel(Toplevel, ex)
+    modexs, _ = JuliaInterpreter.split_expressions(Toplevel, ex)
     stack = JuliaStackFrame[]
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
@@ -250,7 +250,7 @@ end
         ret[] = map(x->parse(Int16, x), AbstractString[])
     end
     stack = JuliaStackFrame[]
-    modexs, _ = JuliaInterpreter.prepare_toplevel(LowerAnon, ex1)
+    modexs, _ = JuliaInterpreter.split_expressions(LowerAnon, ex1)
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true
@@ -259,7 +259,7 @@ end
     end
     @test isa(LowerAnon.ret[], Vector{Int16})
     LowerAnon.ret[] = nothing
-    modexs, _ = JuliaInterpreter.prepare_toplevel(LowerAnon, ex2)
+    modexs, _ = JuliaInterpreter.split_expressions(LowerAnon, ex2)
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true
@@ -272,7 +272,7 @@ end
     ex3 = quote
         const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...}
     end
-    modexs, _ = JuliaInterpreter.prepare_toplevel(LowerAnon, ex3)
+    modexs, _ = JuliaInterpreter.split_expressions(LowerAnon, ex3)
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true
@@ -286,7 +286,7 @@ end
         z = map(x->x^2+y, [1,2,3])
         y = 4
     end
-    modexs, _ = JuliaInterpreter.prepare_toplevel(LowerAnon, ex4)
+    modexs, _ = JuliaInterpreter.split_expressions(LowerAnon, ex4)
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true
@@ -319,7 +319,7 @@ end
         end
     end
     Core.eval(Toplevel, Expr(:toplevel, ex.args...))
-    modexs, docexprs = JuliaInterpreter.prepare_toplevel(Toplevel, ex; extract_docexprs=true)
+    modexs, docexprs = JuliaInterpreter.split_expressions(Toplevel, ex; extract_docexprs=true)
     for (mod, ex) in modexs
         frame = JuliaInterpreter.prepare_thunk(mod, ex)
         while true

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -168,7 +168,7 @@ function run_test_by_eval(test, fullpath, nstmts)
         ts = Test.DefaultTestSet($test)
         Test.push_testset(ts)
         current_task().storage[:SOURCE_PATH] = $fullpath
-        modexs, _ = JuliaInterpreter.prepare_toplevel(JuliaTests, ex)
+        modexs, _ = JuliaInterpreter.split_expressions(JuliaTests, ex)
         stack = JuliaStackFrame[]
         for (i, modex) in enumerate(modexs)  # having the index can be useful for debugging
             nstmtsleft = $nstmts


### PR DESCRIPTION
Fixes #56. (Better suggestions are welcome, of course.)