### PR TITLE
move builtin generation logic to precompilation time

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,0 @@
-using InteractiveUtils
-
-const srcpath = joinpath(dirname(@__DIR__), "src")
-include(joinpath(srcpath, "generate_builtins.jl"))
-open(joinpath(srcpath, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl"), "w") do io
-    generate_builtins(io)
-end

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -22,12 +22,11 @@ end
 
 const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
 
-if ccall(:jl_generating_output, Cint, ()) == 1
-    @info "Generating builtins for this julia version..."
-    gen_builtins_file = joinpath(@__DIR__, "generate_builtins.jl")
-    run(`$(Base.julia_cmd()) $gen_builtins_file`)
-    include_dependency(gen_builtins_file)
-end
+@info "Generating builtins for this julia version..."
+gen_builtins_file = joinpath(@__DIR__, "generate_builtins.jl")
+# Run as separate command to prevent including the generate_builtins into the precompile cache
+run(`$(Base.julia_cmd()) $gen_builtins_file`)
+include_dependency(gen_builtins_file)
 
 include("types.jl")
 include("utils.jl")

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -22,12 +22,11 @@ end
 
 const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
 
-if !isfile(BUILTIN_FILE)
+if ccall(:jl_generating_output, Cint, ()) == 1
     @info "Generating builtins for this julia version..."
-    include("generate_builtins.jl")
-    open(BUILTIN_FILE, "w") do io
-        generate_builtins(io)
-    end
+    gen_builtins_file = joinpath(@__DIR__, "generate_builtins.jl")
+    run(`$(Base.julia_cmd()) $gen_builtins_file`)
+    include_dependency(gen_builtins_file)
 end
 
 include("types.jl")

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -25,7 +25,7 @@ const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(I
 @info "Generating builtins for this julia version..."
 gen_builtins_file = joinpath(@__DIR__, "generate_builtins.jl")
 # Run as separate command to prevent including the generate_builtins into the precompile cache
-run(`$(Base.julia_cmd()) $gen_builtins_file`)
+run(`$(Base.julia_cmd()) --startup-file=no $gen_builtins_file`)
 include_dependency(gen_builtins_file)
 
 include("types.jl")

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -20,12 +20,22 @@ module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall)
 end
 
+const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
+
+if !isfile(BUILTIN_FILE)
+    @info "Generating builtins for this julia version..."
+    include("generate_builtins.jl")
+    open(BUILTIN_FILE, "w") do io
+        generate_builtins(io)
+    end
+end
+
 include("types.jl")
 include("utils.jl")
 include("construct.jl")
 include("localmethtable.jl")
 include("interpret.jl")
-include("builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
+include(BUILTIN_FILE)
 include("optimize.jl")
 include("commands.jl")
 include("breakpoints.jl")

--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -1,4 +1,5 @@
 # This file generates builtins.jl.
+using InteractiveUtils
 
 function scopedname(f)
     io = IOBuffer()
@@ -66,6 +67,11 @@ end
 
 # `io` is for the generated source file
 # `intrinsicsfile` is the path to Julia's `src/intrinsics.h` file
+function generate_builtins(file::String)
+    open(file, "w") do io
+        generate_builtins(io::IO)
+    end
+end
 function generate_builtins(io::IO)
     pat = r"(ADD_I|ALIAS)\((\w*),"
     print(io,
@@ -209,3 +215,5 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 end
 """)
 end
+
+generate_builtins(joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl"))


### PR DESCRIPTION
The current build system has the problem that if someone adds JuliaInterpreter on two julia versions, the second add will not build JuliaInterpreter (since it is already downloaded and assumed built). This will then give an error when loading it that it misses the file.

Instead, just run this on precompilation time if we cant find the file.

The negative is that we need to load the code for generating the builtin file every time we load the package but from my measurements it is within noise.