### PR TITLE
Abandon attempts to force frame construction for "trivial" toplevels

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -138,6 +138,7 @@ end
 through_methoddef_or_done!(@nospecialize(recurse), t::Tuple{Module,Expr,Frame}) =
     through_methoddef_or_done!(recurse, t[end])
 through_methoddef_or_done!(@nospecialize(recurse), modex::Tuple{Module,Expr,Expr}) = Core.eval(modex[1], modex[3])
+through_methoddef_or_done!(@nospecialize(recurse), ::Nothing) = nothing
 through_methoddef_or_done!(arg) = through_methoddef_or_done!(finish_and_return!, arg)
 
 function changed_line!(expr, line, fls)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -322,7 +322,12 @@ function prepare_thunk(mod::Module, thunk::Expr, recursive::Bool=false)
     elseif isexpr(thunk, :error) || isexpr(thunk, :incomplete)
         error("lowering returned an error, ", thunk)
     elseif recursive
-        thunk = Meta.lower(mod, Expr(:block, nothing, thunk))
+        thunk = Meta.lower(mod, thunk)
+        if isa(thunk, Expr)
+            # If on 2nd attempt to lower it's still an Expr, just evaluate it
+            Core.eval(mod, thunk)
+            return nothing
+        end
         framecode = FrameCode(mod, thunk.args[1])
     else
         lwr = Meta.lower(mod, thunk)

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -17,7 +17,8 @@ end
     @test JuliaInterpreter.is_doc_expr(ex.args[2])
     @test !JuliaInterpreter.is_doc_expr(:(1+1))
 
-    @test isa(JuliaInterpreter.prepare_thunk(Main, :(export foo)), Frame)
+    @test JuliaInterpreter.prepare_thunk(Main, :(export foo)) === nothing
+    @test JuliaInterpreter.prepare_thunk(Base.Threads, :(global Condition)) === nothing
 
     @test !isdefined(Main, :JIInvisible)
     JuliaInterpreter.split_expressions(JIVisible, :(module JIInvisible f() = 1 end))


### PR DESCRIPTION
While trying to get https://github.com/timholy/Revise.jl/pull/243 to pass on nightly, I discovered that recent Julia versions no longer allow one to coerce certain expressions into a `CodeInfo`. So we're going to have to allow for the possibility that `prepare_thunk` will not return a `Frame`.