### PR TITLE
Implement core debug API here instead of Debugger.jl

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -44,8 +44,11 @@ JuliaInterpreter.evaluate_foreigncall
 JuliaInterpreter.maybe_evaluate_builtin
 JuliaInterpreter.maybe_next_call!
 JuliaInterpreter.next_line!
+JuliaInterpreter.next_call!
+JuliaInterpreter.maybe_reset_frame!
 JuliaInterpreter.maybe_step_through_wrapper!
 JuliaInterpreter.handle_err
+JuliaInterpreter.debug_command
 ```
 
 ## Breakpoints

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -43,6 +43,8 @@ JuliaInterpreter.evaluate_call!
 JuliaInterpreter.evaluate_foreigncall
 JuliaInterpreter.maybe_evaluate_builtin
 JuliaInterpreter.maybe_next_call!
+JuliaInterpreter.next_line!
+JuliaInterpreter.maybe_step_through_wrapper!
 JuliaInterpreter.handle_err
 ```
 

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -49,6 +49,8 @@ function set_compiled_methods()
     push!(compiled_methods, which(flush, Tuple{IOStream}))
     push!(compiled_methods, which(disable_sigint, Tuple{Function}))
     push!(compiled_methods, which(reenable_sigint, Tuple{Function}))
+    # Signal-handling in the `print` dispatch hierarchy
+    push!(compiled_methods, which(Base.unsafe_write, Tuple{Base.LibuvStream, Ptr{UInt8}, UInt}))
 end
 
 function __init__()

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -13,7 +13,8 @@ using InteractiveUtils
 using CodeTracking
 
 export @interpret, Compiled, Frame, root, leaf,
-       BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove
+       BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove,
+       debug_command
 
 module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -217,7 +217,7 @@ function breakpoint(filename::AbstractString, line::Integer, args...)
         offset = line1 - method.line
         src = JuliaInterpreter.get_source(method)
         lastline = src.linetable[end]
-        if lastline.line + offset >= line
+        if getline(lastline) + offset >= line
             return breakpoint(method, line, args...)
         end
     end

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -309,7 +309,6 @@ or one of the 'advanced' commands
 - "sg": step into the generator of a generated function
 
 `rootistoplevel` and `ret` are as described for [`JuliaInterpreter.maybe_reset_frame!`](@ref).
