### PR TITLE
Build compiled methods to handle llvmcall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -177,6 +177,15 @@ function evaluate_call!(::Compiled, frame::JuliaStackFrame, call_expr::Expr, pc;
 end
 
 function evaluate_call!(stack, frame::JuliaStackFrame, call_expr::Expr, pc; exec!::Function=finish_and_return!)
+    idx = convert(Int, pc)
+    if isassigned(frame.code.methodtables, idx)
+        tme = frame.code.methodtables[idx]
+        if isa(tme, Compiled)
+            fargs = collect_args(frame, call_expr)
+            f = to_function(fargs[1])
+            return f(fargs[2:end]...)
+        end
+    end
     ret = maybe_evaluate_builtin(frame, call_expr)
     isa(ret, Some{Any}) && return ret.value
     fargs = collect_args(frame, call_expr)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -226,3 +226,28 @@ if isdefined(Core.Compiler, :SNCA)
     cfg = Core.Compiler.compute_basic_blocks(ci.code)
     @test isa(@interpret(Core.Compiler.SNCA(cfg)), Vector{Int})
 end
+
+# llvmcall
+function add1234(x::Tuple{Int32,Int32,Int32,Int32})
+    Base.llvmcall("""%3 = extractvalue [4 x i32] %0, 0
+      %4 = extractvalue [4 x i32] %0, 1
+      %5 = extractvalue [4 x i32] %0, 2
+      %6 = extractvalue [4 x i32] %0, 3
+      %7 = extractvalue [4 x i32] %1, 0
+      %8 = extractvalue [4 x i32] %1, 1
+      %9 = extractvalue [4 x i32] %1, 2
+      %10 = extractvalue [4 x i32] %1, 3
+      %11 = add i32 %3, %7
+      %12 = add i32 %4, %8
+      %13 = add i32 %5, %9
+      %14 = add i32 %6, %10
+      %15 = insertvalue [4 x i32] undef, i32 %11, 0
+      %16 = insertvalue [4 x i32] %15, i32 %12, 1
+      %17 = insertvalue [4 x i32] %16, i32 %13, 2
+      %18 = insertvalue [4 x i32] %17, i32 %14, 3
+      ret [4 x i32] %18""",Tuple{Int32,Int32,Int32,Int32},
+      Tuple{Tuple{Int32,Int32,Int32,Int32},Tuple{Int32,Int32,Int32,Int32}},
+        (Int32(1),Int32(2),Int32(3),Int32(4)),
+        x)
+end
+@test @interpret(add1234(map(Int32,(2,3,4,5)))) === map(Int32,(3,5,7,9))


### PR DESCRIPTION
This addresses https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/13#issuecomment-464880123 by building a compiled call that gets dispatched to.

Unfortunately, generalizing this to handle :foreigncall does *not* fix #28. So we'll have to do that by a different means.