### PR TITLE
step through invokes

### DIFF
--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -153,9 +153,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             if !expand
                 return Some{Any}(invoke(argswrapped...))
             end
-            new_f = which(argswrapped[1], argswrapped[2])
-            new_expr = Expr(:call, new_f, argswrapped[3:end]...)
-            return new_expr
+            return Expr(:call, invoke, argswrapped...)
 """)
             continue
         end

--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -138,11 +138,24 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     $head f === Core._apply
         argswrapped = getargs(args, frame)
         if !expand
-            return Some{Any}(Core._apply(getargs(args, frame)...))
+            return Some{Any}(Core._apply(argswrapped...))
         end
         argsflat = Base.append_any((argswrapped[1],), argswrapped[2:end]...)
         new_expr = Expr(:call, map(x->isa(x, Symbol) || isa(x, Expr) || isa(x, QuoteNode) ? QuoteNode(x) : x, argsflat)...)
         return new_expr
+""")
+            continue
+        elseif f === Core.invoke
+            print(io, 
+"""
+    $head f === invoke
+            argswrapped = getargs(args, frame)
+            if !expand
+                return Some{Any}(invoke(argswrapped...))
+            end
+            new_f = which(argswrapped[1], argswrapped[2])
+            new_expr = Expr(:call, new_f, argswrapped[3:end]...)
+            return new_expr
 """)
             continue
         end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -208,22 +208,23 @@ function evaluate_call_recurse!(@nospecialize(recurse), frame::Frame, call_expr:
         err = length(fargs) > 1 ? fargs[2] : frame.framedata.last_exception[]
         throw(err)
     end
-    if fargs[1] isa Method # happens on invoke, fargs[1] is the method to call
-        f, sig = fargs[1], Tuple{typeof.(fargs[2:end])...}
-        ret = prepare_framecode(f, sig; enter_generated=enter_generated)
-        if ret === nothing
-            error("help...")
-        end
+    if fargs[1] === Core.invoke # invoke needs special handling
+        f_invoked = which(fargs[2], fargs[3])
+        sig = Tuple{_Typeof.(fargs)...}
+        ret = prepare_framecode(f_invoked, sig; enter_generated=enter_generated)
+        isa(ret, Compiled) && invoke(fargs[2:end]...)
         framecode, lenv = ret
+        fargs = [fargs[2]; fargs[4:end]]
+        lenv === nothing && return framecode  # this was a Builtin
     else
         framecode, lenv = get_call_framecode(fargs, frame.framecode, frame.pc; enter_generated=enter_generated)
-    end
-    if lenv === nothing
-        if isa(framecode, Compiled)
-            popfirst!(fargs)  # now it's really just `args`
-            return f(fargs...)
+        if lenv === nothing
+            if isa(framecode, Compiled)
+                popfirst!(fargs)  # now it's really just `args`
+                return f(fargs...)
+            end
+            return framecode  # this was a Builtin
         end
-        return framecode  # this was a Builtin
     end
     newframe = prepare_frame_caller(frame, framecode, fargs, lenv)
     npc = newframe.pc

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -295,38 +295,50 @@ struct B{T} end
         finally
             break_off(:error)
         end
+    end
 
-        @testset "breakpoints" begin
-            # In source breakpoints
-            function f_bp(x)
-                #=1=#    i = 1
-                #=2=#    @label foo
-                #=3=#    @bp
-                #=4=#    repr("foo")
-                #=5=#    i += 1
-                #=6=#    i > 3 && return x
-                #=7=#    @goto foo
-            end
-            ln = @__LINE__
-            method_start = ln - 9
-            fr = enter_call(f_bp, 2)
-            @test JuliaInterpreter.linenumber(fr) == method_start + 1
-            fr, pc =  JuliaInterpreter.debug_command(fr, :c)
-            # Hit the breakpoint x1
-            @test JuliaInterpreter.linenumber(fr) == method_start + 3
-            @test pc isa BreakpointRef
-            fr, pc =  JuliaInterpreter.debug_command(fr, :n)
-            @test JuliaInterpreter.linenumber(fr) == method_start + 4
-            fr, pc =  JuliaInterpreter.debug_command(fr, :c)
-            # Hit the breakpoint again x2
-            @test pc isa BreakpointRef
-            @test JuliaInterpreter.linenumber(fr) == method_start + 3
-            fr, pc =  JuliaInterpreter.debug_command(fr, :c)
-            # Hit the breakpoint for the last time x3
-            @test pc isa BreakpointRef
-            @test JuliaInterpreter.linenumber(fr) == method_start + 3
-            JuliaInterpreter.debug_command(fr, :c)
-            @test get_return(fr) == 2
+    @testset "breakpoints" begin
+        # In source breakpoints
+        function f_bp(x)
+            #=1=#    i = 1
+            #=2=#    @label foo
+            #=3=#    @bp
+            #=4=#    repr("foo")
+            #=5=#    i += 1
+            #=6=#    i > 3 && return x
+            #=7=#    @goto foo
         end
+        ln = @__LINE__
+        method_start = ln - 9
+        fr = enter_call(f_bp, 2)
+        @test JuliaInterpreter.linenumber(fr) == method_start + 1
+        fr, pc =  JuliaInterpreter.debug_command(fr, :c)
+        # Hit the breakpoint x1
+        @test JuliaInterpreter.linenumber(fr) == method_start + 3
+        @test pc isa BreakpointRef
+        fr, pc =  JuliaInterpreter.debug_command(fr, :n)
+        @test JuliaInterpreter.linenumber(fr) == method_start + 4
+        fr, pc =  JuliaInterpreter.debug_command(fr, :c)
+        # Hit the breakpoint again x2
+        @test pc isa BreakpointRef
+        @test JuliaInterpreter.linenumber(fr) == method_start + 3
+        fr, pc =  JuliaInterpreter.debug_command(fr, :c)
+        # Hit the breakpoint for the last time x3
+        @test pc isa BreakpointRef
+        @test JuliaInterpreter.linenumber(fr) == method_start + 3
+        JuliaInterpreter.debug_command(fr, :c)
+        @test get_return(fr) == 2
+    end
+
+    f_inv(x::Real) = x^2;
+    f_inv(x::Integer) = 1 + invoke(f_inv, Tuple{Real}, x)
+    @testset "invoke" begin
+        fr = JuliaInterpreter.enter_call(f_inv, 2)
+        fr, pc = JuliaInterpreter.debug_command(fr, :s) # apply_type
+        frame, pc = JuliaInterpreter.debug_command(fr, :s) # step into invoke
+        @test frame.framecode.scope.sig == Tuple{typeof(f_inv),Real}
+        JuliaInterpreter.debug_command(frame, :c)
+        frame = root(frame)
+        @test get_return(frame) == f_inv(2)
     end
 # end


### PR DESCRIPTION
With this:

```jl
julia> @enter Dense(10,10)(randn(10,10))
In Dense(x) at C:\Users\Kristoffer\.julia\packages\Flux\WSB7k\src\layers\basic.jl
>81    W, b, σ = a.W, a.b, a.σ
 82    σ.(W*x .+ b)
 83  end
 84  
 85  function Base.show(io::IO, l::Dense)

About to run: (getproperty)(<suppressed 109 bytes of output>, :W)
```

TODO:

- [x] Tests
- [x] Figure out what to do when `prepare_framecode` returns `nothing`.

Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/177