### PR TITLE
An export-worthy API for break_on_error

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -60,6 +60,8 @@ breakpoint
 enable
 disable
 remove
+break_on
+break_off
 JuliaInterpreter.dummy_breakpoint
 ```
 

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -14,7 +14,7 @@ using CodeTracking
 
 export @interpret, Compiled, Frame, root, leaf,
        BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove,
-       debug_command, @bp
+       debug_command, @bp, break_on, break_off
 
 module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -130,6 +130,40 @@ function remove()
 end
 
 """
+    break_on(states...)
+
+Turn on automatic breakpoints when any of the conditions described in `states` occurs.
+The supported states are:
+
+- `:error`: trigger a breakpoint any time an uncaught exception is thrown
+"""
+function break_on(states::Vararg{Symbol})
+    for state in states
+        if state == :error
+            break_on_error[] = true
+        else
+            throw(ArgumentError(string("unsupported state :", state)))
+        end
+    end
+end
+
+"""
+    break_off(states...)
+
+Turn off automatic breakpoints when any of the conditions described in `states` occurs.
+See [`break_on`](@ref) for a description of valid states.
+"""
+function break_off(states::Vararg{Symbol})
+    for state in states
+        if state == :error
+            break_on_error[] = false
+        else
+            throw(ArgumentError(string("unsupported state :", state)))
+        end
+    end
+end
+
+"""
     breakpoint(f, sig)
     breakpoint(f, sig, line)
     breakpoint(f, sig, condition)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -130,7 +130,9 @@ end
 
     # break on error
     try
-        JuliaInterpreter.break_on_error[] = true
+        @test_throws ArgumentError("unsupported state :missing") break_on(:missing)
+        @test_throws ArgumentError("inputs must be Symbols, got String") break_on("missing")
+        break_on(:error)
 
         inner(x) = error("oops")
         outer() = inner(1)
@@ -158,7 +160,7 @@ end
         @test v isa ErrorException
         @test stacklength(frame) == 1
     finally
-        JuliaInterpreter.break_on_error[] = false
+        break_off(:error)
     end
 
     # Breakpoint display

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -131,7 +131,6 @@ end
     # break on error
     try
         @test_throws ArgumentError("unsupported state :missing") break_on(:missing)
-        @test_throws ArgumentError("inputs must be Symbols, got String") break_on("missing")
         break_on(:error)
 
         inner(x) = error("oops")

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -247,7 +247,7 @@ struct B{T} end
         # Don't break on caught exceptions
         err_caught = Any[nothing]
         function f_exc_outer()
-            try 
+            try
                 f_exc_inner()
             catch err;
                 err_caught[1] = err
@@ -282,7 +282,7 @@ struct B{T} end
 
         # Break on error
         try
-            JuliaInterpreter.break_on_error[] = true
+            break_on(:error)
             fr = JuliaInterpreter.enter_call(f_outer)
             fr, pc = debug_command(JuliaInterpreter.finish_and_return!, fr, "finish")
             @test fr.framecode.scope.name == :error
@@ -293,7 +293,7 @@ struct B{T} end
             @test isa(pc, BreakpointRef)
             @test pc.err isa UndefVarError
         finally
-            JuliaInterpreter.break_on_error[] = false
+            break_off(:error)
         end
 
         @testset "breakpoints" begin


### PR DESCRIPTION
Some day we hope to have more possibilities for triggering automatic breakpoints (issue #102). For now, let's at least establish an extensible user-level API.