### PR TITLE
more thorough testing of commands

### DIFF
--- a/test/debug.jl
+++ b/test/debug.jl
@@ -2,7 +2,7 @@ using JuliaInterpreter, Test
 using JuliaInterpreter: enter_call, enter_call_expr, get_return, @lookup
 using Base.Meta: isexpr
 
-const ALL_COMMANDS = ("n", "s", "c", "finish", "nc", "se", "si") # ,"sg") sg current broken
+const ALL_COMMANDS = ("n", "s", "c", "finish", "nc", "se", "si", "sg")
 
 function step_through_command(fr::Frame, cmd::String)
     while true

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -2,7 +2,7 @@ using JuliaInterpreter, Test
 using JuliaInterpreter: enter_call, enter_call_expr, get_return, @lookup
 using Base.Meta: isexpr
 
-const ALL_COMMANDS = ("n", "s", "c", "finish", "nc", "se", "si", "sg")
+const ALL_COMMANDS = ("n", "s", "c", "finish", "nc", "se", "si")
 
 function step_through_command(fr::Frame, cmd::String)
     while true


### PR DESCRIPTION
Stepping with "sg" currently errors with

```
ERROR: MethodError: no method matching #s5#3(::Symbol, ::Symbol)
Closest candidates are:
  #s5#3(::Any, ::Any, ::Any, ::Any) at boot.jl:557
Stacktrace:
 [1] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any,N} where N) at .\boot.jl:522
 [2] get_source at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\construct.jl:51 [inlined]
 [3] #prepare_framecode#11(::Bool, ::Function, ::Method, ::Any) at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\construct.jl:141
 [4] (::getfield(JuliaInterpreter, Symbol("#kw##prepare_framecode")))(::NamedTuple{(:enter_generated,),Tuple{Bool}}, ::typeof(JuliaInterpreter.prepare_framecode), ::Method, ::Type) at .\none:0
 [5] #prepare_call#12(::Bool, ::Function, ::Any, ::Array{Any,1}) at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\construct.jl:219
 [6] #prepare_call at .\none:0 [inlined]
 [7] #get_call_framecode#30(::Bool, ::Function, ::Array{Any,1}, ::JuliaInterpreter.FrameCode, ::Int64) at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\localmethtable.jl:53
 [8] #get_call_framecode at .\none:0 [inlined]
 [9] #evaluate_call_recurse!#35(::Bool, ::Function, ::Any, ::Frame, ::Expr) at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\interpret.jl:203
 [10] #evaluate_call_recurse! at .\none:0 [inlined]
 [11] #evaluate_call!#37 at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\interpret.jl:237 [inlined]
 [12] #evaluate_call! at .\none:0 [inlined]
 [13] debug_command(::Any, ::Frame, ::String, ::Bool) at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\commands.jl:341
 [14] debug_command at C:\Users\Kristoffer\Debugging\JuliaInterpreter\src\commands.jl:315 [inlined]
 [15] step_through_command(::Frame, ::String) at .\REPL[15]:3
 [16] #step_through#11(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Function) at .\REPL[19]:6
 [17] step_through(::Function) at .\REPL[19]:2
 [18] top-level scope at none:0
```