### PR TITLE
Micro-optimizations that reduce dynamic dispatch

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -327,8 +327,8 @@ function do_assignment!(frame, @nospecialize(lhs), @nospecialize(rhs))
         data.ssavalues[lhs.id] = rhs
     elseif isa(lhs, SlotNumber)
         data.locals[lhs.id] = Some{Any}(rhs)
-        data.last_reference[code.src.slotnames[lhs.id]] =
-            lhs.id
+        slotnames = code.src.slotnames::Vector{Any}
+        data.last_reference[slotnames[lhs.id]::Symbol] = lhs.id
     elseif isa(lhs, GlobalRef)
         Core.eval(lhs.mod, :($(lhs.name) = $(QuoteNode(rhs))))
     elseif isa(lhs, Symbol)
@@ -430,7 +430,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                     throw(TypeError(nameof(frame), "if", Bool, node.args[1]))
                 end
                 if !arg
-                    return (frame.pc = node.args[2])
+                    return (frame.pc = node.args[2]::Int)
                 end
             elseif node.head == :enter
                 rhs = node.args[1]

--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -7,11 +7,11 @@ Return the framecode and environment for a call specified by `fargs = [f, args..
 `parentframecode` is the caller, and `idx` is the program-counter index.
 If possible, `framecode` will be looked up from the local method tables of `parentframe`.
 """
-function get_call_framecode(fargs, parentframe::FrameCode, idx::Int; enter_generated::Bool=false)
+function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int; enter_generated::Bool=false)
     nargs = length(fargs)  # includes f as the first "argument"
     # Determine whether we can look up the appropriate framecode in the local method table
     if isassigned(parentframe.methodtables, idx)  # if this is the first call, this may not yet be set
-        tme = tme1 = parentframe.methodtables[idx]
+        tme = tme1 = parentframe.methodtables[idx]::TypeMapEntry
         local tmeprev
         depth = 1
         while true

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -293,7 +293,8 @@ function locals(frame::Frame)
     vars = Variable[]
     data, code = frame.framedata, frame.framecode
     added = Set{Symbol}()
-    for sym in code.src.slotnames
+    slotnames = code.src.slotnames::Vector{Any}
+    for sym in slotnames
         sym ∈ added && continue
         idx = get(data.last_reference, sym, 0)
         idx == 0 && continue


### PR DESCRIPTION
Before:
```julia
julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
 14.597646 seconds (72.11 M allocations: 2.350 GiB, 3.33% gc time)
```
After:
```julia
julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
 11.713349 seconds (69.40 M allocations: 2.286 GiB, 3.02% gc time)
```
This is running on top of https://github.com/JuliaLang/julia/pull/31537.