### PR TITLE
make `show_backtrace` and `display_error` work for Frame

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -141,6 +141,11 @@ Fields:
 - `pc`: the program counter (integer index of the next statment to be evaluated) for this frame
 - `caller`: the parent caller of this frame, or `nothing`
 - `callee`: the frame called by this one, or `nothing`
+
+The `Base` functions `show_backtrace` and `display_error` are overloaded such that
+`show_backtrace(io::IO, frame::Frame)` and `display_error(io::IO, er, frame::Frame)`
+shows a backtrace or error, respectively, in a similar way as to how Base shows
+them.
 """
 mutable struct Frame
     framecode::FrameCode

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -338,3 +338,49 @@ function show_stackloc(io::IO, frame)
     end
 end
 show_stackloc(frame) = show_stackloc(stdout, frame)
+
+# Pretty printing of stacktraces and errors with Frame
+function Base.StackTraces.StackFrame(frame::Frame)
+    if frame.framecode.scope isa Method
+        method = frame.framecode.scope
+        method_args = something.(frame.framedata.locals[1:frame.framecode.scope.nargs])
+        atypes = Tuple{typeof.(method_args)...}
+        sig = frame.framecode.scope.sig
+        (ti, lenv) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), atypes, sig)
+        mi = Core.Compiler.code_for_method(method, atypes, lenv, typemax(UInt))
+    else
+        mi = frame.framecode.src
+    end
+
+    Base.StackFrame(
+        frame.framecode.scope.name,
+        Symbol(JuliaInterpreter.getfile(frame)),
+        JuliaInterpreter.linenumber(frame),
+        mi,
+        false,
+        false,
+        C_NULL
+    )
+end
+
+function Base.show_backtrace(io::IO, frame::Frame)
+    stackframes = Tuple{Base.StackTraces.StackFrame, Int}[]
+    while frame !== nothing
+        push!(stackframes, (Base.StackTraces.StackFrame(frame), 1))
+        frame = JuliaInterpreter.caller(frame)
+    end
+
+    print(io, "\nStacktrace:")
+    try invokelatest(Base.update_stackframes_callback[], stackframes) catch end
+    frame_counter = 0
+    for (last_frame, n) in stackframes
+        frame_counter += 1
+        Base.show_trace_entry(IOContext(io, :backtrace => true), last_frame, n, prefix = string(" [", frame_counter, "] "))
+    end
+end
+
+function Base.display_error(io::IO, er, frame::Frame)
+    printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
+    showerror(IOContext(io, :limit => true), er, frame)
+    println(io)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -347,7 +347,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
         atypes = Tuple{typeof.(method_args)...}
         sig = method.sig
         sparams = Core.svec(frame.framedata.sparams...)
-        mi = Core.Compiler.code_for_method(method, atypes, lenv, typemax(UInt))
+        mi = Core.Compiler.code_for_method(method, atypes, sparams, typemax(UInt))
     else
         mi = frame.framecode.src
     end


### PR DESCRIPTION
When an error is encountered in interpreted code, naively printing the stacktrace will just spew out internals of the interpreter which is not so nice to show a user. Fortunately, it is fairly easy to recreate the data structures that Base uses to print a "native" stacktrace from the leaf `Frame`. For example, with this PR:

```jl
julia> f() = "αβ"[2]
f (generic function with 1 method)

julia> break_on(:error)

julia> frame, bp = @interpret f();

julia> Base.display_error(stdout, bp.err, leaf(frame))
ERROR: StringIndexError("αβ", 2)
Stacktrace:
 [1] string_index_err(::String, ::Int64) at strings/string.jl:12
 [2] getindex_continued(::String, ::Int64, ::UInt32) at strings/string.jl:218
 [3] getindex(::String, ::Int64) at strings/string.jl:211
 [4] f() at REPL[122]:1
```

Compare vs the native printing in error:

```jl
julia> f()
ERROR: StringIndexError("αβ", 2)
Stacktrace:
 [1] string_index_err(::String, ::Int64) at ./strings/string.jl:12
 [2] getindex_continued(::String, ::Int64, ::UInt32) at ./strings/string.jl:218
 [3] getindex at ./strings/string.jl:211 [inlined]
 [4] f() at ./REPL[122]:1
 [5] top-level scope at none:0
```

Since we just use the Base functions for the printing, we get the nice colored printing for free.
A frontend for a debugger can then chose to catch the error and display this stacktrace instead.

Ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/18, https://github.com/JuliaDebug/Debugger.jl/issues/145

TODO:
- [x] Docs.
- [x] Tests.