-Unlike other commands, the default setting for `recurse` is `Compiled()`.
 """
 function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString, rootistoplevel::Bool=false)
     istoplevel = rootistoplevel && frame.caller === nothing
@@ -317,11 +316,11 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString
         stmt = pc_expr(frame)
         cmd = is_call(stmt) ? "s" : "se"
     end
-    try 
+    try
         cmd == "nc" && return maybe_reset_frame!(recurse, frame, next_call!(recurse, frame, istoplevel), rootistoplevel)
         cmd == "n" && return maybe_reset_frame!(recurse, frame, next_line!(recurse, frame, istoplevel), rootistoplevel)
         cmd == "se" && return maybe_reset_frame!(recurse, frame, step_expr!(recurse, frame, istoplevel), rootistoplevel)
-   
+
         enter_generated = false
         if cmd == "sg"
             enter_generated = true
@@ -337,7 +336,7 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString
             ret = evaluate_call!(dummy_breakpoint, frame, stmt; enter_generated=enter_generated)
             isa(ret, BreakpointRef) && return maybe_reset_frame!(recurse, frame, ret, rootistoplevel)
             maybe_assign!(frame, stmt0, ret)
-            frame.pc = ret + 1
+            frame.pc += 1
             return frame, frame.pc
         end
         if cmd == "c"
@@ -357,4 +356,4 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString
     throw(ArgumentError("command $cmd not recognized"))
 end
 debug_command(frame::Frame, cmd::AbstractString, rootistoplevel::Bool=false) =
-    debug_command(Compiled(), frame, cmd, rootistoplevel)
+    debug_command(finish_and_return!, frame, cmd, rootistoplevel)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -330,6 +330,7 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString
             pc = maybe_next_call!(recurse, frame, istoplevel)
             (isa(pc, BreakpointRef) || pc === nothing) && return maybe_reset_frame!(recurse, frame, pc, rootistoplevel)
             stmt0 = stmt = pc_expr(frame, pc)
+            isexpr(stmt0, :return) && return maybe_reset_frame!(recurse, frame, nothing, rootistoplevel)
             if isexpr(stmt, :(=))
                 stmt = stmt.args[2]
             end

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -334,7 +334,13 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::AbstractString
             if isexpr(stmt, :(=))
                 stmt = stmt.args[2]
             end
-            ret = evaluate_call!(dummy_breakpoint, frame, stmt; enter_generated=enter_generated)
+            local ret
+            try
+                ret = evaluate_call!(dummy_breakpoint, frame, stmt; enter_generated=enter_generated)
+            catch err
+                ret = handle_err(recurse, frame, err)
+                return isa(ret, BreakpointRef) ? (leaf(frame), ret) : ret
+            end
             isa(ret, BreakpointRef) && return maybe_reset_frame!(recurse, frame, ret, rootistoplevel)
             maybe_assign!(frame, stmt0, ret)
             frame.pc += 1

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -283,7 +283,7 @@ function unwind_exception(frame::Frame, exc)
             frame.framedata.last_exception[] = exc
             return frame
         end
-        # recycle(frame)
+        recycle(frame)
         frame = caller(frame)
         frame === nothing || (frame.callee = nothing)
     end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -178,7 +178,7 @@ function evaluate_call_compiled!(::Compiled, frame::Frame, call_expr::Expr; ente
     pc = frame.pc
     ret = bypass_builtins(frame, call_expr, pc)
     isa(ret, Some{Any}) && return ret.value
-    ret = maybe_evaluate_builtin(frame, call_expr)
+    ret = maybe_evaluate_builtin(frame, call_expr, false)
     isa(ret, Some{Any}) && return ret.value
     fargs = collect_args(frame, call_expr)
     f = fargs[1]
@@ -190,8 +190,9 @@ function evaluate_call_recurse!(@nospecialize(recurse), frame::Frame, call_expr:
     pc = frame.pc
     ret = bypass_builtins(frame, call_expr, pc)
     isa(ret, Some{Any}) && return ret.value
-    ret = maybe_evaluate_builtin(frame, call_expr)
+    ret = maybe_evaluate_builtin(frame, call_expr, true)
     isa(ret, Some{Any}) && return ret.value
+    call_expr = ret
     fargs = collect_args(frame, call_expr)
     if (f = fargs[1]) === Core.eval
         return Core.eval(fargs[2], fargs[3])  # not a builtin, but worth treating specially

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -310,6 +310,20 @@ function do_assignment!(frame, @nospecialize(lhs), @nospecialize(rhs))
     end
 end
 
+function maybe_assign!(frame, @nospecialize(stmt), @nospecialize(val))
+    pc = frame.pc
+    if isexpr(stmt, :(=))
+        lhs = stmt.args[1]
+        do_assignment!(frame, lhs, val)
+    elseif isassign(frame, pc)
+        lhs = getlhs(pc)
+        do_assignment!(frame, lhs, val)
+    end
+    return nothing
+end
+maybe_assign!(frame, @nospecialize(val)) = maybe_assign!(frame, pc_expr(frame), val)
+
+
 function eval_rhs(@nospecialize(recurse), frame, node::Expr)
     head = node.head
     if head == :new

--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -7,7 +7,7 @@ Return the framecode and environment for a call specified by `fargs = [f, args..
 `parentframecode` is the caller, and `idx` is the program-counter index.
 If possible, `framecode` will be looked up from the local method tables of `parentframe`.
 """
-function get_call_framecode(fargs, parentframe::FrameCode, idx::Int)
+function get_call_framecode(fargs, parentframe::FrameCode, idx::Int; enter_generated::Bool=false)
     nargs = length(fargs)  # includes f as the first "argument"
     # Determine whether we can look up the appropriate framecode in the local method table
     if isassigned(parentframe.methodtables, idx)  # if this is the first call, this may not yet be set
@@ -19,11 +19,15 @@ function get_call_framecode(fargs, parentframe::FrameCode, idx::Int)
             # Determine whether the argument types match the signature
             sig = tme.sig.parameters::SimpleVector
             if length(sig) == nargs
-                matches = true
-                for i = 1:nargs
-                    if !isa(fargs[i], sig[i])
-                        matches = false
-                        break
+                # If this is generated, match only if `enter_generated` also matches
+                mi = tme.func::FrameInstance
+                matches = !is_generated(scopeof(mi.framecode)) || enter_generated == mi.enter_generated
+                if matches
+                    for i = 1:nargs
+                        if !isa(fargs[i], sig[i])
+                            matches = false
+                            break
+                        end
                     end
                 end
                 if matches
@@ -34,7 +38,6 @@ function get_call_framecode(fargs, parentframe::FrameCode, idx::Int)
                         tmeprev.next = tme.next
                         tme.next = tme1
                     end
-                    mi = tme.func::FrameInstance
                     return mi.framecode, mi.sparam_vals
                 end
             end
@@ -47,12 +50,12 @@ function get_call_framecode(fargs, parentframe::FrameCode, idx::Int)
     end
     # We haven't yet encountered this argtype combination and need to look it up by dispatch
     fargs[1] = f = to_function(fargs[1])
-    ret = prepare_call(f, fargs)
+    ret = prepare_call(f, fargs; enter_generated=enter_generated)
     ret === nothing && return f(fargs[2:end]...), nothing
     isa(ret, Compiled) && return ret, nothing
     framecode, args, env, argtypes = ret
     # Store the results of the method lookup in the local method table
