### PR TITLE
add some benchmarks

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+tune.json

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,9 @@
+The benchmarks are recommended to be run using PkgBenchmark.jl as:
+
+```
+using PkgBenchmark
+results = benchmarkpkg("JuliaInterpreter")
+```
+
+See the [PkgBenchmark](https://juliaci.github.io/PkgBenchmark.jl/stable/index.html) documentation for what
+analysis is possible on `result`.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,56 @@
+using JuliaInterpreter
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Recursively call itself
+f(i, j) = i == 0 ? j : f(i - 1, j + 1)
+SUITE["recursive self 1_000"] = @benchmarkable @interpret f(1_000, 0)
+
+# Long stack trace calling other functions
+f0(i) = i
+for i in 1:1_000
+    @eval $(Symbol("f", i))(i) = $(Symbol("f", i-1))(i)
+end
+SUITE["recursive other 1_000"] = @benchmarkable @interpret f1000(1)
+
+# Tight loop
+function f(X)
+    s = 0
+    for x in X
+        s += x
+    end
+    return s
+end
+const X = rand(1:10, 10_000)
+SUITE["tight loop 10_000"] = @benchmarkable @interpret f(X)
+
+# Throwing and catching an error over a large stacktrace
+function g0(i)
+    try
+        g1(i)
+    catch e
+        e
+    end
+end
+for i in 1:1_000
+    @eval $(Symbol("g", i))(i) = $(Symbol("g", i+1))(i)
+end
+g1001(i) = error()
+SUITE["throw long 1_000"] = @benchmarkable @interpret g0(1)
+
+# Function with many statements
+macro do_thing(expr, N)
+    e = Expr(:block)
+    for i in 1:N
+        push!(e.args, esc(expr))
+    end
+    return e
+end
+
+function counter()
+    a = 0
+    @do_thing(a = a + 1, 5_000)
+    return a
+end
+SUITE["long function 5_000"] = @benchmarkable @interpret counter()


### PR DESCRIPTION
Using https://juliaci.github.io/PkgBenchmark.jl/stable/export_markdown.html:

| ID                          | time            | GC time  | memory          | allocations |
|-----------------------------|----------------:|---------:|----------------:|------------:|
| `["long function 5_000"]`   |   5.560 ms (5%) |          |   1.31 MiB (1%) |       53490 |
| `["recursive other 1_000"]` |   1.405 ms (5%) |          | 173.80 KiB (1%) |        5031 |
| `["recursive self 1_000"]`  |   6.340 ms (5%) |          | 814.39 KiB (1%) |       28017 |
| `["throw long 1_000"]`      |   3.575 ms (5%) |          | 175.44 KiB (1%) |        5075 |
| `["tight loop 10_000"]`     | 674.890 ms (5%) | 2.856 ms |  58.04 MiB (1%) |     1857126 |