### PR TITLE
Revert "only break if we are throwing an uncaught exception (#89)"

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -488,11 +488,6 @@ function step_expr!(stack, frame, istoplevel::Bool=false)
 end
 
 function handle_err(stack, frame, pc, err)
-    if !isempty(frame.exception_frames)
-        # Exception caught
-        frame.last_exception[] = err
-        return JuliaProgramCounter(frame.exception_frames[end])
-    end
     if break_on_error[]
         frame.pc[] = pc
         push!(stack, frame)
@@ -506,9 +501,12 @@ function handle_err(stack, frame, pc, err)
             hasmethod(err.f, arg_types) &&
             !hasmethod(err.f, arg_types, world = err.world))
             @warn "likely failure to return to toplevel, try JuliaInterpreter.split_expressions"
+            rethrow(err)
         end
     end
-    rethrow(err)
+    isempty(frame.exception_frames) && rethrow(err)
+    frame.last_exception[] = err
+    return JuliaProgramCounter(frame.exception_frames[end])
 end
 
 """

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -92,10 +92,6 @@ end
         @test length(stack) >= 2
         @test stack[1].code.scope.name == :outer
         @test stack[2].code.scope.name == :inner
-
-        f_catch() = try error(); catch; return 2; end
-        @test @interpret f_catch() == 2
-
     finally
         JuliaInterpreter.break_on_error[] = false
     end


### PR DESCRIPTION
This reverts commit 28af3b350bb2f6ab427e55e8cadbe539a5ef5a5e.

This behavior actually doesn't make sense since it will only not break for things that are caught in the same frame which is a really weird special case.