-    mi = FrameInstance(framecode, env)
+    mi = FrameInstance(framecode, env, is_generated(scopeof(framecode)) & enter_generated)
     # it's sort of odd to call this a TypeMapEntry, then set most of the fields incorrectly
     # but since we're just using it as a linked list, it's probably ok
     tme = ccall(:jl_new_struct_uninit, Any, (Any,), TypeMapEntry)::TypeMapEntry

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    precompile(Tuple{typeof(maybe_evaluate_builtin), Frame, Expr})
+    precompile(Tuple{typeof(maybe_evaluate_builtin), Frame, Expr, Bool})
     precompile(Tuple{typeof(getargs), Vector{Any}, Frame})
     precompile(Tuple{typeof(get_call_framecode), Vector{Any}, FrameCode, Int})
     for f in (evaluate_call!,

--- a/src/types.jl
+++ b/src/types.jl
@@ -90,10 +90,11 @@ Fields:
 struct FrameInstance
     framecode::FrameCode
     sparam_vals::SimpleVector
+    enter_generated::Bool
 end
 
 Base.show(io::IO, instance::FrameInstance) =
-    print(io, "FrameInstance(", scopeof(instance.framecode), ", ", instance.sparam_vals, ')')
+    print(io, "FrameInstance(", scopeof(instance.framecode), ", ", instance.sparam_vals, ", ", instance.enter_generated, ')')
 
 """
 `FrameData` holds the arguments, local variables, and intermediate execution state

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -223,6 +223,11 @@ struct B{T} end
             fr = JuliaInterpreter.enter_call(f_outer)
             fr, pc = debug_command(JuliaInterpreter.finish_and_return!, fr, "finish")
             @test fr.framecode.scope.name == :error
+
+            fundef() = undef_func()
+            frame = JuliaInterpreter.enter_call(fundef)
+            fr, pc = debug_command(frame, "s")
+            @test isa(pc, BreakpointRef)
         finally
             JuliaInterpreter.break_on_error[] = false
         end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -228,6 +228,7 @@ struct B{T} end
             frame = JuliaInterpreter.enter_call(fundef)
             fr, pc = debug_command(frame, "s")
             @test isa(pc, BreakpointRef)
+            @test pc.err isa UndefVarError
         finally
             JuliaInterpreter.break_on_error[] = false
         end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -1,0 +1,131 @@
+using JuliaInterpreter, Test
+using JuliaInterpreter: enter_call, enter_call_expr, get_return
+
+function step_through(frame)
+    r = root(frame)
+    @test debug_command(JuliaInterpreter.finish_and_return!, frame, "c") === nothing
+    @test r.callee === nothing
+    return get_return(r)
+end
+
+@generated function generatedfoo(T)
+    :(return $T)
+end
+callgenerated() = generatedfoo(1)
+
+macro insert_some_calls()
+    esc(quote
+        x = sin(b)
+        y = asin(x)
+        z = sin(y)
+    end)
+end
+
+# @testset "Debug" begin
+    @testset "Basics" begin
+        frame = enter_call(map, x->2x, 1:10)
+        @test debug_command(frame, "finish") === nothing
+        @test frame.caller === frame.callee === nothing
+        @test get_return(frame) == map(x->2x, 1:10)
+
+        function complicated_keyword_stuff(args...; kw...)
+            args[1] == args[1]
+            (args..., kw...)
+        end
+        for (args, kwargs) in (((1,), ()), ((1, 2), (x=7, y=33)))
+            frame = enter_call(complicated_keyword_stuff, args...; kwargs...)
+            f, pc = debug_command(frame, "n")
+            @test f === frame
+            @test isa(pc, Int)
+            @test debug_command(frame, "finish") === nothing
+            @test frame.caller === frame.callee === nothing
+            @test get_return(frame) == complicated_keyword_stuff(args...; kwargs...)
+        end
+
+        f22() = string(:(a+b))
+        @test step_through(enter_call(f22)) == "a + b"
+        f22() = string(QuoteNode(:a))
+        @test step_through(enter_call(f22)) == ":a"
+
+        @test step_through(enter_call_expr(:($(+)(1,2.5)))) == 3.5
+        @test step_through(enter_call_expr(:($(sin)(1)))) == sin(1)
+        @test step_through(enter_call_expr(:($(gcd)(10,20)))) == gcd(10, 20)
+    end
+
+    @testset "generated" begin
+        frame = enter_call_expr(:($(callgenerated)()))
+        f, pc = debug_command(frame, "s")
+        @test isa(pc, BreakpointRef)
+        @test JuliaInterpreter.scopeof(f).name == :generatedfoo
+        stmt = JuliaInterpreter.pc_expr(f)
+        @test stmt.head == :return && stmt.args[1] === Int
+        @test debug_command(frame, "c") === nothing
+        @test frame.callee === nothing
+        @test get_return(frame) === Int
+        # This time, step into the generated function itself
+        frame = enter_call_expr(:($(callgenerated)()))
+        f, pc = debug_command(frame, "sg")
+        @test isa(pc, BreakpointRef)
+        @test JuliaInterpreter.scopeof(f).name == :generatedfoo
+        stmt = JuliaInterpreter.pc_expr(f)
+        @test stmt.head == :return && JuliaInterpreter.@lookup(f, stmt.args[1]) === 1
+        f2, pc = debug_command(f, "finish")
+        @test JuliaInterpreter.scopeof(f2).name == :callgenerated
+        # Now finish the regular function
+        @test debug_command(frame, "finish") === nothing
+        @test frame.callee === nothing
+        @test get_return(frame) === 1
+    end
+
+    @testset "Optional arguments" begin
+        function optional(n = sin(1))
+            x = asin(n)
+            cos(x)
+        end
+        frame = JuliaInterpreter.enter_call_expr(:($(optional)()))
+        # First call steps in and executes the first statement
+        f, pc = debug_command(frame, "n")
+        @test frame !== f
+        # cos(1.0)
+        debug_command(f, "n")
+        # return
+        f2, pc = debug_command(f, "n")
+        @test f2 === frame
+        @test debug_command(frame, "n") === nothing
+    end
+
+    @testset "Macros" begin
+        # Work around the fact that we can't detect macro expansions if the macro
+        # is defined in the same file
+        include_string(Main, """
+        function test_macro()
+            a = sin(5)
+            b = asin(a)
+            @insert_some_calls
+            z
+        end
+        ""","file.jl")
+        frame = JuliaInterpreter.enter_call_expr(:($(test_macro)()))
+        f, pc = debug_command(frame, "n")        # a is set
+        f, pc = debug_command(f, "n")            # b is set
+        f, pc = debug_command(f, "n")            # x is set
+        f, pc = debug_command(f, "n")            # y is set
+        f, pc = debug_command(f, "n")            # z is set
+        @test debug_command(f, "n") === nothing  # return
+    end
+
+    @testset "Keyword arguments" begin
+        f(x; b = 1) = x+b
+        g() = f(1; b = 2)
+        frame = JuliaInterpreter.enter_call_expr(:($(g)()));
+        fr, pc = debug_command(frame, "nc")
+        fr, pc = debug_command(fr, "nc")
+        fr, pc = debug_command(fr, "nc")
+        fr, pc = debug_command(fr, "s")
+        fr, pc = debug_command(fr, "finish")
+        @test debug_command(fr, "finish") === nothing
+        @test frame.callee === nothing
+        @test get_return(frame) == 3
+    end
+
+# end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -22,6 +22,8 @@ macro insert_some_calls()
     end)
 end
 
+trivial(x) = x
+
 struct B{T} end
 
 # @testset "Debug" begin
@@ -50,6 +52,11 @@ struct B{T} end
         f22() = string(QuoteNode(:a))
         @test step_through(enter_call(f22)) == ":a"
 
+        frame = enter_call(trivial, 2)
+        @test debug_command(frame, "s") === nothing
+        @test get_return(frame) == 2
+
+        @test step_through(enter_call(trivial, 2)) == 2
         @test step_through(enter_call_expr(:($(+)(1,2.5)))) == 3.5
         @test step_through(enter_call_expr(:($(sin)(1)))) == sin(1)
         @test step_through(enter_call_expr(:($(gcd)(10,20)))) == gcd(10, 20)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ end
     include("toplevel.jl")
     include("limits.jl")
     include("breakpoints.jl")
+    include("debug.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,6 +6,16 @@ using JuliaInterpreter: finish_and_return!, evaluate_call!, step_expr!, shouldbr
 using Base.Meta: isexpr
 using Test, Random, SHA
 
+function stacklength(frame)
+    n = 1
+    frame = frame.callee
+    while frame !== nothing
+        n += 1
+        frame = frame.callee
+    end
+    return n
+end
+
 # Execute a frame using Julia's regular compiled-code dispatch for any :call expressions
 runframe(frame) = Some{Any}(finish_and_return!(Compiled(), frame))
 


### PR DESCRIPTION
I haven't really played much with Debugger.jl. Porting over some of its functionality is proving to be a useful exercise, as several of these commits generalize JuliaInterpreter in useful ways or detect problems that might not have surfaced so readily otherwise.

This is a WIP; I should probably transition to other things now. If folks want to chip in, I stopped [here](https://github.com/JuliaDebug/Debugger.jl/blob/4d9c0fc99b09ffdcf8ae1b4df8e6612ca0924884/test/stepping.jl#L93). Otherwise I'll pick this up again tomorrow.