### PR TITLE
Support `breakpoint(filename, lineno)`

### DIFF
--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -70,6 +70,16 @@ end
     @test isa(bp, Breakpoints.BreakpointRef)
     @test JuliaInterpreter.finish_stack!(stack) == 2
 
+    # Breakpoints by file/line
+    if isdefined(Main, :Revise)
+        remove()
+        method = which(JuliaInterpreter.locals, Tuple{JuliaStackFrame})
+        breakpoint(String(method.file), method.line+1)
+        frame = JuliaInterpreter.enter_call(loop_radius2, 2)
+        ret = @interpret JuliaInterpreter.locals(frame)
+        @test isa(bp, Breakpoints.BreakpointRef)
+    end
+
     # Direct return
     @breakpoint gcd(1,1) a==5
     @test @interpret(gcd(10,20)) == 10


### PR DESCRIPTION
This implements the last remaining way of setting breakpoints. Note that it depends on `signatures_at`, which in turn depends on Revise. This is the only truly robust solution I know of: for example, keyword-arg methods will need the breakpoint set in a gensymmed body method that cannot be easily discovered (https://github.com/JuliaLang/julia/issues/30908). I guess the question is whether we want a fallback that sometimes works.
