### PR TITLE
use a Set of compiled modules instead of hardcoding it

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -83,6 +83,7 @@ JuliaInterpreter.BreakpointRef
 JuliaInterpreter.framedict
 JuliaInterpreter.genframedict
 JuliaInterpreter.compiled_methods
+JuliaInterpreter.compiled_modules
 ```
 
 ## Utilities

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -72,6 +72,9 @@ function set_compiled_methods()
     # These are currently extremely slow to interpret (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/193)
     push!(compiled_methods, which(subtypes, Tuple{Module, Type}))
     push!(compiled_methods, which(subtypes, Tuple{Type}))
+
+    push!(compiled_modules, Core.Compiler)
+    push!(compiled_modules, Base.Threads)
 end
 
 function __init__()

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -20,6 +20,12 @@ rather than recursed into via the interpreter.
 """
 const compiled_methods = Set{Method}()
 
+"""
+`mod ∈ compiled_modules` indicates that any method in `mod` should be run using [`Compiled`](@ref)
+rather than recursed into via the interpreter.
+"""
+const compiled_modules = Set{Module}()
+
 const junk = Base.IdSet{FrameData}()      # to allow re-use of allocated memory (this is otherwise a bottleneck)
 recycle(frame) = push!(junk, frame.framedata)  # using an IdSet ensures that a frame can't be added twice
 
@@ -116,7 +122,7 @@ end
 
 function prepare_framecode(method::Method, @nospecialize(argtypes); enter_generated=false)
     sig = method.sig
-    if method.module == Core.Compiler || method.module == Base.Threads || method ∈ compiled_methods
+    if method.module ∈ compiled_modules || method ∈ compiled_methods
         return Compiled()
     end
     # Get static parameters


### PR DESCRIPTION
Makes it easier to experiment with #242.

@vchuravy, should be able to just `delete!` this module now from `compiled_modules` and experiment in the debugger.

We can also push modules that are very time consuming and we dont care about (like `Pkg.TOML`). Care of course has to be taken since any method that ends up dispatching through a compiled module will be "cut off" from the interpreter.