### PR TITLE
more `unwrap_unionall`s for kw func handling

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -937,7 +937,7 @@ function maybe_step_through_wrapper!(stack)
     last = stack[1].code.code.code[end-1]
     isexpr(last, :(=)) && (last = last.args[2])
     stack1 = stack[1]
-    is_kw = stack1.code.scope isa Method && startswith(String(Base.unwrap_unionall(stack1.code.scope.sig).parameters[1].name.name), "#kw")
+    is_kw = stack1.code.scope isa Method && startswith(String(Base.unwrap_unionall(Base.unwrap_unionall(stack1.code.scope.sig).parameters[1]).name.name), "#kw")
     if is_kw || isexpr(last, :call) && any(x->x==SlotNumber(1), last.args)
         # If the last expr calls #self# or passes it to an implementation method,
         # this is a wrapper function that we might want to step through


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/25.

There's something wonky about how we handle that function though:
```
julia> Debugger.@enter ∇(det)([1 2; 3 4])
In #13(args) at /home/pfitzseb/.julia/packages/Nabla/w019J/src/core.jl:188
188           args_ = Leaf.(Tape(), args)
189           y = f(args_...)
190           y isa Node || return zero.(args)

About to run: (Tape)()
1|debug> n
In #13(args) at /home/pfitzseb/.julia/packages/Nabla/w019J/src/core.jl:188
188           args_ = Leaf.(Tape(), args)
189           y = f(args_...)
190           y isa Node || return zero.(args)
191           ∇f = ∇(y)

# Wait what's going on here?

About to run: (getfield)(<suppressed 78 bytes of output>, :f)
1|debug> n
In det(610) at none:0
1   1 ─ %1 = (tuple)(610)
2   │   %2 = (getfield)(610, :tape)
3   │   %3 = (Branch)))($(QuoteNode(LinearAlgebra.det, %1, %2)

About to run: (tuple)(Leaf{Array{Int64,2}} (2, 2))
1|debug> n
In det(610) at none:0
1   1 ─ %1 = (tuple)(610)
2   │   %2 = (getfield)(610, :tape)
3   │   %3 = (Branch)))($(QuoteNode(LinearAlgebra.det, %1, %2)
4   └──      return %3

About to run: return Branch{Float64} -2.0 f=LinearAlgebra.det
1|debug> n
([4.0 -3.0; -2.0 1.0],)
```