### PR TITLE
More optimizations and a fix for `is_vararg_type`

### DIFF
--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -22,8 +22,14 @@ function nargs(f, table, id)
         maxarg = typemax(Int)
     end
     # The tfunc tables are wrong for fptoui and fptosi (fixed in https://github.com/JuliaLang/julia/pull/30787)
-    if f == "Base.fptoui" || f == "Base.fptosi"
+    if f == Base.fptoui || f == Base.fptosi
         minarg = 2
+    end
+    # Specialize arrayref and arrayset for small numbers of arguments
+    if f == Core.arrayref
+        maxarg = 5
+    elseif f == Core.arrayset
+        maxarg = 6
     end
     return minarg, maxarg
 end

--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -212,11 +212,11 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 """)
     end
     # Now handle calls with bounded numbers of args
-    fcall = generate_fcall_nargs("f", minmin, maxmax)
     print(io,
 """
     if isa(f, Core.IntrinsicFunction)
-        $fcall
+        cargs = getargs(args, frame)
+        return Some{Any}(ccall(:jl_f_intrinsic_call, Any, (Any, Ptr{Any}, UInt32), f, cargs, length(cargs)))
 """)
     print(io,
 """

--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -139,8 +139,9 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         if !expand
             return Some{Any}($fstr(argswrapped...))
         end
-        argsflat = Base.append_any((argswrapped[1],), argswrapped[2:end]...)
-        new_expr = Expr(:call)
+        new_expr = Expr(:call, argswrapped[1])
+        popfirst!(argswrapped)
+        argsflat = Base.append_any(argswrapped...)
         for x in argsflat
             push!(new_expr.args, (isa(x, Symbol) || isa(x, Expr) || isa(x, QuoteNode)) ? QuoteNode(x) : x)
         end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -135,7 +135,7 @@ function resolvefc(frame, @nospecialize(expr))
     error("unexpected ccall to ", expr)
 end
 
-function collect_args(frame, call_expr; isfc=false)
+function collect_args(frame::Frame, call_expr::Expr; isfc::Bool=false)
     args = frame.framedata.callargs
     resize!(args, length(call_expr.args))
     mod = moduleof(frame)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,7 +148,7 @@ is_leaf(frame::Frame) = frame.callee === nothing
 
 function is_vararg_type(x)
     if isa(x, Type)
-        x <: Vararg && return true
+        (x <: Vararg && !(x <: Union{})) && return true
         if isa(x, UnionAll)
             x = Base.unwrap_unionall(x)
         end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -99,6 +99,7 @@ end
 # issue #6
 @test @interpret(Array.body.body.name) === Array.body.body.name
 @test @interpret(Vararg.body.body.name) === Vararg.body.body.name
+@test !JuliaInterpreter.is_vararg_type(Union{})
 frame = JuliaInterpreter.prepare_thunk(Main, :(Vararg.body.body.name))
 @test JuliaInterpreter.finish_and_return!(frame, true) === Vararg.body.body.name
 frame = JuliaInterpreter.prepare_thunk(Base, :(Union{AbstractChar,Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}}))


### PR DESCRIPTION
These are all low-level optimizations. The cumulative effect is to go from ~18us/iteration in the `summer` benchmark to ~16us/iteration. One of the commits, the `is_vararg_type`, actually leads to a 3% hit on that benchmark, but it fixes what seems to be an outright mistake. (Before 22a8b2c it was not possible to step into any function that received `Union{}` as an argument; the case that I observed was for `promote_result`.)

On the `summer` benchmark, it seems the only remaining case of dynamic dispatch arises from https://github.com/JuliaLang/julia/issues/31565.

While performance improvements are always nice, my real goal in doing this is to prepare the way for a trial of the effect of lowered-code inlining (ref. https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/204#issuecomment-478046381). Since I am hoping it has a dramatic effect, it would be a shame if it were "spoiled" by pre-existing bottlenecks, so I thought I'd start by getting rid of them even though currently they aren't terribly important.

To develop inlining, I think the best approach would be to first take a simple case, like `summer`, and "inline by hand" to see if it provides as much improvement as I hope. If so, then it will be worth building out the more general machinery.
