### PR TITLE
 Run `objectid` in Compiled mode (fixes #92) 

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -174,7 +174,7 @@ struct Variable
     isparam::Bool
 end
 Base.show(io::IO, var::Variable) = print(io, var.name, " = ", var.value)
-Base.isequal(var1::Variable, var2::Variable) = 
+Base.isequal(var1::Variable, var2::Variable) =
     var1.value == var2.value && var1.name == var2.name && var1.isparam == var2.isparam
 
 """
@@ -1148,6 +1148,8 @@ function set_compiled_methods()
     # issue #76
     push!(compiled_methods, which(unsafe_store!, (Ptr{Any}, Any, Int)))
     push!(compiled_methods, which(unsafe_store!, (Ptr, Any, Int)))
+    # issue #92
+    push!(compiled_methods, which(objectid, Tuple{Any}))
 end
 
 function __init__()

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -271,6 +271,12 @@ let TT = Union{UInt8, Int8}
     @interpret unsafe_store!(pa, 0x1, 2)
 end
 
+# issue #92
+let x = Core.TypedSlot(1, Any)
+    f(x) = objectid(x)
+    @test isa(@interpret(f(x)), UInt)
+end
+
 # Some expression can appear nontrivial but lower to nothing
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) == :NoOS 1+1 end)), Nothing)
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(Base.BaseDocs.@kw_str "using")), Nothing)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -58,7 +58,7 @@ function evaluate_limited!(stack, frame::JuliaStackFrame, nstmts::Int, pc::Julia
                     do_assignment!(frame, lhs, rhs)
                     new_pc = pc + 1
                 catch err
-                    new_pc = handle_err(frame, err)
+                    new_pc = handle_err(stack, frame, pc, err)
                 end
                 nstmts = refnstmts[]
             elseif stmt.head == :(=) && isexpr(stmt.args[2], :call) && !isa(stack, Compiled)
@@ -69,7 +69,7 @@ function evaluate_limited!(stack, frame::JuliaStackFrame, nstmts::Int, pc::Julia
                     do_assignment!(frame, stmt.args[1], rhs)
                     new_pc = pc + 1
                 catch err
-                    new_pc = handle_err(frame, err)
+                    new_pc = handle_err(stack, frame, pc, err)
                 end
                 nstmts = refnstmts[]
             elseif stmt.head == :thunk


### PR DESCRIPTION
The `evaluate_foreigncall!` that would otherwise be triggered ends up complaining.