### PR TITLE
optimize!: don't look up GlobalRefs on the lhs of an assignment

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
 deps = ["Test", "UUIDs"]
-git-tree-sha1 = "591b73b37c92ed7d55d3a14e266829c21aa3a7eb"
+git-tree-sha1 = "12aa4d41c7926afd7a71af5af603a4d8b94292c2"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.3.0"
+version = "0.3.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -759,6 +759,7 @@ end
 function lookup_global_refs!(ex::Expr)
     (ex.head == :isdefined || ex.head == :thunk || ex.head == :toplevel) && return nothing
     for (i, a) in enumerate(ex.args)
+        ex.head == :(=) && i == 1 && continue # Don't look up globalrefs on the LHS of an assignment (issue #98)
         if isa(a, GlobalRef)
             r = getfield(a.mod, a.name)
             ex.args[i] = QuoteNode(r)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -280,6 +280,16 @@ let x = Core.TypedSlot(1, Any)
     @test isa(@interpret(f(x)), UInt)
 end
 
+# issue #98
+x98 = 5
+function f98()
+    global x98
+    x98 = 7
+    return nothing
+end
+@interpret f98()
+@test x98 == 7
+
 # Some expression can appear nontrivial but lower to nothing
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) == :NoOS 1+1 end)), Nothing)
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(Base.BaseDocs.@kw_str "using")), Nothing)


### PR DESCRIPTION
Fixes #98