### PR TITLE
Run all Base users of `sigatomic` in compiled mode. Fixes #106

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -1145,6 +1145,10 @@ function set_compiled_methods()
     push!(compiled_methods, which(unsafe_store!, (Ptr, Any, Int)))
     # issue #92
     push!(compiled_methods, which(objectid, Tuple{Any}))
+    # issue #106 --- anything that uses sigatomic_(begin|end)
+    push!(compiled_methods, which(flush, Tuple{IOStream}))
+    push!(compiled_methods, which(disable_sigint, Tuple{Function}))
+    push!(compiled_methods, which(reenable_sigint, Tuple{Function}))
 end
 
 function __init__()

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -295,6 +295,25 @@ end
 @interpret f98()
 @test x98 == 7
 
+# issue #106
+function f106()
+    n = tempname()
+    w = open(n, "a")
+    write(w, "A")
+    flush(w)
+    return true
+end
+@test @interpret(f106()) == 1
+f106b() = rand()
+f106c() = disable_sigint(f106b)
+function f106d()
+    disable_sigint() do
+        reenable_sigint(f106b)
+    end
+end
+@interpret f106c()
+@interpret f106d()
+
 # Some expression can appear nontrivial but lower to nothing
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) == :NoOS 1+1 end)), Nothing)
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(Base.BaseDocs.@kw_str "using")), Nothing)


### PR DESCRIPTION
REPL also uses sigatomic, but I don't expect to be interpreting REPL anytime soon.