### PR TITLE
fix ccall with e.g. integer static parameters

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -463,3 +463,7 @@ function call_cf()
     ccall(cf[1], Int, (Int, Int), 1, 2)
 end
 @test (@interpret call_cf()) == call_cf()
+
+# ccall with literal 
+f_N() =  Array{Float64, 4}(undef, 1, 3, 2, 1)
+@test (@interpret f_N()) isa Array{Float64, 4}

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -464,7 +464,7 @@ function call_cf()
 end
 @test (@interpret call_cf()) == call_cf()
 
-# ccall with literal 
+# ccall with integer static parameter
 f_N() =  Array{Float64, 4}(undef, 1, 3, 2, 1)
 @test (@interpret f_N()) isa Array{Float64, 4}
 


### PR DESCRIPTION
Use a `Val` wrapper instead of `Type` since `Val` works for everything. This means we need to do the call extraction after the foreigncall wrapper generation since we introduce a `Val` call. Fixes #233 