### PR TITLE
fix test from builtin check on 1.0

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -444,5 +444,5 @@ finally
 end
 
 # Check #args for builtins (#217)
-f217() =  Core._typevar(:foo, Union{}, Any, "foo")
+f217() = <:(Float64, Float32, Float16)
 @test_throws ArgumentError @interpret(f217())


### PR DESCRIPTION
https://github.com/JuliaDebug/JuliaInterpreter.jl/commit/fc15ae8a861680a4c66916b1c22affa4e18aba23 added a test with a builtin that doesn't exist on 1.0.