### PR TITLE
Add support for breakpoints (!)

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -41,8 +41,10 @@ isless(x::JuliaProgramCounter, y::Integer) = isless(x.next_stmt, y)
 
 Base.show(io::IO, pc::JuliaProgramCounter) = print(io, "JuliaProgramCounter(", pc.next_stmt, ')')
 
+# Breakpoint support
 truecondition(frame) = true
 falsecondition(frame) = false
+const break_on_error = Ref(false)
 
 """
     BreakpointState(isactive=true, condition=JuliaInterpreter.truecondition)

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -1119,8 +1119,6 @@ macro interpret(arg)
         if frame === nothing
             return eval(Expr(:call, map(QuoteNode, theargs)...))
         end
-        empty!(framedict)  # start fresh each time; kind of like bumping the world age at the REPL prompt
-        empty!(genframedict)
         finish_and_return!(stack, frame)
     end
 end

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -1119,6 +1119,10 @@ macro interpret(arg)
         if frame === nothing
             return eval(Expr(:call, map(QuoteNode, theargs)...))
         end
+        if shouldbreak(frame, 1)
+            push!(stack, frame)
+            return stack, BreakpointRef(frame.code, 1)
+        end
         finish_and_return!(stack, frame)
     end
 end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -14,13 +14,17 @@ struct Unassigned end
 
 """
     BreakpointRef(framecode, stmtidx)
+    BreakpointRef(framecode, stmtidx, err)
 
 A reference to a breakpoint at a particular statement index `stmtidx` in `framecode`.
