### PR TITLE
only unlink frames if exception will not be thrown to top level

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -552,16 +552,18 @@ behaviors:
 """
 function handle_err(@nospecialize(recurse), frame, err)
     data = frame.framedata
+    err_will_be_thrown_to_top_level = isempty(data.exception_frames) && !data.caller_will_catch_err
     if break_on_error[]
         # See if the current frame or a frame in the stack will catch this exception,
         # otherwise this exception would have been thrown to the user and we should
         # return a breakpoint
-        if isempty(data.exception_frames) && !data.caller_will_catch_err
+        if err_will_be_thrown_to_top_level
             return BreakpointRef(frame.framecode, frame.pc, err)
         end
     end
     if isempty(data.exception_frames)
-        if frame.caller !== nothing
+        is_root_frame = frame.caller == nothing
+        if !is_root_frame && !err_will_be_thrown_to_top_level
             frame.caller.callee = nothing
             recycle(frame)
         end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -562,7 +562,7 @@ function handle_err(@nospecialize(recurse), frame, err)
         end
     end
     if isempty(data.exception_frames)
-        is_root_frame = frame.caller == nothing
+        is_root_frame = frame.caller === nothing
         if !is_root_frame && !err_will_be_thrown_to_top_level
             frame.caller.callee = nothing
             recycle(frame)

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -427,13 +427,13 @@ struct B{T} end
 
 
     @testset "preservation of stack when throwing to toplevel" begin
+        f() = "αβ"[2]
+        frame1 = JuliaInterpreter.enter_call(f);
+        err = try debug_command(frame1, :c)
+        catch err
+            err
+        end
         try
-            f() = "αβ"[2]
-            frame1 = JuliaInterpreter.enter_call(f);
-            err = try debug_command(frame1, :c)
-            catch err
-                err
-            end
             break_on(:error)
             frame2, pc = @interpret f()
             @test leaf(frame2).framecode.scope === leaf(frame1).framecode.scope


### PR DESCRIPTION
This allows a frontend to inspect the call stack after error by keeping the links between frames in case we would throw to top level and thus do something like:

```jl
julia> f() = "αβ"[2]
f (generic function with 1 method)

julia> frame = JuliaInterpreter.enter_call(f);

julia> err = try debug_command(frame, :c)
       catch err
            err
       end
StringIndexError("αβ", 2)

julia> Base.display_error(stdout, err, leaf(frame))
ERROR: StringIndexError("αβ", 2)
Stacktrace:
 [1] string_index_err(::String, ::Int64) at strings/string.jl:12
 [2] getindex_continued(::String, ::Int64, ::UInt32) at strings/string.jl:218
 [3] getindex(::String, ::Int64) at strings/string.jl:211
 [4] f() at REPL[2]:1
```

This seemed like the easiest implementation and it feels like it should be fine since we are just throwing anyway, so we can kinda do what we want with the frames? There are other possible implementations that would still allow us to do the unlinking but this has the fewest lines of codes changed, so putting this one up first.
