### PR TITLE
fix lookup for SSAValues in foreigncalls and quote the library if it is a symbol

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -116,7 +116,7 @@ function lookup_or_eval(@nospecialize(recurse), frame, @nospecialize(node))
 end
 
 function resolvefc(frame, @nospecialize(expr))
-    if isa(expr, SlotNumber)
+    if isa(expr, SlotNumber) || isa(expr, SSAValue)
         expr = lookup_var(frame, expr)
     end
     (isa(expr, Symbol) || isa(expr, String) || isa(expr, Ptr) || isa(expr, QuoteNode)) && return expr
@@ -151,7 +151,7 @@ Evaluate a `:foreigncall` (from a `ccall`) statement `callexpr` in the context o
 function evaluate_foreigncall(frame::Frame, call_expr::Expr)
     head = call_expr.head
     args = collect_args(frame, call_expr; isfc = head==:foreigncall)
-    for i = 2:length(args)
+    for i = 1:length(args)
         arg = args[i]
         args[i] = isa(arg, Symbol) ? QuoteNode(arg) : arg
     end


### PR DESCRIPTION
Fixes #220 

```

julia> @interpret CSV.read("../SampleCSVFile_11kb.csv")
99×10 DataFrames.DataFrame. Omitted printing of 7 columns
│ Row │ 1      │ Eldon Base for stackable storage shelf, platinum                                   │ Muhammed MacIntyre │
│     │ Int64⍰ │ Union{Missing, String}                                                             │ String⍰            │
├─────┼────────┼────────────────────────────────────────────────────────────────────────────────────┼────────────────────┤
│ 1   │ 2      │ 1.7 Cubic Foot Compact "Cube" Office Refrigerators                                 │ Barry French       │
│ 2   │ 3      │ Cardinal Slant-D\xae Ring Binder, Heavy Gauge Vinyl                                │ Barry French       │
│ 3   │ 4      │ R380                                                                               │ Clay Rozendal      │
│ 4   │ 5      │ Holmes HEPA Air Purifier                                                           │ Carlos Soltero     │
│ 5   │ 6      │ G.E. Longer-Life Indoor Recessed Floodlight Bulbs                                  │ Carlos Soltero     │
│ 6   │ 7      │ Angle-D Binders with Locking Rings, Label Holders                                  │ Carl Jackson       │
│ 7   │ 8      │ SAFCO Mobile Desk Side File, Wire Frame                                            │ Carl Jackson       │
```

Not sure how to test this but I'll figure something out,