### PR TITLE
fix interpreting getting env vars on windows

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -59,6 +59,11 @@ function set_compiled_methods()
     push!(compiled_methods, which(reenable_sigint, Tuple{Function}))
     # Signal-handling in the `print` dispatch hierarchy
     push!(compiled_methods, which(Base.unsafe_write, Tuple{Base.LibuvStream, Ptr{UInt8}, UInt}))
+    # Libc.GetLastError()
+    @static if Sys.iswindows()
+        push!(compiled_methods, which(Base.access_env, Tuple{Function, AbstractString}))
+        push!(compiled_methods, which(Base._hasenv, Tuple{Vector{UInt16}}))
+    end
 end
 
 function __init__()

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -384,3 +384,6 @@ end
     x = Union{Array{UInt8,N},Array{Int8,N}} where N
     @test isa(JuliaInterpreter.prepare_call(varargidentity, [varargidentity, x])[1], JuliaInterpreter.FrameCode)
 end
+
+# https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/141
+@test @interpret get(ENV, "THIS_IS_NOT_DEFINED_1234", "24") == "24"


### PR DESCRIPTION
We should probably enable AV heh.

Fixes #141 