### PR TITLE
prevent expensive compilation of map / splatting

### DIFF
--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -140,7 +140,10 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}($fstr(argswrapped...))
         end
         argsflat = Base.append_any((argswrapped[1],), argswrapped[2:end]...)
-        new_expr = Expr(:call, map(x->isa(x, Symbol) || isa(x, Expr) || isa(x, QuoteNode) ? QuoteNode(x) : x, argsflat)...)
+        new_expr = Expr(:call)
+        for x in argsflat
+            push!(new_expr.args, (isa(x, Symbol) || isa(x, Expr) || isa(x, QuoteNode)) ? QuoteNode(x) : x)
+        end
         return new_expr
 """)
             continue


### PR DESCRIPTION
Timings on kc/compiled_calls branch:

Before:

```
julia> @time @interpret plot(rand(5))
  8.959916 seconds (32.77 M allocations: 1.415 GiB, 3.33% gc time)

julia> @time @interpret plot(rand(5))
  7.090033 seconds (24.37 M allocations: 1.010 GiB, 3.47% gc time)

julia> @time @interpret plot(rand(5))
  3.643197 seconds (13.57 M allocations: 485.439 MiB, 2.84% gc time

julia> @time @interpret plot(rand(5))
  3.923732 seconds (13.57 M allocations: 485.295 MiB, 2.67% gc time)
```

After:

```
julia> @time @interpret plot(rand(5))
  5.578359 seconds (21.28 M allocations: 863.471 MiB, 3.34% gc time)

julia> @time @interpret plot(rand(5))
  2.970612 seconds (13.54 M allocations: 481.273 MiB, 2.18% gc time)

julia> @time @interpret plot(rand(5))
  3.482414 seconds (13.45 M allocations: 476.643 MiB, 1.89% gc time)

julia> @time @interpret plot(rand(5))
  3.020646 seconds (13.45 M allocations: 476.534 MiB, 2.20% gc time)
```