### PR TITLE
RFC: step through kwprep in next_line

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -216,6 +216,7 @@ function next_line!(@nospecialize(recurse), frame::Frame, istoplevel::Bool=false
         end
         shouldbreak(frame, pc) && return BreakpointRef(frame.framecode, pc)
     end
+    maybe_step_through_kwprep!(recurse, frame, istoplevel)
     maybe_next_call!(recurse, frame, istoplevel)
 end
 next_line!(frame::Frame, istoplevel::Bool=false) = next_line!(finish_and_return!, frame, istoplevel)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -402,7 +402,7 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::Symbol, rootis
     end
     try
         cmd == :nc && return nicereturn!(recurse, frame, next_call!(recurse, frame, istoplevel), rootistoplevel)
-        cmd == :n && return nicereturn!(recurse, frame, next_line!(recurse, frame, istoplevel), rootistoplevel)
+        cmd == :n && return maybe_reset_frame!(recurse, frame, next_line!(recurse, frame, istoplevel), rootistoplevel)
         cmd == :se && return maybe_reset_frame!(recurse, frame, step_expr!(recurse, frame, istoplevel), rootistoplevel)
 
         enter_generated = false

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -386,4 +386,16 @@ struct B{T} end
         frame = stepkw!(frame)
         @test frame.pc == JuliaInterpreter.nstatements(frame.framecode) - 1
     end
+
+    function f(x, y)
+        sin(2.0)
+        g(x; y = 3)
+    end
+    g(x; y) = x + y
+    @testset "interaction of :n with kw functions" begin
+        frame = JuliaInterpreter.enter_call(f, 2, 3) # at sin
+        frame, pc = debug_command(frame, :n)
+        # Check that we are at the kw call to g
+        @test Core.kwfunc(g) == JuliaInterpreter.@lookup frame JuliaInterpreter.pc_expr(frame).args[1]
+    end
 # end


### PR DESCRIPTION
Currently, the debug command `:n` interacts a bit badly with the kwprep functionality, for example:

```jl
julia> function f(x, y)
          sin(2.0)
          g(x; y = 3)
       end
f (generic function with 1 method)

julia> g(x; y) = x + y
g (generic function with 1 method)

julia> frame = JuliaInterpreter.enter_call(f, 2, 3)
Frame for f(x, y) in Main at REPL[23]:2
  1* 2  1 ─      (sin)(2.0)
  2  3  │   %2 = (:y,)
  3  3  │   %3 = (Core.apply_type)(NamedTuple, %2)
⋮
x = 2
y = 3

julia> frame, pc = JuliaInterpreter.debug_command(frame, :n)
(Frame for f(x, y) in Main at REPL[23]:2
  1  2  1 ─      (sin)(2.0)
  2  3  │   %2 = (:y,)
  3* 3  │   %3 = (Core.apply_type)(NamedTuple, %2)
  4  3  │   %4 = (tuple)(3)
  5  3  │   %5 = (%3)(%4)
⋮
x = 2
y = 3, 3)

julia> JuliaInterpreter.maybe_step_through_kwprep!(frame) # does nothing
Frame for f(x, y) in Main at REPL[23]:2
  1  2  1 ─      (sin)(2.0)
  2  3  │   %2 = (:y,)
  3* 3  │   %3 = (Core.apply_type)(NamedTuple, %2)
  4  3  │   %4 = (tuple)(3)
  5  3  │   %5 = (%3)(%4)
⋮
x = 2
y = 3
```

The problem here is that `:n` finishes by computing `maybe_next_call!` which is at `pc = 3` which is one step into the kw prep (that starts with the tuple being formed). The pattern matching of kwprep thus fails and we are stuck having to step through the kwprep stuff. And if we call `n` again we miss the call to the actual keyword function. With this change:

```jl
julia> frame = JuliaInterpreter.enter_call(f, 2, 3)
Frame for f(x, y) in Main at REPL[23]:2
  1* 2  1 ─      (sin)(2.0)
  2  3  │   %2 = (:y,)
  3  3  │   %3 = (Core.apply_type)(NamedTuple, %2)
⋮
x = 2
y = 3

julia> frame, pc = JuliaInterpreter.debug_command(frame, :n)
(Frame for f(x, y) in Main at REPL[23]:2
⋮
  5  3  │   %5 = (%3)(%4)
  6  3  │   %6 = (Core.kwfunc)(g)
  7* 3  │   %7 = (%6)(%5, g, x)
  8  3  └──      return %7
x = 2
y = 3, 7)
```

we instead step right to the keyword call.
