### PR TITLE
Integrate with CodeTracking and support line numbers when setting breakpoints

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,21 +3,44 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Dates]]
-deps = ["Printf"]
-uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+[[CodeTracking]]
+deps = ["Test", "UUIDs"]
+git-tree-sha1 = "591b73b37c92ed7d55d3a14e266829c21aa3a7eb"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "0.3.0"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[Printf]]
-deps = ["Unicode"]
-uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[Unicode]]
-uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 version = "0.1.1"
 
 [deps]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -3,6 +3,12 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[CodeTracking]]
+deps = ["Test", "UUIDs"]
+git-tree-sha1 = "591b73b37c92ed7d55d3a14e266829c21aa3a7eb"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "0.3.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -19,16 +25,16 @@ version = "0.6.0"
 
 [[Documenter]]
 deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]
-git-tree-sha1 = "de745be4b00336588ab3269d5f43517e5c012973"
+git-tree-sha1 = "a8c41ba3d0861240dbec942ee1d0f86c57c37c1c"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.21.1"
+version = "0.21.5"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
-deps = ["InteractiveUtils"]
+deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
 path = ".."
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 version = "0.1.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -28,6 +28,7 @@ JuliaInterpreter.Compiled
 JuliaInterpreter.step_expr!
 JuliaInterpreter.finish!
 JuliaInterpreter.finish_and_return!
+JuliaInterpreter.finish_stack!
 JuliaInterpreter.get_return
 JuliaInterpreter.next_until!
 JuliaInterpreter.through_methoddef_or_done!
@@ -36,12 +37,24 @@ JuliaInterpreter.evaluate_foreigncall!
 JuliaInterpreter.maybe_evaluate_builtin
 ```
 
+## Breakpoints
+
+```@docs
+@breakpoint
+breakpoint
+enable
+disable
+remove
+```
+
 ## Types
 
 ```@docs
 JuliaInterpreter.JuliaStackFrame
 JuliaInterpreter.JuliaFrameCode
 JuliaInterpreter.JuliaProgramCounter
+JuliaInterpreter.BreakpointState
+JuliaInterpreter.BreakpointRef
 ```
 
 ## Internal storage
@@ -57,4 +70,7 @@ JuliaInterpreter.compiled_methods
 ```@docs
 JuliaInterpreter.@lookup
 JuliaInterpreter.iswrappercall
+JuliaInterpreter.isdocexpr
+JuliaInterpreter.isglobalref
+JuliaInterpreter.statementnumber
 ```

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -391,7 +391,7 @@ julia> framecode, frameargs, lenv, argtypes = JuliaInterpreter.prepare_call(myme
 julia> framecode
 JuliaInterpreter.JuliaFrameCode(mymethod(x::Array{T,1}) where T in Main at none:1, CodeInfo(
 1 ─     return 1
-), Core.TypeMapEntry[#undef], BitSet([]), false, false, true)
+), Union{Compiled, TypeMapEntry}[#undef], JuliaInterpreter.BreakpointState[#undef], BitSet([]), false, false, true)
 
 julia> frameargs
 2-element Array{Any,1}:
@@ -916,9 +916,9 @@ mymethod (generic function with 1 method)
 
 julia> JuliaInterpreter.enter_call_expr(:(\$mymethod(1)))
 JuliaStackFrame(JuliaInterpreter.JuliaFrameCode(mymethod(x) in Main at none:1, CodeInfo(
-1 ─ %1 = (\$(QuoteNode(+)))(x, 1)
+1 ─ %1 = ($(QuoteNode(+)))(x, 1)
 └──      return %1
-), Core.TypeMapEntry[#undef, #undef], BitSet([1]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some(1)], Any[#undef, #undef], Any[], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict{Symbol,Int64}(), Any[])
+), Union{Compiled, TypeMapEntry}[#undef, #undef], JuliaInterpreter.BreakpointState[#undef, #undef], BitSet([1]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some(1)], Any[#undef, #undef], Any[], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict(Symbol("#self#")=>1,:x=>2), Any[])
 
 julia> mymethod(x::Vector{T}) where T = 1
 mymethod (generic function with 2 methods)
@@ -931,7 +931,7 @@ julia> a = [1.0, 2.0]
 julia> JuliaInterpreter.enter_call_expr(:(\$mymethod(\$a)))
 JuliaStackFrame(JuliaInterpreter.JuliaFrameCode(mymethod(x::Array{T,1}) where T in Main at none:1, CodeInfo(
 1 ─     return 1
-), Core.TypeMapEntry[#undef], BitSet([]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some([1.0, 2.0])], Any[#undef], Any[Float64], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict{Symbol,Int64}(), Any[])
+), Union{Compiled, TypeMapEntry}[#undef], JuliaInterpreter.BreakpointState[#undef], BitSet([]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some([1.0, 2.0])], Any[#undef], Any[Float64], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict(Symbol("#self#")=>1,:x=>2), Any[])
 ```
 
 See [`enter_call`](@ref) for a similar approach not based on expressions.
