### PR TITLE
fix for varargs in ccall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,10 @@ CodeTracking = "0.3.2, 0.4, 0.5"
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+
 
 [targets]
-test = ["Test", "Distributed", "Random", "Dates", "SHA"]
+test = ["Test", "Distributed", "Dates", "SHA", "Mmap"]

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -232,6 +232,10 @@ end
 
 function parametric_type_to_expr(t::Type)
     t isa Core.TypeofBottom && return t
+    t isa UnionAll && (t = t.body)
+    if t <: Vararg 
+        return Expr(:(...), t.parameters[1])
+    end
     return t.hasfreetypevars ? Expr(:curly, t.name.name, ((tv-> tv isa TypeVar ? tv.name : tv).(t.parameters))...) : t
 end
 


### PR DESCRIPTION
This happens for https://github.com/JuliaLang/julia/blob/b0427fc1b44adf8069e23e5bbaba194148eda4e5/stdlib/Mmap/src/Mmap.jl#L67  which I noticed when testing some random things on Linux. 