### PR TITLE
bump Project for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
- get rid of O(n^2) behavior in stacklength when enabling `break_on(:error)` (#212)
- make `show_backtrace` and `display_error` work for Frame (#211) 
- check the number of arguments to builtins https://github.com/JuliaDebug/JuliaInterpreter.jl/commit/fc15ae8a861680a4c66916b1c22affa4e18aba23
- frames now keep their callees when the interpreter throws an error (#214)
- fix assertion when breakpoint triggers during wrapper step through (#225)
- also build compiled calls for ccall (#216), (#227), (#231), (#236), (#237), (#240)
- fix a problem for methods with docstrings (#229)
- some general performance improvements (#243), (#245)
