### PR TITLE
fix typo in whereis

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,7 +168,7 @@ function CodeTracking.whereis(framecode::FrameCode, pc)
     codeloc == 0 && return nothing
     lineinfo = framecode.src.linetable[codeloc]
     return isa(framecode.scope, Method) ?
-        whereis(lineinfo, framecode.scope) : getfile(lineinfo), getline(lineinfo)
+        whereis(lineinfo, framecode.scope) : (getfile(lineinfo), getline(lineinfo))
 end
 CodeTracking.whereis(frame::Frame, pc=frame.pc) = whereis(frame.framecode, pc)
 

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -384,3 +384,10 @@ end
     x = Union{Array{UInt8,N},Array{Int8,N}} where N
     @test isa(JuliaInterpreter.prepare_call(varargidentity, [varargidentity, x])[1], JuliaInterpreter.FrameCode)
 end
+
+# Test return value of whereis
+f() = nothing
+fr = JuliaInterpreter.enter_call(f)
+file, line = JuliaInterpreter.whereis(fr)
+@test file == @__FILE__
+@test line == (@__LINE__() - 4)

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -55,7 +55,7 @@ end
 module Toplevel end
 
 @testset "toplevel" begin
-    modexs, _ = JuliaInterpreter.split_expressions(Toplevel, read_and_parse("toplevel_script.jl"))
+    modexs, _ = JuliaInterpreter.split_expressions(Toplevel, read_and_parse(joinpath(@__DIR__, "toplevel_script.jl")))
     for modex in modexs
         frame = JuliaInterpreter.prepare_thunk(modex)
         while true


### PR DESCRIPTION
```jl
julia> f() = nothing
f (generic function with 1 method)

julia> fr = enter_call(f)
Frame for f() in Main at REPL[3]:1
  1 1  1 ─     return nothing

julia> file, line = JuliaInterpreter.whereis(fr)
(("REPL[3]", 1), 1) # oooops
```
