### PR TITLE
fix breakpoint on first line of function call

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -10,6 +10,7 @@ In the latter case, `leaf(frame)` returns the frame in which it hit the breakpoi
 by normal dispatch, whereas the default `recurse = finish_and_return!` uses recursive interpretation.
 """
 function finish!(@nospecialize(recurse), frame::Frame, istoplevel::Bool=false)
+    shouldbreak(frame, frame.pc) && return BreakpointRef(frame.framecode, frame.pc)
     while true
         pc = step_expr!(recurse, frame, istoplevel)
         (pc === nothing || isa(pc, BreakpointRef)) && return pc
@@ -26,6 +27,7 @@ Call [`JuliaInterpreter.finish!`](@ref) and pass back the return value `ret`. If
 pauses at a breakpoint, `ret` is the reference to the breakpoint.
 """
 function finish_and_return!(@nospecialize(recurse), frame::Frame, istoplevel::Bool=false)
+    shouldbreak(frame, frame.pc) && return BreakpointRef(frame.framecode, frame.pc)
     pc = finish!(recurse, frame, istoplevel)
     isa(pc, BreakpointRef) && return pc
     return get_return(frame)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -197,6 +197,15 @@ end
     @test bp.stmtidx == 3
 end
 
+@testset "breakpoint on first statement" begin
+    JuliaInterpreter.breakpoint(gcd)
+    frame = JuliaInterpreter.enter_call_expr(Expr(:call, gcd, 2,3))
+    ret = JuliaInterpreter.debug_command(frame, :finish)
+    @test ret !== nothing
+    @test ret[2] isa BreakpointRef
+    JuliaInterpreter.remove()
+end
+
 if tmppath != ""
     rm(tmppath)
 end


### PR DESCRIPTION
This fixes https://github.com/JunoLab/Juno.jl/issues/273 and https://github.com/JuliaDebug/Debugger.jl/issues/134, but I think the `shouldbreak(frame, frame.pc) && return BreakpointRef(frame.framecode, frame.pc)` guard statement should be in more of those functions, maybe.