### PR TITLE
use non rng seed dependent uuid to avoid collisions

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -6,6 +6,7 @@ using Core: CodeInfo, SSAValue, SlotNumber, TypeMapEntry, SimpleVector, LineInfo
             GeneratedFunctionStub, MethodInstance, NewvarNode, TypeName
 
 using UUIDs
+using Random
 # The following are for circumventing #28, memcpy invalid instruction error,
 # in Base and stdlib
 using Random.DSFMT

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -95,6 +95,8 @@ function lookup_global_refs!(ex::Expr)
     return nothing
 end
 
+const rng = MersenneTwister()
+
 """
     optimize!(code::CodeInfo, mod::Module)
 
@@ -161,7 +163,7 @@ function optimize!(code::CodeInfo, scope)
             # Check for :llvmcall
             arg1 = stmt.args[1]
             if (arg1 == :llvmcall || lookup_stmt(code.code, arg1) == Base.llvmcall) && isempty(sparams) && scope isa Method
-                uuid = uuid1()
+                uuid = uuid1(rng)
                 ustr = replace(string(uuid), '-'=>'_')
                 methname = Symbol("llvmcall_", ustr)
                 nargs = length(stmt.args)-4
@@ -171,7 +173,7 @@ function optimize!(code::CodeInfo, scope)
         elseif isexpr(stmt, :foreigncall) && scope isa Method
             f = lookup_stmt(code.code, stmt.args[1])
             if isa(f, Ptr)
-                f = string(uuid1())
+                f = string(uuid1(rng))
             elseif isexpr(f, :call)
                 length(f.args) == 3 || continue
                 f.args[1] === tuple || continue
@@ -184,7 +186,7 @@ function optimize!(code::CodeInfo, scope)
                 continue
             end
             # TODO: Only compile one ccall per call and argument types
-            uuid = uuid1()
+            uuid = uuid1(rng)
             ustr = replace(string(uuid), '-'=>'_')
             methname = Symbol("ccall", '_', f, '_', ustr)
             nargs = stmt.args[5]

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -161,7 +161,7 @@ function optimize!(code::CodeInfo, scope)
             # Check for :llvmcall
             arg1 = stmt.args[1]
             if (arg1 == :llvmcall || lookup_stmt(code.code, arg1) == Base.llvmcall) && isempty(sparams) && scope isa Method
-                uuid = uuid4()
+                uuid = uuid1()
                 ustr = replace(string(uuid), '-'=>'_')
                 methname = Symbol("llvmcall_", ustr)
                 nargs = length(stmt.args)-4
@@ -171,7 +171,7 @@ function optimize!(code::CodeInfo, scope)
         elseif isexpr(stmt, :foreigncall) && scope isa Method
             f = lookup_stmt(code.code, stmt.args[1])
             if isa(f, Ptr)
-                f = string(uuid4())
+                f = string(uuid1())
             elseif isexpr(f, :call)
                 length(f.args) == 3 || continue
                 f.args[1] === tuple || continue
@@ -184,7 +184,7 @@ function optimize!(code::CodeInfo, scope)
                 continue
             end
             # TODO: Only compile one ccall per call and argument types
-            uuid = uuid4()
+            uuid = uuid1()
             ustr = replace(string(uuid), '-'=>'_')
             methname = Symbol("ccall", '_', f, '_', ustr)
             nargs = stmt.args[5]


### PR DESCRIPTION
See https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/230#issuecomment-477906104

I have not been able to have this situation occur artificially, even by explicitly trying to set the RNG seed.