### PR TITLE
Overload show(io, mime, x) instead of show(io, x) for pretty-printing.

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -85,7 +85,7 @@ end
 
 nstatements(framecode::FrameCode) = length(framecode.src.code)
 
-Base.show(io::IO, framecode::FrameCode) = print_framecode(io, framecode)
+Base.show(io::IO, ::MIME"text/plain", framecode::FrameCode) = print_framecode(io, framecode)
 
 """
 `FrameInstance` represents a method specialized for particular argument types.
@@ -175,7 +175,7 @@ Return the deepest callee in the call stack.
 """
 leaf(frame) = traverse(callee, frame)
 
-function Base.show(io::IO, frame::Frame)
+function Base.show(io::IO, ::MIME"text/plain", frame::Frame)
     frame_loc = CodeTracking.replace_buildbot_stdlibpath(repr(scopeof(frame)))
     println(io, "Frame for ", frame_loc)
     pc = frame.pc
@@ -208,7 +208,10 @@ struct Variable
     name::Symbol
     isparam::Bool
 end
-Base.show(io::IO, var::Variable) = (print(io, var.name, " = "); show(io,var.value))
+function Base.show(io::IO, m::MIME"text/plain", var::Variable)
+    print(io, var.name, " = ")
+    show(io, m, var.value)
+end
 Base.isequal(var1::Variable, var2::Variable) =
     var1.value == var2.value && var1.name == var2.name && var1.isparam == var2.isparam
 
@@ -233,7 +236,7 @@ struct BreakpointRef
 end
 BreakpointRef(framecode, stmtidx) = BreakpointRef(framecode, stmtidx, nothing)
 
-function Base.show(io::IO, bp::BreakpointRef)
+function Base.show(io::IO, ::MIME"text/plain", bp::BreakpointRef)
     if checkbounds(Bool, bp.framecode.breakpoints, bp.stmtidx)
         lineno = linenumber(bp.framecode, bp.stmtidx)
         print(io, "breakpoint(", bp.framecode.scope, ", line ", lineno)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -173,13 +173,13 @@ end
     io = IOBuffer()
     frame = JuliaInterpreter.enter_call(loop_radius2, 2)
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 1)
-    show(io, bp)
+    show(io, "text/plain", bp)
     @test String(take!(io)) == "breakpoint(loop_radius2(n) in $(@__MODULE__) at $(@__FILE__):3, line 3)"
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 0)  # fictive breakpoint
-    show(io, bp)
+    show(io,  "text/plain",bp)
     @test String(take!(io)) == "breakpoint(loop_radius2(n) in $(@__MODULE__) at $(@__FILE__):3, %0)"
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 1, ArgumentError("whoops"))
-    show(io, bp)
+    show(io,  "text/plain",bp)
     @test String(take!(io)) == "breakpoint(loop_radius2(n) in $(@__MODULE__) at $(@__FILE__):3, line 3, ArgumentError(\"whoops\"))"
 
     # In source breakpointing

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -400,7 +400,7 @@ fr = JuliaInterpreter.enter_call(Test.eval, 1)
 file, line = JuliaInterpreter.whereis(fr)
 @test isfile(file)
 @test isfile(JuliaInterpreter.getfile(fr.framecode.src.linetable[1]))
-@test occursin(Sys.STDLIB, repr(fr))
+@test occursin(Sys.STDLIB, repr("text/plain", fr))
 
 # Test undef sparam (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/165)
 function foo(x::T) where {T <: AbstractString, S <: AbstractString}


### PR DESCRIPTION
I think the three-arg method is recommended for pretty-printing. Otherwise the pretty-printing leaks out in e.g. error messages.