### PR TITLE
pop top frame from stack if we throw evaluating it

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -212,7 +212,12 @@ function evaluate_call!(stack, frame::JuliaStackFrame, call_expr::Expr, pc; exec
         push!(stack, newframe)
         return BreakpointRef(newframe.code, newframe.pc[])
     end
-    ret = exec!(stack, newframe)
+    ret = try
+        exec!(stack, newframe)
+    catch e
+        pop!(stack)
+        rethrow(e)
+    end
     isa(ret, BreakpointRef) && return ret
     pop!(stack)
     push!(junk, newframe)  # rather than going through GC, just re-use it

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -118,6 +118,7 @@ end
         frame = JuliaInterpreter.enter_call(f_exc_outer);
         v = JuliaInterpreter.finish_and_return!(stack, frame)
         @test v isa ErrorException
+        @test isempty(stack)
     finally
         JuliaInterpreter.break_on_error[] = false
     end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -353,23 +353,3 @@ end
     @test length(locals) == 3
     @test JuliaInterpreter.Variable(3, :x, false) in locals
 end
-
-@testset "empty stack after try catch" begin
-    function f_exc_outer()
-        try
-            f_exc_inner()
-        catch err
-            return err
-        end
-    end
-
-    function f_exc_inner()
-        error()
-    end
-
-    stack = JuliaStackFrame[];
-    frame = JuliaInterpreter.enter_call(f_exc_outer);
-    v = JuliaInterpreter.finish_and_return!(stack, frame)
-    @test v isa ErrorException
-    @test length(stack) == 0
-end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -353,3 +353,23 @@ end
     @test length(locals) == 3
     @test JuliaInterpreter.Variable(3, :x, false) in locals
 end
+
+@testset "empty stack after try catch" begin
+    function f_exc_outer()
+        try
+            f_exc_inner()
+        catch err
+            return err
+        end
+    end
+
+    function f_exc_inner()
+        error()
+    end
+
+    stack = JuliaStackFrame[];
+    frame = JuliaInterpreter.enter_call(f_exc_outer);
+    v = JuliaInterpreter.finish_and_return!(stack, frame)
+    @test v isa ErrorException
+    @test length(stack) == 0
+end


### PR DESCRIPTION
Unless each `push!` is guaranteed to have a corresponding `pop!`, we might end up with frames in the stack even when the function exits (#110). Currently, if we throw in `exec!` the `pop!` will not be executed, so when the stack unwinds after an error, we are left with frames in the stack.

This should fix that.