### PR TITLE
WIP: file:line breakpoints without Revise

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -49,6 +49,9 @@ include("commands.jl")
 include("breakpoints.jl")
 
 function set_compiled_methods()
+    ###########
+    # Methods #
+    ###########
     # Work around #28 by preventing interpretation of all Base methods that have a ccall to memcpy
     push!(compiled_methods, which(vcat, (Vector,)))
     push!(compiled_methods, first(methods(Base._getindex_ra)))
@@ -79,7 +82,11 @@ function set_compiled_methods()
     # These are currently extremely slow to interpret (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/193)
     push!(compiled_methods, which(subtypes, Tuple{Module, Type}))
     push!(compiled_methods, which(subtypes, Tuple{Type}))
+    push!(compiled_methods, which(match, Tuple{Regex, String, Int, UInt32}))
 
+    ###########
+    # Modules #
+    ###########
     push!(compiled_modules, Core.Compiler)
     push!(compiled_modules, Base.Threads)
 end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -26,6 +26,8 @@ rather than recursed into via the interpreter.
 """
 const compiled_modules = Set{Module}()
 
+const framecode_locations = Dict{Symbol, Vector{Pair{UnitRange, FrameCode}}}()
+
 const junk = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
 const debug_recycle = Base.RefValue(false)
 @noinline _check_frame_not_in_junk(frame) = @assert frame.framedata ∉ junk

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -26,7 +26,6 @@ rather than recursed into via the interpreter.
 """
 const compiled_modules = Set{Module}()
 
-const framecode_locations = Dict{Symbol, Vector{Pair{UnitRange, FrameCode}}}()
 
 const junk = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
 const debug_recycle = Base.RefValue(false)

--- a/src/generate_builtins.jl
+++ b/src/generate_builtins.jl
@@ -149,6 +149,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         popfirst!(argswrapped)
         argsflat = Base.append_any(argswrapped...)
         for x in argsflat
+            x isa SSAValue && (x = SSAWrapper(x))
             push!(new_expr.args, (isa(x, Symbol) || isa(x, Expr) || isa(x, QuoteNode)) ? QuoteNode(x) : x)
         end
         return new_expr

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -217,6 +217,20 @@ function codelocation(code::CodeInfo, idx)
     return codeloc
 end
 
+function compute_corrected_linerange(method::Method)
+    _, line1 = whereis(method)
+    offset = line1 - method.line
+    src = JuliaInterpreter.get_source(method)
+    lastline = src.linetable[end]
+    return line1:getline(lastline) + offset
+end
+
+function method_contains_line(method::Method, line::Integer)
+    # Check to see if this method really contains that line. Methods that fill in a default positional argument,
+    # keyword arguments, and @generated sections may not contain the line.
+    return last(compute_corrected_linerange(method)) >= line
+end
+
 """
     stmtidx = statementnumber(frame, line)
 

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -209,6 +209,24 @@ end
     @test bp.stmtidx == 3
 end
 
+mktemp() do path, io
+    print(io, """
+    function somefunc(x, y=0)
+        a = x + y
+        b = z^a
+        return a + b
+    end
+    """)
+    close(io)
+    breakpoint(path, 3)
+    include(path)
+    frame, bp = @interpret somefunc(2, 3)
+    @test JuliaInterpreter.whereis(frame) == (path, 3)
+    breakpoint(path, 2)
+    frame, bp = @interpret somefunc(2, 3)
+    @test JuliaInterpreter.whereis(frame) == (path, 2)
+end
+
 if tmppath != ""
     rm(tmppath)
 end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -505,3 +505,10 @@ end
 # Test exception type for undefined variables
 f() = s = s + 1
 @test_throws UndefVarError @interpret f()
+
+# Handling of SSAValues
+function f()
+    z = [Core.SSAValue(5),]
+    repr(z[1])
+end
+@test @interpret f() == f()


### PR DESCRIPTION
The current breakpoint system for file:line is "eager" in the sense that it wants to insert breakpoints directly into the `FrameCode` when the breakpoint is created. This means that we need to know the full signature of the method at the location at breakpoint insertion time. We currently know that only if the file is tracked by Revise. It can sometimes be a bit unintuitive that you need to load Revise, then load a file with `includet` before you can breakpoint in it.

This PR provides a fallback in the case where we do not find any signatures at a given location. Instead of just erroring, we create something called an `UnresolvedBreakpoint` which we, at `FrameCode` creation time look through a list of to see if it is inside our method body. In that case we add the breakpoint.
We also need to handle the case where a breakpoint is inserted when the `FrameCode` is already cached. We do that by, at `FrameCode` creation, store a lookup from a file and line range to a `FrameCode` and upon breakpoint insertion, first look through this lookup and see if we have a matching `FrameCode`.

For example, a possible use case is:

```jl
julia> breakpoint("../foo.jl", 3)

julia> include("../foo.jl")
foo (generic function with 1 method)

julia> @interpret foo(2)
hello
(Frame for foo(x) in Main at C:\Users\Kristoffer\Debugging\foo.jl:2
  1 2  1 ─     (println)("hello")
b 2 3  │       (sin)(2.0)
  3 4  └──     return 5
x = 2, breakpoint(foo(x) in Main at C:\Users\Kristoffer\Debugging\foo.jl:2, line 3))

julia> breakpoint("../foo.jl", 2)

julia> @interpret foo(2)
(Frame for foo(x) in Main at C:\Users\Kristoffer\Debugging\foo.jl:2
b 1 2  1 ─     (println)("hello")
b 2 3  │       (sin)(2.0)
  3 4  └──     return 5
x = 2, breakpoint(foo(x) in Main at C:\Users\Kristoffer\Debugging\foo.jl:2, line 2))
```

TODO:
   - [ ] Make it "Revise safe". Might need your help here @timholy 
   - [ ] Add tests for Base methods since their paths are a bit different
   - [ ] Expose unresolved breakpoints to the API somehow