### PR TITLE
handle `codeloc==0` in `linenumber`

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -613,13 +613,19 @@ end
 
 isgotonode(node) = isa(node, GotoNode) || isexpr(node, :gotoifnot)
 
-linenumber(frame) = linenumber(frame, frame.pc[])
-function linenumber(frame, pc)
+"""
+    linenumber(frame, pc=frame.pc[])
+
+Return line number for `frame` at `pc` or -1 if it cannot be determined.
+"""
+function linenumber(frame, pc=frame.pc[])
     codeloc = frame.code.code.codelocs[pc.next_stmt]
+    codeloc == 0 && return -1
     return frame.code.scope isa Method ?
         frame.code.code.linetable[codeloc].line :
         codeloc
 end
+
 function next_line!(stack, frame, dbstack = nothing)
     initial = linenumber(frame)
     first = true

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -616,11 +616,11 @@ isgotonode(node) = isa(node, GotoNode) || isexpr(node, :gotoifnot)
 """
     linenumber(frame, pc=frame.pc[])
 
-Return line number for `frame` at `pc` or -1 if it cannot be determined.
+Return line number for `frame` at `pc` or `nothing` if it cannot be determined.
 """
 function linenumber(frame, pc=frame.pc[])
     codeloc = frame.code.code.codelocs[pc.next_stmt]
-    codeloc == 0 && return -1
+    codeloc == 0 && return nothing
     return frame.code.scope isa Method ?
         frame.code.code.linetable[codeloc].line :
         codeloc


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/63.