### PR TITLE
Avoid illegal instruction crash by circumventing ccall

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -981,6 +981,17 @@ macro interpret(arg)
     end
 end
 
+function set_compiled_methods()
+    # Work around #28 by preventing interpretation of all Base methods that have a ccall to memcpy
+    push!(compiled_methods, which(vcat, (Vector,)))
+    push!(compiled_methods, first(methods(Base._getindex_ra)))
+    push!(compiled_methods, first(methods(Base._setindex_ra!)))
+end
+
+function __init__()
+    set_compiled_methods()
+end
+
 include("precompile.jl")
 _precompile_()
 

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -220,6 +220,11 @@ frame = JuliaInterpreter.enter_call(f, 3)
 @test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(3)) == defline + 4
 @test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(5)) == defline + 6
 
+# issue #28
+let a = ['0'], b = ['a']
+    @test @interpret(vcat(a, b)) == vcat(a, b)
+end
+
 # issue #51
 if isdefined(Core.Compiler, :SNCA)
     ci = @code_lowered gcd(10, 20)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -141,6 +141,7 @@ function configure_test()
     # in particular those that are used by the Test infrastructure
     cm = JuliaInterpreter.compiled_methods
     empty!(cm)
+    JuliaInterpreter.set_compiled_methods()
     push!(cm, which(Test.eval_test, Tuple{Expr, Expr, LineNumberNode}))
     push!(cm, which(Test.get_testset, Tuple{}))
     push!(cm, which(Test.push_testset, Tuple{Test.AbstractTestSet}))


### PR DESCRIPTION
This circumvents #28 by "blacklisting" Base methods that have a `ccall` to `memcpy`. This won't catch packages, unfortunately, but this seems to be the best we can do.