### PR TITLE
go back to using a Vector for recycled frames

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -20,8 +20,13 @@ rather than recursed into via the interpreter.
 """
 const compiled_methods = Set{Method}()
 
-const junk = Base.IdSet{FrameData}()      # to allow re-use of allocated memory (this is otherwise a bottleneck)
-recycle(frame) = push!(junk, frame.framedata)  # using an IdSet ensures that a frame can't be added twice
+const junk = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
+const debug_recycle = Base.RefValue(false)
+@noinline _check_frame_not_in_junk(frame) = @assert frame.framedata ∉ junk
+@inline function recycle(frame)
+    debug_recycle[] && _check_frame_not_in_junk(frame)
+    push!(junk, frame.framedata)
+end
 
 const empty_svec = Core.svec()
 
@@ -239,9 +244,8 @@ function prepare_framedata(framecode, argvals::Vector{Any}, caller_will_catch_er
         ssavt = src.ssavaluetypes
         ng = isa(ssavt, Int) ? ssavt : length(ssavt::Vector{Any})
         nargs, meth_nargs = length(argvals), Int(meth.nargs)
-        if !isempty(junk)
-            olddata = first(junk)
-            delete!(junk, olddata)
+        if length(junk) > 0
+            olddata = pop!(junk)
             locals, ssavalues, sparams = olddata.locals, olddata.ssavalues, olddata.sparams
             exception_frames, last_reference = olddata.exception_frames, olddata.last_reference
             last_exception = olddata.last_exception
@@ -517,6 +521,7 @@ T = Float64
 See [`enter_call`](@ref) for a similar approach not based on expressions.
 """
 function enter_call_expr(expr; enter_generated = false)
+    empty!(junk)
     r = determine_method_for_expr(expr; enter_generated = enter_generated)
     if isa(r, Tuple)
         return prepare_frame(r[1:end-1]...)
@@ -558,6 +563,7 @@ would be created by the generator.
 See [`enter_call_expr`](@ref) for a similar approach based on expressions.
 """
 function enter_call(@nospecialize(finfo), @nospecialize(args...); kwargs...)
+    empty!(junk)
     if isa(finfo, Tuple)
         f = finfo[1]
         enter_generated = finfo[2]::Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ if !isdefined(@__MODULE__, :read_and_parse)
     include("utils.jl")
 end
 
+JuliaInterpreter.debug_recycle[] = true
+
 @testset "Main tests" begin
     include("interpret.jl")
     include("toplevel.jl")


### PR DESCRIPTION
Before

```jl
julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
 12.059313 seconds (63.78 M allocations: 2.143 GiB, 2.58% gc time)

julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
 12.198480 seconds (65.08 M allocations: 2.175 GiB, 2.66% gc time)
```

After

```jl
julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
  9.768135 seconds (65.32 M allocations: 2.052 GiB, 2.97% gc time)

julia> @time (p = @interpret(plot(rand(5))); @interpret(display(p)))
  9.531303 seconds (64.33 M allocations: 2.011 GiB, 3.06% gc time)
```