### PR TITLE
fix exception type for undefined variables

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -10,7 +10,7 @@ lookup_var(frame, ref::GlobalRef) = getfield(ref.mod, ref.name)
 function lookup_var(frame, slot::SlotNumber)
     val = frame.framedata.locals[slot.id]
     val !== nothing && return val.value
-    error("slot ", slot, " with name ", frame.framecode.src.slotnames[slot.id], " not assigned")
+    throw(UndefVarError(frame.framecode.src.slotnames[slot.id]))
 end
 
 function lookup_expr(frame, e::Expr)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -336,7 +336,7 @@ f113(;x) = x
     end
     frame = JuliaInterpreter.enter_call(f_multi, 1)
     nlocals = length(frame.framedata.locals)
-    @test_throws ErrorException("slot _4 with name x not assigned") JuliaInterpreter.lookup_var(frame, Core.SlotNumber(nlocals))
+    @test_throws UndefVarError JuliaInterpreter.lookup_var(frame, Core.SlotNumber(nlocals))
     stack = [frame]
     locals = JuliaInterpreter.locals(frame)
     @test length(locals) == 2
@@ -500,3 +500,7 @@ function f_mmap()
     end
 end
 @interpret f_mmap()
+
+# Test exception type for undefined variables
+f() = s = s + 1
+@test_throws UndefVarError @interpret f()


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/139

Previously we were not returning the correct exception type:

```jl
julia> f(2)
ERROR: UndefVarError: s not defined

julia> @interpret f(2)
ERROR: slot _5 with name s not assigned
```