@@ -959,7 +959,7 @@ julia> JuliaInterpreter.enter_call(mymethod, 1)
 JuliaStackFrame(JuliaInterpreter.JuliaFrameCode(mymethod(x) in Main at none:1, CodeInfo(
 1 ─ %1 = ($(QuoteNode(+)))(x, 1)
 └──      return %1
-), Core.TypeMapEntry[#undef, #undef], BitSet([1]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some(1)], Any[#undef, #undef], Any[], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict{Symbol,Int64}(), Any[])
+), Union{Compiled, TypeMapEntry}[#undef, #undef], JuliaInterpreter.BreakpointState[#undef, #undef], BitSet([1]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some(1)], Any[#undef, #undef], Any[], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict(Symbol("#self#")=>1,:x=>2), Any[])
 
 julia> mymethod(x::Vector{T}) where T = 1
 mymethod (generic function with 2 methods)
@@ -967,7 +967,7 @@ mymethod (generic function with 2 methods)
 julia> JuliaInterpreter.enter_call(mymethod, [1.0, 2.0])
 JuliaStackFrame(JuliaInterpreter.JuliaFrameCode(mymethod(x::Array{T,1}) where T in Main at none:1, CodeInfo(
 1 ─     return 1
-), Core.TypeMapEntry[#undef], BitSet([]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some([1.0, 2.0])], Any[#undef], Any[Float64], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict{Symbol,Int64}(), Any[])
+), Union{Compiled, TypeMapEntry}[#undef], JuliaInterpreter.BreakpointState[#undef], BitSet([]), false, false, true), Union{Nothing, Some{Any}}[Some(mymethod), Some([1.0, 2.0])], Any[#undef], Any[Float64], Int64[], Base.RefValue{Any}(nothing), Base.RefValue{JuliaInterpreter.JuliaProgramCounter}(JuliaProgramCounter(1)), Dict(Symbol("#self#")=>1,:x=>2), Any[])
 ```
 
 For a `@generated` function you can use `enter_call((f, true), args...; kwargs...)`

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -10,6 +10,7 @@ using UUIDs
 # in Base and stdlib
 using Random.DSFMT
 using InteractiveUtils
+using CodeTracking
 
 export @interpret, Compiled, JuliaStackFrame,
        Breakpoints, breakpoint, @breakpoint, breakpoints, enable, disable, remove
@@ -1084,7 +1085,8 @@ macro interpret(arg)
             push!(stack, frame)
             return stack, BreakpointRef(frame.code, 1)
         end
-        finish_and_return!(stack, frame)
+        ret = finish_and_return!(stack, frame)
+        isa(ret, BreakpointRef) ? (stack, ret) : ret
     end
 end
 

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -109,8 +109,25 @@ end
 breakpoint!(frame::JuliaStackFrame, pc=frame.pc[], condition::Condition=nothing) =
     breakpoint!(frame.code, pc, condition)
 
+"""
+    enable(bp::BreakpointRef)
+
+Enable breakpoint `bp`.
+"""
 enable(bp::BreakpointRef)  = bp[] = true
+
+"""
+    disable(bp::BreakpointRef)
+
+Disable breakpoint `bp`. Disabled breakpoints can be re-enabled with [`enable`](@ref).
+"""
 disable(bp::BreakpointRef) = bp[] = false
+
+"""
+    remove(bp::BreakpointRef)
+
+Remove (delete) breakpoint `bp`. Removed breakpoints cannot be re-enabled.
+"""
 function remove(bp::BreakpointRef)
     idx = findfirst(isequal(bp), _breakpoints)
     deleteat!(_breakpoints, idx)
@@ -118,8 +135,25 @@ function remove(bp::BreakpointRef)
     return nothing
 end
 
+"""
+    enable()
+
+Enable all breakpoints.
+"""
 enable() = for bp in _breakpoints enable(bp) end
+
+"""
+    disable()
+
+Disable all breakpoints.
+"""
 disable() = for bp in _breakpoints disable(bp) end
+
+"""
+    remove()
+
+Remove all breakpoints.
+"""
 function remove()
     for bp in _breakpoints
         bp.framecode.breakpoints[bp.stmtidx] = BreakpointState(false, falsecondition)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -3,7 +3,7 @@ module Breakpoints
 using ..JuliaInterpreter
 using JuliaInterpreter: JuliaFrameCode, JuliaStackFrame, BreakpointState,
                         truecondition, falsecondition, prepare_framecode, get_framecode,
-                        sparam_syms, linenumber
+                        sparam_syms, linenumber, statementnumber
 using Base.Meta: isexpr
 using InteractiveUtils
 
@@ -91,18 +91,22 @@ function prepare_slotfunction(framecode::JuliaFrameCode, body::Union{Symbol,Expr
     return Expr(:function, Expr(:call, funcname, framename), Expr(:block, assignments..., body))
 end
 
+const Condition = Union{Nothing,Expr,Tuple{Module,Expr}}
+_unpack(condition) = isa(condition, Expr) ? (Main, condition) : condition
+
 ## The fundamental implementations of breakpoint-setting
-function breakpoint!(framecode::JuliaFrameCode, pc, condition::Union{Bool,Expr}=true)
+function breakpoint!(framecode::JuliaFrameCode, pc, condition::Condition=nothing)
     stmtidx = convert(Int, pc)
-    if isa(condition, Bool)
-        framecode.breakpoints[stmtidx] = BreakpointState(condition)
+    if condition === nothing
+        framecode.breakpoints[stmtidx] = BreakpointState()
     else
-        fex = prepare_slotfunction(framecode, condition)
-        framecode.breakpoints[stmtidx] = BreakpointState(true, eval(fex))
+        mod, cond = _unpack(condition)
+        fex = prepare_slotfunction(framecode, cond)
+        framecode.breakpoints[stmtidx] = BreakpointState(true, Core.eval(mod, fex))
     end
     return add_breakpoint(framecode, stmtidx)
 end
-breakpoint!(frame::JuliaStackFrame, pc=frame.pc[], condition::Union{Bool,Expr}=true) =
+breakpoint!(frame::JuliaStackFrame, pc=frame.pc[], condition::Condition=nothing) =
     breakpoint!(frame.code, pc, condition)
 
 enable(bp::BreakpointRef)  = bp[] = true
@@ -126,11 +130,16 @@ end
 
 """
     breakpoint(f, sig)
+    breakpoint(f, sig, line)
     breakpoint(f, sig, condition)
+    breakpoint(f, sig, line, condition)
     breakpoint(...; enter_generated=false)
 
-Add a breakpoint upon entry to `f` with the specified argument types `sig`.
-The first will break unconditionally, the second only if `condition` evaluates to `true`.
+Add a breakpoint to `f` with the specified argument types `sig`.
+Optionally specify an absolute line number `line` in the source file; the default
+is to break upon entry at the first line of the body.
+Without `condition`, the breakpoint will be triggered every time it is encountered;
+the second only if `condition` evaluates to `true`.
 `condition` should be written in terms of the arguments and local variables of `f`.
 
 # Example
@@ -142,7 +151,15 @@ end
 breakpoint(radius2, Tuple{Int,Int}, :(y > x))
 ```
 """
-function breakpoint(f, sig::Type, condition::Union{Bool,Expr}=true; enter_generated=false)
+function breakpoint(f, sig::Type, line::Integer, condition::Condition=nothing; enter_generated=false)
+    method = which(f, sig)
+    framecode, _ = prepare_framecode(method, sig; enter_generated=enter_generated)
+    # Don't use statementnumber(method, line) in case it's enter_generated
+    linec = line - whereis(method)[2] + method.line
+    stmtidx = statementnumber(framecode, linec)
+    breakpoint!(framecode, stmtidx, condition)
+end
+function breakpoint(f, sig::Type, condition::Condition=nothing; enter_generated=false)
     method = which(f, sig)
     framecode, _ = prepare_framecode(method, sig; enter_generated=enter_generated)
     breakpoint!(framecode, 1, condition)
@@ -150,11 +167,17 @@ end
 
 """
     breakpoint(method::Method)
+    breakpoint(method::Method, line)
     breakpoint(method::Method, condition::Expr)
+    breakpoint(method::Method, line, condition::Expr)
 
-Add a breakpoint upon entry to `method`.
+Add a breakpoint to `method`.
 """
-function breakpoint(method::Method, condition::Union{Bool,Expr}=true)
+function breakpoint(method::Method, line::Integer, condition::Condition=nothing)
+    framecode, stmtidx = statementnumber(method, line)
+    breakpoint!(framecode, stmtidx, condition)
+end
+function breakpoint(method::Method, condition::Condition=nothing)
     framecode = get_framecode(method)
     breakpoint!(framecode, 1, condition)
 end
@@ -165,7 +188,7 @@ end
 
 Break-on-entry to all methods of `f`.
 """
-function breakpoint(f, condition::Union{Bool,Expr}=true)
+function breakpoint(f, condition::Condition=nothing)
     bps = BreakpointRef[]
     for method in methods(f)
         push!(bps, breakpoint(method, condition))
@@ -173,11 +196,61 @@ function breakpoint(f, condition::Union{Bool,Expr}=true)
     return bps
 end
 
-macro breakpoint(call_expr, condition)
+"""
+    @breakpoint f(args...) condition=nothing
+    @breakpoint f(args...) line condition=nothing
+
+Break upon entry, or at the specified line number, in the method called by `f(args...)`.
+Optionally supply a condition expressed in terms of the arguments and internal variables
+of the method.
+If `line` is supplied, it must be a literal integer.
+
+# Example
+
+Suppose a method `mysum` is defined as follows, where the numbers to the left are the line
+number in the file:
+
+```
+12 function mysum(A)
+13     s = zero(eltype(A))
+14     for a in A
+15         s += a
+16     end
+17     return s
+18 end
+```
+
+Then
+
+```
+@breakpoint mysum(A) 15 s>10
+```
+
+would cause execution of the loop to break whenever `s>10`.
+"""
+macro breakpoint(call_expr, args...)
     whichexpr = InteractiveUtils.gen_call_with_extracted_types(__module__, :which, call_expr)
-    return quote
-        local method = $whichexpr
-        $breakpoint(method, $(Expr(:quote, condition)))
+    haveline, line, condition = false, 0, nothing
+    while !isempty(args)
+        arg = first(args)
+        if isa(arg, Integer)
+            haveline, line = true, arg
+        else
+            condition = arg
+        end
+        args = Base.tail(args)
+    end
+    condexpr = condition === nothing ? nothing : Expr(:quote, condition)
+    if haveline
+        return quote
+            local method = $whichexpr
+            $breakpoint(method, $line, $condexpr)
+        end
+    else
+        return quote
+            local method = $whichexpr
+            $breakpoint(method, $condexpr)
+        end
     end
 end
 

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -679,29 +679,53 @@ end
 isgotonode(node) = isa(node, GotoNode) || isexpr(node, :gotoifnot)
 
 """
-    linenumber(frame, pc=frame.pc[])
+    loc = whereis(frame, pc=frame.pc[])
 
-Return line number for `frame` at `pc` or `nothing` if it cannot be determined.
+Return the file and line number for `frame` at `pc`.  If this cannot be
+determined, `loc == nothing`. Otherwise `loc == (filepath, line)`.
+
+When `frame` represents top-level code,
 """
+function CodeTracking.whereis(framecode::JuliaFrameCode, pc)
+    codeloc = framecode.code.codelocs[convert(Int, pc)]
+    codeloc == 0 && return nothing
+    lineinfo = framecode.code.linetable[codeloc]
+    return framecode.scope isa Method ?
+        whereis(lineinfo, framecode.scope) : string(lineinfo.file), lineinfo.line
+end
+CodeTracking.whereis(frame::JuliaStackFrame, pc=frame.pc[]) = whereis(frame.code, pc)
+
+# Note: linenumber is now an internal method for use by `next_line!`
+# If you want to know the actual line number in a file, call `whereis`.
 function linenumber(framecode::JuliaFrameCode, pc)
     codeloc = framecode.code.codelocs[convert(Int, pc)]
     codeloc == 0 && return nothing
-    return framecode.scope isa Method ?
-        framecode.code.linetable[codeloc].line :
-        codeloc
+    return framecode.code.linetable[codeloc].line
 end
 linenumber(frame::JuliaStackFrame, pc=frame.pc[]) = linenumber(frame.code, pc)
 
 """
-    statementnumber(frame, line)
+    stmtidx = statementnumber(frame, line)
 
 Return the index of the first statement in `frame`'s `CodeInfo` that corresponds to `line`.
 """
 function statementnumber(framecode::JuliaFrameCode, line)
-    lineidx = searchsortedfirst(framecode.code.linetable, line; by=lin->lin.line)
+    lineidx = searchsortedfirst(framecode.code.linetable, line; by=lin->isa(lin,Integer) ? lin : lin.line)
+    1 <= lineidx <= length(framecode.code.linetable) || throw(ArgumentError("line $line not found in $(framecode.scope)"))
     return searchsortedfirst(framecode.code.codelocs, lineidx)
 end
 statementnumber(frame::JuliaStackFrame, line) = statementnumber(frame.code, line)
+
+"""
+    framecode, stmtidx = statementnumber(method, line)
+
+Return the index of the first statement in `framecode` that corresponds to the given `line` in `method`.
+"""
+function statementnumber(method::Method, line; line1=whereis(method)[2])
+    linec = line - line1 + method.line  # line number at time of compilation
+    framecode = get_framecode(method)
+    return framecode, statementnumber(framecode, linec)
+end
 
 function next_line!(stack, frame, dbstack = nothing)
     initial = linenumber(frame)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -44,15 +44,11 @@ end
 
     # Conditional breakpoints on local variables
     remove()
-    stack = JuliaStackFrame[]
-    frame = JuliaInterpreter.enter_call(loop_radius2, 10)
     halfthresh = loop_radius2(5)
-    JuliaInterpreter.next_line!(stack, frame)
-    JuliaInterpreter.next_line!(stack, frame)
-    pc = frame.pc[]
-    Breakpoints.breakpoint!(frame.code, pc, :(s > $halfthresh))
-    bp = JuliaInterpreter.finish_and_return!(stack, frame)
+    @breakpoint loop_radius2(10) 5 s>$halfthresh
+    stack, bp = @interpret loop_radius2(10)
     @test isa(bp, Breakpoints.BreakpointRef)
+    frame = stack[end]
     s_extractor = eval(Breakpoints.prepare_slotfunction(frame.code, :s))
     @test s_extractor(frame) == loop_radius2(6)
     JuliaInterpreter.finish_stack!(stack)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1,6 +1,6 @@
 using JuliaInterpreter
 using JuliaInterpreter: enter_call_expr
-using Test, InteractiveUtils
+using Test, InteractiveUtils, CodeTracking
 
 pc = JuliaInterpreter.JuliaProgramCounter(2)
 @test convert(Int, pc) == 2
@@ -216,9 +216,9 @@ function f(x)
     return x*x
 end
 frame = JuliaInterpreter.enter_call(f, 3)
-@test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(1)) == defline + 1
-@test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(3)) == defline + 4
-@test JuliaInterpreter.linenumber(frame, JuliaInterpreter.JuliaProgramCounter(5)) == defline + 6
+@test whereis(frame, JuliaInterpreter.JuliaProgramCounter(1))[2] == defline + 1
+@test whereis(frame, JuliaInterpreter.JuliaProgramCounter(3))[2] == defline + 4
+@test whereis(frame, JuliaInterpreter.JuliaProgramCounter(5))[2] == defline + 6
 
 # issue #28
 let a = ['0'], b = ['a']


### PR DESCRIPTION
If the user is running an appropriate version of Revise, reported location will update as code moves around due to edits. Because methods can move files as well as from line-to-line, `linenumber` should not be used except internally. (Use `whereis` instead.)

If the user is not running Revise, CodeTracking should be harmless. Of course this makes this package sensitive to bugs in CodeTracking, but because it's a small package hopefully there won't be many of those before it becomes an asset.

Here's a fun demo (requires https://github.com/timholy/CodeTracking.jl/pull/10 to work with methods defined at the REPL):

```julia
julia> using JuliaInterpreter

julia> function mysum(A)
           s = zero(eltype(A))
           for a in A
               s += a
           end
           return s
       end
mysum (generic function with 1 method)

julia> first(methods(mysum))  # note the first line is "2"
mysum(A) in Main at REPL[2]:2

julia> @breakpoint mysum(1:5) 4 s >= 10
breakpoint(mysum(A) in Main at REPL[2]:2, 4)

julia> stack, bp = @interpret mysum(1:10);

julia> bp
breakpoint(mysum(A) in Main at REPL[2]:2, 4)

julia> stack[1].locals
5-element Array{Union{Nothing, Some{Any}},1}:
 Some(mysum) 
 Some(1:10)  
 Some(10)    
 Some((5, 5))
 Some(5)     

julia> stack[1].code.code.slotnames
5-element Array{Any,1}:
 Symbol("#self#")
 :A              
 :s              
 Symbol("#temp#")
 :a              
```