+If the break was due to an error, supply that as well.
 """
 struct BreakpointRef
     framecode::JuliaFrameCode
     stmtidx::Int
+    err
 end
+BreakpointRef(framecode, stmtidx) = BreakpointRef(framecode, stmtidx, nothing)
 
 function Base.show(io::IO, bp::BreakpointRef)
     lineno = linenumber(bp.framecode, bp.stmtidx)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -1,0 +1,186 @@
+module Breakpoints
+
+using ..JuliaInterpreter
+using JuliaInterpreter: JuliaFrameCode, JuliaStackFrame,
+                        prepare_framecode, framedict, get_source, sparam_syms,
+                        linenumber
+
+export breakpoint
+
+# A type that is unique to this package for which there are no valid operations
+struct Unassigned end
+
+"""
+    Breakpoint(framecode, stmtidx)
+
+A reference to a breakpoint at a particular statement index `stmtidx` in `framecode`.
+"""
+struct Breakpoint
+    framecode::JuliaFrameCode
+    stmtidx::Int
+end
+
+function Base.show(io::IO, bp::Breakpoint)
+    lineno = linenumber(bp.framecode, bp.stmtidx)
+    print(io, "breakpoint(", bp.framecode.scope, ", ", lineno, ')')
+end
+
+const _breakpoints = Set{Breakpoint}()
+
+function shouldbreak(frame, pc=frame.pc[])
+    idx = convert(Int, pc)
+    isassigned(frame.code.breakpoints, idx) || return false
+    bp = frame.code.breakpoints[idx]
+    bp[1] || return false
+    slotfunction = bp[2]
+    return slotfunction(frame)::Bool
+end
+
+function prepare_slotfunction(framecode::JuliaFrameCode, body::Union{Symbol,Expr})
+    ismeth = framecode.scope isa Method
+    uslotnames = Set{Symbol}()
+    slotnames  = Symbol[]
+    for name in framecode.code.slotnames
+        if name ∉ uslotnames
+            push!(slotnames, name)
+            push!(uslotnames, name)
+        end
+    end
+    assignments = Expr[]
+    framename = gensym("frame")
+    default = Unassigned()
+    for i = 1:length(slotnames)
+        slotname = framecode.code.slotnames[i]
+        qslotname = QuoteNode(slotname)
+        getexpr = :(something($framename.locals[$framename.last_reference[$qslotname]]))
+        push!(assignments, Expr(:(=), slotname, :(haskey($framename.last_reference, $qslotname) ? $getexpr : $default)))
+    end
+    if ismeth
+        syms = sparam_syms(framecode.scope)
+        for i = 1:length(syms)
+            push!(assignments, Expr(:(=), syms[i], :($framename.sparams[$i])))
+        end
+    end
+    funcname = ismeth ? gensym("slotfunction") : gensym(Symbol(framecode.scope.name, "_slotfunction"))
+    return Expr(:function, Expr(:call, funcname, framename), Expr(:block, assignments..., body))
+end
+
+truecondition(frame) = true
+falsecondition(frame) = false
+
+## The fundamental implementations of breakpoint-setting
+function breakpoint!(framecode::JuliaFrameCode, pc, condition::Union{Bool,Expr}=true)
+    stmtidx = convert(Int, pc)
+    if isa(condition, Bool)
+        framecode.breakpoints[stmtidx] = condition ? (true, truecondition) : (false, falsecondition)
+    else
+        fex = prepare_slotfunction(framecode, condition)
+        framecode.breakpoints[stmtidx] = (true, eval(fex))
+    end
+    bp = Breakpoint(framecode, stmtidx)
+    push!(_breakpoints, bp)
+    return bp
+end
+breakpoint!(frame::JuliaStackFrame, pc=frame.pc[], condition::Union{Bool,Expr}=true) =
+    breakpoint!(frame.code, pc, condition)
+
+function set_breakpoint_active!(framecode::JuliaFrameCode, active, pc)
+    stmtidx = convert(Int, pc)
+    _, condition = framecode.breakpoints[stmtidx]
+    framecode.breakpoints[stmtidx] = (active, condition)
+    active
+end
+set_breakpoint_active!(frame::JuliaStackFrame, active, pc) =
+    set_breakpoint_active!(frame.code, active, pc)
+
+function get_breakpoint_active(framecode::JuliaFrameCode, pc)
+    stmtidx = convert(Int, pc)
+    return framecode.breakpoints[stmtidx][1]
+end
+get_breakpoint_active(frame::JuliaStackFrame, pc) =
+    get_breakpoint_active(frame.code, pc)
+
+function toggle_breakpoint_active!(framecode::JuliaFrameCode, pc)
+    stmtidx = convert(Int, pc)
+    active, condition = framecode.breakpoints[stmtidx]
+    framecode.breakpoints[stmtidx] = (!active, condition)
+    !active
+end
+toggle_breakpoint_active!(frame::JuliaStackFrame, active, pc) =
+    toggle_breakpoint_active!(frame.code, active, pc)
+
+enable(bp::Breakpoint)  = set_breakpoint_active!(bp.framecode, true, bp.stmtidx)
+disable(bp::Breakpoint) = set_breakpoint_active!(bp.framecode, false, bp.stmtidx)
+function remove(bp::Breakpoint)
+    bp.framecode.breakpoints[bp.stmtidx] = (false, falsecondition)
+    delete!(_breakpoints, bp)
+    return nothing
+end
+
+enable() = for bp in _breakpoints enable(bp) end
+disable() = for bp in _breakpoints disable(bp) end
+function remove()
+    for bp in _breakpoints
+        bp.framecode.breakpoints[bp.stmtidx] = (false, falsecondition)
+    end
+    empty!(_breakpoints)
+    return nothing
+end
+
+"""
+    breakpoint(f, sig)
+    breakpoint(f, sig, condition)
+    breakpoint(...; enter_generated=false)
+
+Add a breakpoint upon entry to `f` with the specified argument types `sig`.
+The first will break unconditionally, the second only if `condition` evaluates to `true`.
+`condition` should be written in terms of the arguments and local variables of `f`.
+
+# Example
+```julia
+function radius2(x, y)
+    return x^2 + y^2
+end
+
+breakpoint(radius2, Tuple{Int,Int}, :(y > x))
+```
+"""
+function breakpoint(f, sig::Type, condition::Union{Bool,Expr}=true; enter_generated=false)
+    method = which(f, sig)
+    framecode, _ = prepare_framecode(method, sig; enter_generated=enter_generated)
+    breakpoint!(framecode, 1, condition)
+end
+
+"""
+    breakpoint(method::Method)
+    breakpoint(method::Method, condition::Expr)
+
+Add a breakpoint upon entry to `method`. The first will break unconditionally, the second
+only if `condition` evaluates to `true`. `condition` should be written in terms of the
+arguments and local variables of `method`.
+"""
+function breakpoint(method::Method, condition::Union{Bool,Expr}=true)
+    # FIXME: this duplicates stuff in prepare_call
+    framecode = get(framedict, method, nothing)
+    if framecode === nothing
+        code = get_source(method)
+        framecode = JuliaFrameCode(method, code; generator=false)
+        framedict[method] = framecode
+    end
+    breakpoint!(framecode, 1, condition)
+end
+
+"""
+    breakpoint(f)
+    breakpoint(f, condition)
+
+Break-on-entry to all methods of `f`.
+"""
+function breakpoint(f, condition::Union{Bool,Expr}=true)
+    for method in methods(f)
+        breakpoint(method, condition)
+    end
+    nothing
+end
+
+end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -91,7 +91,6 @@ function prepare_slotfunction(framecode::JuliaFrameCode, body::Union{Symbol,Expr
     return Expr(:function, Expr(:call, funcname, framename), Expr(:block, assignments..., body))
 end
 
-
 ## The fundamental implementations of breakpoint-setting
 function breakpoint!(framecode::JuliaFrameCode, pc, condition::Union{Bool,Expr}=true)
     stmtidx = convert(Int, pc)
@@ -172,6 +171,14 @@ function breakpoint(f, condition::Union{Bool,Expr}=true)
         push!(bps, breakpoint(method, condition))
     end
     return bps
+end
+
+macro breakpoint(call_expr, condition)
+    whichexpr = InteractiveUtils.gen_call_with_extracted_types(__module__, :which, call_expr)
+    return quote
+        local method = $whichexpr
+        $breakpoint(method, $(Expr(:quote, condition)))
+    end
 end
 
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -1,0 +1,51 @@
+radius2(x, y) = x^2 + y^2
+function loop_radius2(n)
+    s = 0
+    for i = 1:n
+        s += radius2(1, i)
+    end
+    s
+end
+
+@testset "Breakpoints" begin
+    breakpoint(radius2)
+    stack = JuliaStackFrame[]
+    frame = JuliaInterpreter.enter_call(loop_radius2, 2)
+    bp = JuliaInterpreter.finish_and_return!(stack, frame)
+    @test isa(bp, Breakpoints.Breakpoint)
+    @test length(stack) == 2
+    @test stack[end].code.scope == @which radius2(0, 0)
+    bp = JuliaInterpreter.finish_stack!(stack)
+    @test isa(bp, Breakpoints.Breakpoint)
+    @test length(stack) == 2
+    @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(2)
+
+    # Conditional breakpoints
+    Breakpoints.remove()
+    breakpoint(radius2, :(y > x))
+    stack = JuliaStackFrame[]
+    frame = JuliaInterpreter.enter_call(loop_radius2, 2)
+    bp = JuliaInterpreter.finish_and_return!(stack, frame)
+    @test isa(bp, Breakpoints.Breakpoint)
+    @test length(stack) == 2
+    @test stack[end].code.scope == @which radius2(0, 0)
+    @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(2)
+
+    # Conditional breakpoints on local variables
+    Breakpoints.remove()
+    stack = JuliaStackFrame[]
+    frame = JuliaInterpreter.enter_call(loop_radius2, 10)
+    halfthresh = loop_radius2(5)
+    JuliaInterpreter.next_line!(stack, frame)
+    JuliaInterpreter.next_line!(stack, frame)
+    pc = frame.pc[]
+    Breakpoints.breakpoint!(frame.code, pc, :(s > $halfthresh))
+    bp = JuliaInterpreter.finish_and_return!(stack, frame)
+    @test isa(bp, Breakpoints.Breakpoint)
+    s_extractor = eval(Breakpoints.prepare_slotfunction(frame.code, :s))
+    @test s_extractor(frame) == loop_radius2(6)
+    JuliaInterpreter.finish_stack!(stack)
+    @test s_extractor(frame) == loop_radius2(7)
+    Breakpoints.disable(bp)
+    @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(10)
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -33,6 +33,14 @@ end
     remove()
     breakpoint(radius2, :(y > x))
     runsimple()
+    remove()
+    @breakpoint radius2(0,0) y>x
+    runsimple()
+    # Demonstrate the problem that we have with scope
+    local_identity(x) = identity(x)
+    remove()
+    @breakpoint radius2(0,0) y>local_identity(x)
+    @test_broken @interpret loop_radius2(2)
 
     # Conditional breakpoints on local variables
     remove()

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -65,4 +65,16 @@ end
     bp = JuliaInterpreter.next_line!(stack, frame)
     @test isa(bp, Breakpoints.BreakpointRef)
     @test JuliaInterpreter.finish_stack!(stack) == 2
+
+    # break on error
+    inner(x) = error("oops")
+    outer() = inner(1)
+    JuliaInterpreter.break_on_error[] = true
+    stack = JuliaStackFrame[]
+    frame = JuliaInterpreter.enter_call(outer)
+    bp = JuliaInterpreter.finish_and_return!(stack, frame)
+    @test bp.err == ErrorException("oops")
+    @test length(stack) >= 2
+    @test stack[1].code.scope.name == :outer
+    @test stack[2].code.scope.name == :inner
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -48,4 +48,18 @@ end
     @test s_extractor(frame) == loop_radius2(7)
     Breakpoints.disable(bp)
     @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(10)
+
+    # Next line with breakpoints
+    function outer(x)
+        inner(x)
+    end
+    function inner(x)
+        return 2
+    end
+    breakpoint(inner)
+    stack = JuliaStackFrame[]
+    frame = JuliaInterpreter.enter_call(outer, 2)
+    bp = JuliaInterpreter.next_line!(stack, frame)
+    @test isa(bp, Breakpoints.Breakpoint)
+    @test JuliaInterpreter.finish_stack!(stack) == 2
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -74,6 +74,15 @@ end
     @test isa(bp, Breakpoints.BreakpointRef)
     @test JuliaInterpreter.finish_stack!(stack) == 2
 
+    # Direct return
+    @breakpoint gcd(1,1) a==5
+    @test @interpret(gcd(10,20)) == 10
+    # FIXME: even though they pass, these tests break Test!
+    # stack, bp = @interpret gcd(5, 20)
+    # @test length(stack) == 1 && isa(stack[1], JuliaStackFrame)
+    # @test isa(bp, Breakpoints.BreakpointRef)
+    remove()
+
     # break on error
     inner(x) = error("oops")
     outer() = inner(1)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -12,27 +12,30 @@ end
     stack = JuliaStackFrame[]
     frame = JuliaInterpreter.enter_call(loop_radius2, 2)
     bp = JuliaInterpreter.finish_and_return!(stack, frame)
-    @test isa(bp, Breakpoints.Breakpoint)
+    @test isa(bp, Breakpoints.BreakpointRef)
     @test length(stack) == 2
     @test stack[end].code.scope == @which radius2(0, 0)
     bp = JuliaInterpreter.finish_stack!(stack)
-    @test isa(bp, Breakpoints.Breakpoint)
+    @test isa(bp, Breakpoints.BreakpointRef)
     @test length(stack) == 2
     @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(2)
 
     # Conditional breakpoints
-    Breakpoints.remove()
+    function runsimple()
+        stack = JuliaStackFrame[]
+        frame = JuliaInterpreter.enter_call(loop_radius2, 2)
+        bp = JuliaInterpreter.finish_and_return!(stack, frame)
+        @test isa(bp, Breakpoints.BreakpointRef)
+        @test length(stack) == 2
+        @test stack[end].code.scope == @which radius2(0, 0)
+        @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(2)
+    end
+    remove()
     breakpoint(radius2, :(y > x))
-    stack = JuliaStackFrame[]
-    frame = JuliaInterpreter.enter_call(loop_radius2, 2)
-    bp = JuliaInterpreter.finish_and_return!(stack, frame)
-    @test isa(bp, Breakpoints.Breakpoint)
-    @test length(stack) == 2
-    @test stack[end].code.scope == @which radius2(0, 0)
-    @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(2)
+    runsimple()
 
     # Conditional breakpoints on local variables
-    Breakpoints.remove()
+    remove()
     stack = JuliaStackFrame[]
     frame = JuliaInterpreter.enter_call(loop_radius2, 10)
     halfthresh = loop_radius2(5)
@@ -41,12 +44,12 @@ end
     pc = frame.pc[]
     Breakpoints.breakpoint!(frame.code, pc, :(s > $halfthresh))
     bp = JuliaInterpreter.finish_and_return!(stack, frame)
-    @test isa(bp, Breakpoints.Breakpoint)
+    @test isa(bp, Breakpoints.BreakpointRef)
     s_extractor = eval(Breakpoints.prepare_slotfunction(frame.code, :s))
     @test s_extractor(frame) == loop_radius2(6)
     JuliaInterpreter.finish_stack!(stack)
     @test s_extractor(frame) == loop_radius2(7)
-    Breakpoints.disable(bp)
+    disable(bp)
     @test JuliaInterpreter.finish_stack!(stack) == loop_radius2(10)
 
     # Next line with breakpoints
@@ -60,6 +63,6 @@ end
     stack = JuliaStackFrame[]
     frame = JuliaInterpreter.enter_call(outer, 2)
     bp = JuliaInterpreter.next_line!(stack, frame)
-    @test isa(bp, Breakpoints.Breakpoint)
+    @test isa(bp, Breakpoints.BreakpointRef)
     @test JuliaInterpreter.finish_stack!(stack) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using Test
     include("interpret.jl")
     include("toplevel.jl")
     include("limits.jl")
+    include("breakpoints.jl")
 end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -195,6 +195,7 @@ module Toplevel end
     @test @interpret(Toplevel.paramtype(Vector)) == Toplevel.NoParam
     @test @interpret(Toplevel.Inner.g()) == 5
     @test @interpret(Toplevel.Inner.InnerInner.g()) == 6
+    # FIXME: even though they pass, these tests break Test!
     # @test @interpret(isdefined(Toplevel, :Beat))
     # @test @interpret(Toplevel.Beat <: Toplevel.DatesMod.Period)
 


### PR DESCRIPTION
Would be great to see what people think of the API. Currently the main API is:

- `breakpoint(f, sig, condition)`: add a breakpoint on entry to the method given by `which(f, sig)`
- `breakpoint(f, condition)`: add break-on-entry for all methods of `f`

Notably missing is `breakpoint(file, lineno, condition)`; I'll add that once I work on CodeTracking.jl integration. There are also `Breakpoints.enable`, `Breakpoints.disable`, and `Breakpoints.remove`, which can either take a specific `bp` to operate on or can be used as `Breakpoints.remove()` to get rid of all breakpoints.

There is also the non-exported all-powerful `breakpoint!(framecode, pc, condition)` that allows you set them wherever you want; this could easily be used when stepping through code to set a breakpoint at the current `pc`. (The tests illustrate this to set a breakpoint in the interior of a loop, but for now it's a purely manual operation.)

Internally, the way this works is to compile a function, call it `slotfunction`, that takes a `frame` as its only input, `slotfunction(frame)::Bool`. When this returns `true`, you've satisfied the condition and should stop. Implementing `slotfunction` steals bits from Debugger (portions of `eval_code`), and I copied over `sparam_syms` wholesale. If this gets merged I will submit a PR to delete it from Debugger and have it use this package's implementation.

Happy to modify aspects of this to make it easier for Debugger, Juno, and/or Rebugger to use.