### PR TITLE
Compiled frames: a sketch

### DIFF
--- a/src/framecompiler.jl
+++ b/src/framecompiler.jl
@@ -1,0 +1,54 @@
+function instrument_method(m::Method)
+    # Step 1: pick a new name
+    name = Symbol(m.name, "#instrumented")
+    f = Core.eval(m.module, :(function $name end)) # create the function object (with no methods)
+    # Step 2: add an extra argument, `#framedata#`
+    # (For simplicity here I'm cheating by assuming no internal locals and no type parameters.
+    #  In reality, among other things you'll need to renumber the slots)
+    # For help, see https://docs.julialang.org/en/latest/devdocs/ast/#Expr-types-1, section on `method`
+    sigm, src = m.sig, copy_codeinfo(Base.uncompressed_ast(m))
+    sigt = Core.svec(typeof(f), sigm.parameters[2:end]..., FrameData) # first is #self#
+    sigp = Core.svec()
+    sigsv = Core.svec(sigt, sigp)
+    push!(src.slotnames, Symbol("#framedata#"))
+    # Step 3: instrument the body
+    #   - for each store to a slotnumber (SlotNumber on the LHS of :(=)), add a
+    #     "real" assignment to `#framedata#.locals`
+    #   - for each line that is `used`, add a store to `#framedata#.ssavalues`
+    # Both of these will require renumbering the ssavalues. Again, for simplicity I'll just cheat:
+    # change `x + 1` into `x + 2` for my `inc1` example
+    src.code[1].args[end] = 2
+    # Step 4: create the new method
+    ccall(:jl_method_def, Cvoid, (Any, Any, Any), sigsv, src, m.module)
+    # See below about "wrapper methods" that set up `#framedata#` for this method;
+    # you might also create the wrapper here?
+    return f
+end
+
+function typeinf_instrumented(linfo::MethodInstance, params::Core.Compiler.Params)
+    # This modifies the source code to add extra instrumentation
+    # Step 1: call regular inference. Here, a major goal is to perform inlining,
+    # so that we don't have to create so many `framedata`s
+    src = Core.Compiler.typeinf_ext(linfo, params)
+    # Step 2: replace the `:invoke` Exprs in `isrc` with invokes to `#framedata#`-instrumented variants.
+    # You will also have to insert statements to create the framedata for that method.
+    # Presumably, the best approach would be to just :invoke a wrapper method that creates a framedata
+    # for the method we instrumented via `instrument_method`, and then calls the instrumented method.
+    # That wrapper would have the same args as the original function, so it's really just a
+    # case of changing which MethodInstance you call.
+    # But of course you have to create these MethodInstances for the callees, so this will
+    # have to recursively call `instrument_method` followed by `precompile` (which will call
+    # this) on all the callees.
+    return src
+end
+
+function precompile_instrumented(f, atypes)
+    # delightfully insane!
+    # !!Note!!: before executing this, you need to compile `typeinf_instrumented` and anything it calls
+    try
+        ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_instrumented)
+        precompile(f, atypes)
+    finally
+        ccall(:jl_set_typeinf_func, Cvoid, (Any,), Core.Compiler.typeinf_ext)
+    end
+end


### PR DESCRIPTION
This is a skeleton illustrating how I think we should implement compiled frames. Like all untested sketches, this could of course run into serious roadblocks.

The code here is heavily commented, so that may be sufficient. (I should say that I started out intending to test this on a method `inc1(x) = x + 1`, but never quite got that far; that may explain some of the elements of the code.) But let me explain some of the overall strategy here. The idea is that for any method, we create an instrumented variant: in addition to doing its regular duty, every time it computes something, store intermediate results in a `FrameData` that gets passed in as an extra argument. Basically, the idea is that `foo(x, y)` becomes `foo#instrumented!(x, y, #framedata#)`. In the instrumented variant, assignments to slots and "used" ssavalues (in the sense of `framedata.used`, where `framedata` is the framedata for `foo` itself) will need an extra statement inserted that performs the same assignment to the `#framedata#` argument. 

Now, if we were to compile this, we'd probably get a fairly respectable result on that particular method. But what to do about all those calls it makes? If we do nothing, it would be like running the frame in `Compiled()` mode, OK for certain things but very limiting.

Here is where the real fun begins. The idea is to intercept inference, and modify the `invokes` to call instrumented variants of the normal methods. A potentially *huge* win here is that if we do this after running normal inference (including the optimizer), then we get inlining for free. I am anticipating that, with compiled frames, `framedata` allocation will become our single biggest expense; we can presumably avoid most of that by inlining all the "simple stuff."

Of course that means we'll be blind to what goes on inside the inlined methods. Optionally, I suppose we could turn off the optimizer. But I think a better way to handle that would be on the UI side: all we'd need to do is copy the framedata that executes that call, and create a normal (slow) interpreted frame with the same data and then start executing that in normal interpreted mode. This essentially lets us "snip out" the little piece of the computation when we need it, but get the (probably huge) benefit of inlining for 99% of the execution time.

While I barely know anything about Cassette (something I should remedy some day), I suspect that there are similarities between what I'm proposing here and stuff Cassette is presumably already good at. However, were I to take a guess, I'd say the inlining tricks I'm proposing are something that would be difficult to do via Cassette. Here, by running inference on what is close to the normal method body (with genuinely-normal callees) and then modifying it, we should get something that's very close to the "normal" inlining decisions.

Why am I posting this as a sketch, rather than just doing it? The reality is that because I've prioritized getting the debugger out above most of my other duties, in my "real job" I have many fires burning. Worse (here I'm being a pessimist), I suspect that what serious coding time I can muster over the next few weeks will likely be eaten up by solving problems I've inadvertently created by rewriting the Revise stack. So I'm afraid I'm going to be limited in terms of how much "difficult" development I can do here. Of course I'm happy to offer what help I can, but it may be in an advisory capacity for many things. But I thought I'd throw this out there to see if it helps get things going.

This ventures into some scary territory, it might be nice to get feedback from folks who know the compiler far better than I: CC @Keno, @JeffBezanson, @vtjnash.