### PR TITLE
 work around problem with finding stdlib files 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,10 +4,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
-deps = ["Test", "UUIDs"]
-git-tree-sha1 = "12aa4d41c7926afd7a71af5af603a4d8b94292c2"
+deps = ["InteractiveUtils", "Test", "UUIDs"]
+git-tree-sha1 = "983f5f7a57c604322917ab8bc5b86ba914d3c345"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.3.1"
+version = "0.3.2"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -4,10 +4,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CodeTracking]]
-deps = ["Test", "UUIDs"]
-git-tree-sha1 = "591b73b37c92ed7d55d3a14e266829c21aa3a7eb"
+deps = ["InteractiveUtils", "Test", "UUIDs"]
+git-tree-sha1 = "983f5f7a57c604322917ab8bc5b86ba914d3c345"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "0.3.0"
+version = "0.3.2"
 
 [[Dates]]
 deps = ["Printf"]
@@ -19,9 +19,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "1df01539a1c952cef21f2d2d1c092c2bcf0177d7"
+git-tree-sha1 = "4d30e889c9f106a51ffa4791a88ffd4765bf20c3"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.6.0"
+version = "0.7.0"
 
 [[Documenter]]
 deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -20,6 +20,9 @@ module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall)
 end
 
+# Just some way to get the path to the buildbot, which is used to workaround https://github.com/JuliaLang/julia/issues/26314
+const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(String((@which clipboard()).file), "..", "..", "..")))
+
 const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
 
 @info "Generating builtins for this julia version..."

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -20,9 +20,6 @@ module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall)
 end
 
-# Just some way to get the path to the buildbot, which is used to workaround https://github.com/JuliaLang/julia/issues/26314
-const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(String((@which clipboard()).file), "..", "..", "..")))
-
 const BUILTIN_FILE = joinpath(@__DIR__, "builtins-julia$(Int(VERSION.major)).$(Int(VERSION.minor)).jl")
 
 @info "Generating builtins for this julia version..."

--- a/src/types.jl
+++ b/src/types.jl
@@ -187,7 +187,7 @@ function truncate!(frame)
 end
 
 function Base.show(io::IO, frame::Frame)
-    frame_loc = replace(repr(scopeof(frame)), BUILDBOT_STDLIB_PATH => Sys.STDLIB)
+    frame_loc = CodeTracking.replace_buildbot_stdlibpath(repr(scopeof(frame)))
     println(io, "Frame for ", frame_loc)
     pc = frame.pc
     ns = nstatements(frame.framecode)

--- a/src/types.jl
+++ b/src/types.jl
@@ -187,7 +187,8 @@ function truncate!(frame)
 end
 
 function Base.show(io::IO, frame::Frame)
-    println(io, "Frame for ", scopeof(frame))
+    frame_loc = replace(repr(scopeof(frame)), BUILDBOT_STDLIB_PATH => Sys.STDLIB)
+    println(io, "Frame for ", frame_loc)
     pc = frame.pc
     ns = nstatements(frame.framecode)
     range = get(io, :limit, false) ? (max(1, pc-2):min(ns, pc+2)) : (1:ns)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,16 +154,8 @@ function lineoffset(framecode::FrameCode)
     return offset
 end
 
-function maybe_find_stdlib_file(filepath)
-    if !isfile(filepath)
-        maybe_stdlib_filepath = replace(filepath, BUILDBOT_STDLIB_PATH => Sys.STDLIB)
-        isfile(maybe_stdlib_filepath) && return maybe_stdlib_filepath
-    end
-    return filepath
-end
-
 getline(ln) = isexpr(ln, :line) ? ln.args[1] : ln.line
-getfile(ln) = maybe_find_stdlib_file(String(isexpr(ln, :line) ? ln.args[2] : ln.file))
+getfile(ln) = CodeTracking.maybe_fixup_stdlib_path(String(isexpr(ln, :line) ? ln.args[2] : ln.file))
 
 """
     loc = whereis(frame, pc=frame.pc)
@@ -175,9 +167,8 @@ function CodeTracking.whereis(framecode::FrameCode, pc)
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
     lineinfo = framecode.src.linetable[codeloc]
-    filepath, line = isa(framecode.scope, Method) ?
+    return isa(framecode.scope, Method) ?
         whereis(lineinfo, framecode.scope) : (getfile(lineinfo), getline(lineinfo))
-    return maybe_find_stdlib_file(filepath), line
 end
 CodeTracking.whereis(frame::Frame, pc=frame.pc) = whereis(frame.framecode, pc)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,9 +154,6 @@ function lineoffset(framecode::FrameCode)
     return offset
 end
 
-# Just some way to get the path to the buildbot
-const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(String((@which clipboard()).file), "..", "..", "..")))
-
 function maybe_find_stdlib_file(filepath)
     if !isfile(filepath)
         maybe_stdlib_filepath = replace(filepath, BUILDBOT_STDLIB_PATH => Sys.STDLIB)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -394,3 +394,8 @@ fr = JuliaInterpreter.enter_call(f)
 file, line = JuliaInterpreter.whereis(fr)
 @test file == @__FILE__
 @test line == (@__LINE__() - 4)
+
+fr = JuliaInterpreter.enter_call(Test.eval, 1)
+file, line = JuliaInterpreter.whereis(fr)
+@test isfile(file)
+@test isfile(JuliaInterpreter.getfile(fr.framecode.src.linetable[1]))

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -395,7 +395,9 @@ file, line = JuliaInterpreter.whereis(fr)
 @test file == @__FILE__
 @test line == (@__LINE__() - 4)
 
+# Test path to files in stdlib
 fr = JuliaInterpreter.enter_call(Test.eval, 1)
 file, line = JuliaInterpreter.whereis(fr)
 @test isfile(file)
 @test isfile(JuliaInterpreter.getfile(fr.framecode.src.linetable[1]))
+@test occursin(Sys.STDLIB, repr(fr))


### PR DESCRIPTION
Commited on top of #145 

Previously we couldnt see the source for stdlib files:

```jl
julia> @enter norm([1,2])
In norm(itr, p) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\LinearAlgebra\src\generic.jl:448
1   1 ── %1  = (isempty)(itr)
2   └───       goto #4 if not %1
3   2 ── %3  = (eltype)(itr)

About to run: (isempty)([1, 2])
1|debug> 
```

Now we can:

```jl
julia> @enter norm([1,2])
In norm(itr, p) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\LinearAlgebra\src\generic.jl:448
448       isempty(itr) && return float(norm(zero(eltype(itr))))
449       if p == 2
450           return norm2(itr)
```

The method printing is still wrong though.