### PR TITLE
RFC: refactor breakpoints

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -63,6 +63,7 @@ breakpoint
 enable
 disable
 remove
+toggle
 break_on
 break_off
 JuliaInterpreter.dummy_breakpoint

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -66,6 +66,7 @@ remove
 toggle
 break_on
 break_off
+breakpoints
 JuliaInterpreter.dummy_breakpoint
 ```
 
@@ -78,6 +79,9 @@ JuliaInterpreter.FrameData
 JuliaInterpreter.FrameInstance
 JuliaInterpreter.BreakpointState
 JuliaInterpreter.BreakpointRef
+JuliaInterpreter.AbstractBreakpoint
+JuliaInterpreter.BreakpointSignature
+JuliaInterpreter.BreakpointFileLocation
 ```
 
 ## Internal storage

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,8 +38,7 @@ Let's set a conditional breakpoint, to be triggered any time one of the elements
 argument to `sum` is bigger than 4:
 
 ```jldoctest demo1; filter = r"in Base at .*$"
-julia> @breakpoint sum([1, 2]) any(x->x>4, a)
-breakpoint(sum(a::AbstractArray) in Base at reducedim.jl:648, line 648)
+julia> bp = @breakpoint sum([1, 2]) any(x->x>4, a);
 ```
 
 Note that in writing the condition, we used `a`, the name of the argument to the relevant
@@ -53,7 +52,7 @@ Now let's see what happens:
 julia> @interpret sum([1,2,3])  # no element bigger than 4, breakpoint should not trigger
 6
 
-julia> frame, bp = @interpret sum([1,2,5])  # should trigger breakpoint
+julia> frame, bpref = @interpret sum([1,2,5])  # should trigger breakpoint
 (Frame for sum(a::AbstractArray) in Base at reducedim.jl:648
 c 1* 648  1 ─      nothing
   2  648  │   %2 = (Base.#sum#550)(Colon(), #self#, a)
@@ -63,18 +62,16 @@ a = [1, 2, 5], breakpoint(sum(a::AbstractArray) in Base at reducedim.jl:648, lin
 
 `frame` is described in more detail on the next page; for now, suffice it to say
 that the `c` in the leftmost column indicates the presence of a conditional breakpoint
-upon entry to `sum`. `bp` is a reference to the breakpoint. You can manipulate these
-at the command line:
+upon entry to `sum`. `bpref` is a reference to the breakpoint of type [`BreakpointRef`](@ref).
+The breakpoint `bp` we created can be manipulated at the command line
 
 ```jldoctest demo1; filter = r"in Base at .*$"
 julia> disable(bp)
-false
 
 julia> @interpret sum([1,2,5])
 8
 
 julia> enable(bp)
-true
 
 julia> @interpret sum([1,2,5])
 (Frame for sum(a::AbstractArray) in Base at reducedim.jl:648

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ julia> @interpret sum(list)
 
 You can interrupt execution by setting breakpoints.
 You can set breakpoints via packages that explicitly target debugging,
-like [Juno](http://junolab.org/), [Debugger](https://github.com/JuliaDebug/Debugger.jl), and
+like [Juno](https://junolab.org/), [Debugger](https://github.com/JuliaDebug/Debugger.jl), and
 [Rebugger](https://github.com/timholy/Rebugger.jl).
 But all of these just leverage the core functionality defined in JuliaInterpreter,
 so here we'll illustrate it without using any of these other packages.

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -14,7 +14,7 @@ using InteractiveUtils
 using CodeTracking
 
 export @interpret, Compiled, Frame, root, leaf,
-       BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove,
+       BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove, toggle,
        debug_command, @bp, break_on, break_off
 
 module CompiledCalls
@@ -39,6 +39,9 @@ include("commands.jl")
 include("breakpoints.jl")
 
 function set_compiled_methods()
+    ###########
+    # Methods #
+    ###########
     # Work around #28 by preventing interpretation of all Base methods that have a ccall to memcpy
     push!(compiled_methods, which(vcat, (Vector,)))
     push!(compiled_methods, first(methods(Base._getindex_ra)))
@@ -69,6 +72,7 @@ function set_compiled_methods()
     # These are currently extremely slow to interpret (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/193)
     push!(compiled_methods, which(subtypes, Tuple{Module, Type}))
     push!(compiled_methods, which(subtypes, Tuple{Type}))
+    push!(compiled_methods, which(match, Tuple{Regex, String, Int, UInt32}))
 
     # Anything that ccalls jl_typeinf_begin cannot currently be handled
     for finf in (Core.Compiler.typeinf_code, Core.Compiler.typeinf_ext, Core.Compiler.typeinf_type)
@@ -77,6 +81,9 @@ function set_compiled_methods()
         end
     end
 
+    ###########
+    # Modules #
+    ###########
     push!(compiled_modules, Base.Threads)
 end
 

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -1,4 +1,10 @@
 const _breakpoints = AbstractBreakpoint[]
+
+"""
+    breakpoints()::Vector{AbstractBreakpoint}
+
+Return an array with all breakpoints.
+"""
 breakpoints() = _breakpoints
 
 function add_to_existing_framecodes(bp::AbstractBreakpoint)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -58,7 +58,7 @@ end
 breakpoint(radius2, Tuple{Int,Int}, :(y > x))
 ```
 """
-function breakpoint(f, sig=nothing, line::Integer=0, condition::Condition=nothing)
+function breakpoint(f::Union{Method, Function}, sig=nothing, line::Integer=0, condition::Condition=nothing)
     sig !== nothing && (sig = Base.to_tuple_type(sig))
     bp = BreakpointSignature(f, sig, line, condition, Ref(true), BreakpointRef[])
     add_to_existing_framecodes(bp)
@@ -66,9 +66,9 @@ function breakpoint(f, sig=nothing, line::Integer=0, condition::Condition=nothin
     idx === nothing ? push!(_breakpoints, bp) : (_breakpoints[idx] = bp)
     return bp
 end
-breakpoint(f, sig, condition::Condition) = breakpoint(f, sig, 0, condition)
-breakpoint(f, line::Integer, condition::Condition=nothing) = breakpoint(f, nothing, line, condition)
-breakpoint(f, condition::Condition) = breakpoint(f, nothing, 0, condition)
+breakpoint(f::Union{Method, Function}, sig, condition::Condition) = breakpoint(f, sig, 0, condition)
+breakpoint(f::Union{Method, Function}, line::Integer, condition::Condition=nothing) = breakpoint(f, nothing, line, condition)
+breakpoint(f::Union{Method, Function}, condition::Condition) = breakpoint(f, nothing, 0, condition)
 
 
 """

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -29,7 +29,7 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
         if ft <: Function && isa(ft, DataType) && isdefined(ft, :instance)
             return ft.instance
         elseif isa(ft, DataType) && ft.name === Type.body.name
-            f = ft.parameters[1]
+            return ft.parameters[1]
         else
             return ft
         end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -11,7 +11,7 @@ function add_breakpoint_if_match!(framecode::FrameCode, bp::AbstractBreakpoint)
     if framecode_matches_breakpoint(framecode, bp)
         stmtidx = bp.line === 0 ? 1 : statementnumber(framecode, bp.line)
         breakpoint!(framecode, stmtidx, bp.condition, bp.enabled[])
-        push!(bp.applications, BreakpointRef(framecode, stmtidx))
+        push!(bp.instances, BreakpointRef(framecode, stmtidx))
     end
 end
 
@@ -152,7 +152,7 @@ end
 breakpoint!(frame::Frame, pc=frame.pc, condition::Condition=nothing) =
     breakpoint!(frame.framecode, pc, condition)
 
-update_states!(bp::AbstractBreakpoint) = foreach(bpref -> update_state!(bpref, bp.enabled[]), bp.applications)
+update_states!(bp::AbstractBreakpoint) = foreach(bpref -> update_state!(bpref, bp.enabled[]), bp.instances)
 update_state!(bp::BreakpointRef, v::Bool) = bp[] = v
 
 """
@@ -180,7 +180,7 @@ Remove (delete) breakpoint `bp`. Removed breakpoints cannot be re-enabled.
 function remove(bp::AbstractBreakpoint)
     idx = findfirst(isequal(bp), _breakpoints)
     idx === nothing || deleteat!(_breakpoints, idx)
-    foreach(remove, bp.applications)
+    foreach(remove, bp.instances)
 end
 function remove(bp::BreakpointRef)
     bp.framecode.breakpoints[bp.stmtidx] = BreakpointState(false, falsecondition)
@@ -219,7 +219,7 @@ Remove all breakpoints.
 """
 function remove()
     for bp in _breakpoints
-        foreach(remove, bp.applications)
+        foreach(remove, bp.instances)
     end
     empty!(_breakpoints)
 end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -1,5 +1,5 @@
 const _breakpoints = AbstractBreakpoint[]
-breakpoints() = copy(_breakpoints)
+breakpoints() = _breakpoints
 
 function add_to_existing_framecodes(bp::AbstractBreakpoint)
     for framecode in values(framedict)
@@ -79,7 +79,7 @@ For example, `file = foo.jl` will match against all files with the name `foo.jl`
 `file = src/foo.jl` will match against all paths containing `src/foo.jl`, e.g. both `Foo/src/foo.jl` and `Bar/src/foo.jl`.
 Absolute paths only matches against the file with that exact absolute path.
 """
-function breakpoint(file::String, line::Integer, condition::Condition=nothing)
+function breakpoint(file::AbstractString, line::Integer, condition::Condition=nothing)
     file = normpath(file)
     bp = BreakpointFileLocation(file, CodeTracking.maybe_fix_path(abspath(file)), line, condition, Ref(true), BreakpointRef[])
     add_to_existing_framecodes(bp)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -26,6 +26,7 @@ rather than recursed into via the interpreter.
 """
 const compiled_modules = Set{Module}()
 
+
 const junk = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
 const debug_recycle = Base.RefValue(false)
 @noinline _check_frame_not_in_junk(frame) = @assert frame.framedata ∉ junk

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -38,6 +38,9 @@ function clear_caches()
     empty!(junk)
     empty!(framedict)
     empty!(genframedict)
+    for bp in breakpoints()
+        empty!(bp.instances)
+    end
 end
 
 const empty_svec = Core.svec()

--- a/src/types.jl
+++ b/src/types.jl
@@ -314,6 +314,11 @@ function Base.show(io::IO, bp::BreakpointSignature)
 end
 
 struct BreakpointFileLocation <: AbstractBreakpoint
+    # Both the input path and the absolute path is stored to handle the case
+    # where a user sets a breakpoint on a relative path e.g. `../foo.jl`. The absolute path is needed
+    # to handle the case where the current working directory change, and
+    # the input path is needed to do "partial path matches", e.g match "src/foo.jl" against
+    # "Package/src/foo.jl".
     path::String
     abspath::String
     line::Int

--- a/src/types.jl
+++ b/src/types.jl
@@ -339,7 +339,7 @@ function Base.show(io::IO, bp::BreakpointSignature)
         print(io, '(', join("::" .* string.(bp.sig.types), ", "), ')')
     end
     if bp.line !== 0
-        print(io, bp.line)
+        print(io, ":", bp.line)
     end
     print_bp_condition(io, bp.condition)
     if !bp.enabled[]

--- a/src/types.jl
+++ b/src/types.jl
@@ -292,7 +292,7 @@ struct BreakpointSignature <: AbstractBreakpoint
     line::Int # 0 is a sentinel for first statement
     condition::Condition
     enabled::Ref{Bool}
-    applications::Vector{BreakpointRef}
+    instances::Vector{BreakpointRef}
 end
 same_location(bp2::BreakpointSignature, bp::BreakpointSignature) = 
     bp2.f == bp.f && bp2.sig == bp.sig && bp2.line == bp.line
@@ -319,7 +319,7 @@ struct BreakpointFileLocation <: AbstractBreakpoint
     line::Integer
     condition::Condition
     enabled::Ref{Bool}
-    applications::Vector{BreakpointRef}
+    instances::Vector{BreakpointRef}
 end
 same_location(bp2::BreakpointFileLocation, bp::BreakpointFileLocation) = 
     bp2.path == bp.path && bp2.abspath == bp.abspath && bp2.line == bp.line

--- a/src/types.jl
+++ b/src/types.jl
@@ -316,7 +316,7 @@ end
 struct BreakpointFileLocation <: AbstractBreakpoint
     path::String
     abspath::String
-    line::Integer
+    line::Int
     condition::Condition
     enabled::Ref{Bool}
     instances::Vector{BreakpointRef}

--- a/src/types.jl
+++ b/src/types.jl
@@ -287,7 +287,7 @@ abstract type AbstractBreakpoint end
 same_location(::AbstractBreakpoint, ::AbstractBreakpoint) = false
 
 struct BreakpointSignature <: AbstractBreakpoint
-    f # Method or function
+    f::Union{Method, Function}
     sig::Union{Nothing, Type}
     line::Int # 0 is a sentinel for first statement
     condition::Condition

--- a/src/types.jl
+++ b/src/types.jl
@@ -305,7 +305,7 @@ function print_bp_condition(io::IO, cond::Condition)
     if cond !== nothing
         if isa(cond, Tuple{Module, Expr}) && (expr = expr[2])
             cond = (cond[1], Base.remove_linenums!(copy(cond[2])))
-        elseif isa(expr, Expr)
+        elseif isa(cond, Expr)
             cond = Base.remove_linenums!(copy(cond))
         end
         print(io, " ", cond)

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,11 +58,11 @@ end
 One `FrameCode` can be shared by many calling `Frame`s.
 
 Important fields:
-- `scope`: the `Method` or `Module` in which this frame is to be evaluated
-- `src`: the `CodeInfo` object storing (optimized) lowered source code
+- `scope`: the `Method` or `Module` in which this frame is to be evaluated.
+- `src`: the `CodeInfo` object storing (optimized) lowered source code.
 - `methodtables`: a vector, each entry potentially stores a "local method table" for the corresponding
   `:call` expression in `src` (undefined entries correspond to statements that do not
-  contain `:call` expressions)
+  contain `:call` expressions).
 - `used`: a `BitSet` storing the list of SSAValues that get referenced by later statements.
 """
 struct FrameCode
@@ -115,8 +115,8 @@ Base.show(io::IO, framecode::FrameCode) = print_framecode(io, framecode)
 `FrameInstance` represents a method specialized for particular argument types.
 
 Fields:
-- `framecode`: the [`FrameCode`](@ref) for the method
-- `sparam_vals`: the static parameter values for the method
+- `framecode`: the [`FrameCode`](@ref) for the method.
+- `sparam_vals`: the static parameter values for the method.
 """
 struct FrameInstance
     framecode::FrameCode
@@ -137,7 +137,7 @@ Important fields:
   to extract the current value of local variables.
 - `ssavalues`: a vector containing the
   [Static Single Assignment](https://en.wikipedia.org/wiki/Static_single_assignment_form)
-  values produced at the current state of execution
+  values produced at the current state of execution.
 - `sparams`: the static type parameters, e.g., for `f(x::Vector{T}) where T` this would store
   the value of `T` given the particular input `x`.
 - `exception_frames`: a list of indexes to `catch` blocks for handling exceptions within
@@ -161,11 +161,11 @@ end
 """
 `Frame` represents the current execution state in a particular call frame.
 Fields:
-- `framecode`: the [`FrameCode`] for this frame
-- `framedata`: the [`FrameData`] for this frame
-- `pc`: the program counter (integer index of the next statment to be evaluated) for this frame
-- `caller`: the parent caller of this frame, or `nothing`
-- `callee`: the frame called by this one, or `nothing`
+- `framecode`: the [`FrameCode`] for this frame.
+- `framedata`: the [`FrameData`] for this frame.
+- `pc`: the program counter (integer index of the next statment to be evaluated) for this frame.
+- `caller`: the parent caller of this frame, or `nothing`.
+- `callee`: the frame called by this one, or `nothing`.
 
 The `Base` functions `show_backtrace` and `display_error` are overloaded such that
 `show_backtrace(io::IO, frame::Frame)` and `display_error(io::IO, er, frame::Frame)`
@@ -229,9 +229,9 @@ By calling the function `locals`[@ref] on a `Frame`[@ref] a
 `Vector` of `Variable`'s is returned.
 
 Important fields:
-- `value::Any`: the value of the local variable
-- `name::Symbol`: the name of the variable as given in the source code
-- `isparam::Bool`: if the variable is a type parameter, for example `T` in `f(x::T) where {T} = x` .
+- `value::Any`: the value of the local variable.
+- `name::Symbol`: the name of the variable as given in the source code.
+- `isparam::Bool`: if the variable is a type parameter, for example `T` in `f(x::T) where {T} = x`.
 """
 struct Variable
     value::Any
@@ -289,11 +289,11 @@ exist.
 
 Common fields shared by the concrete breakpoints:
 
-- `condition::Union{Nothing,Expr,Tuple{Module,Expr}}`: the condition when the breakpoint applies
-`nothing` means unconditionally, otherwise when the `Expr` (optionally in `Module`)
-- `enabled::Ref{Bool}`: If the breakpoint is enabled (should not be directly modified, use `[enable]`(@ref) or `[disable]`(@ref))
-- `instances::Vector{BreakpointRef}`: All the [`BreakpointRef`](@ref) that the breakpoint has applied to
-- `line::Int` The line of the breakpoint (equal to 0 if unset)
+- `condition::Union{Nothing,Expr,Tuple{Module,Expr}}`: the condition when the breakpoint applies .
+  `nothing` means unconditionally, otherwise when the `Expr` (optionally in `Module`).
+- `enabled::Ref{Bool}`: If the breakpoint is enabled (should not be directly modified, use [`enable()`](@ref) or [`disable()`](@ref)).
+- `instances::Vector{BreakpointRef}`: All the [`BreakpointRef`](@ref) that the breakpoint has applied to.
+- `line::Int` The line of the breakpoint (equal to 0 if unset).
 
 See [`BreakpointSignature`](@ref) and [`BreakpointFileLocation`](@ref) for additional fields in the concrete types.
 """
@@ -319,7 +319,7 @@ Fields:
 
 - `f::Union{Method, Function}`: A method or function that the breakpoint should apply to.
 - `sig::Union{Nothing, Type}`: if `f` is a `Method`, always equal to `nothing`. Otherwise, contains the method signature
-as a tuple type for what methods the breakpoint should apply to.
+   as a tuple type for what methods the breakpoint should apply to.
 
 For common fields shared by all breakpoints, see [`AbstractBreakpoint`](@ref).
 """
@@ -351,9 +351,8 @@ end
 A `BreakpointFileLocation` is a breakpoint that is set on a line in a file.
 
 Fields:
-
-- `path::String`: The literal string that was used to create the breakpoint, e.g. `"path/file.jl"`
-- `abspath`::String: The absolute path to the file when the breakpoint was created, e.g. `"/Users/Someone/path/file.jl"`
+- `path::String`: The literal string that was used to create the breakpoint, e.g. `"path/file.jl"`.
+- `abspath`::String: The absolute path to the file when the breakpoint was created, e.g. `"/Users/Someone/path/file.jl"`.
 
 For common fields shared by all breakpoints, see [`AbstractBreakpoint`](@ref).
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -233,6 +233,20 @@ function codelocation(code::CodeInfo, idx)
     return codeloc
 end
 
+function compute_corrected_linerange(method::Method)
+    _, line1 = whereis(method)
+    offset = line1 - method.line
+    src = JuliaInterpreter.get_source(method)
+    lastline = src.linetable[end]
+    return line1:getline(lastline) + offset
+end
+
+function method_contains_line(method::Method, line::Integer)
+    # Check to see if this method really contains that line. Methods that fill in a default positional argument,
+    # keyword arguments, and @generated sections may not contain the line.
+    return line in compute_corrected_linerange(method)
+end
+
 """
     stmtidx = statementnumber(frame, line)
 

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -202,7 +202,7 @@ struct Squarer end
     @breakpoint Int(5.0)
     frame, bp = @interpret g()
     @test bp isa BreakpointRef
-    @test leaf(frame).framecode.scope === @which Int(5.0) 
+    @test leaf(frame).framecode.scope === @which Int(5.0)
 
     # Breakpoint on call overloads
     (::Squarer)(x) = x^2

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -225,10 +225,29 @@ mktemp() do path, io
     breakpoint(path, 3)
     include(path)
     frame, bp = @interpret somefunc(2, 3)
+    @test bp isa BreakpointRef
     @test JuliaInterpreter.whereis(frame) == (path, 3)
     breakpoint(path, 2)
     frame, bp = @interpret somefunc(2, 3)
+    @test bp isa BreakpointRef
     @test JuliaInterpreter.whereis(frame) == (path, 2)
+    remove()
+    # Test relative paths
+    mktempdir(dirname(path)) do tmp
+        cd(tmp) do
+            breakpoint(joinpath("..", basename(path)), 3)
+            frame, bp = @interpret somefunc(2, 3)
+            @test bp isa BreakpointRef
+            @test JuliaInterpreter.whereis(frame) == (path, 3)
+            remove()
+            breakpoint(joinpath("..", basename(path)), 3)
+            cd(homedir()) do
+                frame, bp = @interpret somefunc(2, 3)
+                @test bp isa BreakpointRef
+                @test JuliaInterpreter.whereis(frame) == (path, 3)
+            end
+        end
+    end
 end
 
 if tmppath != ""

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -523,3 +523,10 @@ function f()
     repr(z[1])
 end
 @test @interpret f() == f()
+
+# Test JuliaInterpreter version of #265
+f(x) = x
+g(x) = f(x)
+@test (@interpret g(5)) == g(5)
+f(x) = x*x
+@test (@interpret g(5)) == g(5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,5 +14,6 @@ JuliaInterpreter.debug_recycle[] = true
     include("toplevel.jl")
     include("limits.jl")
     include("breakpoints.jl")
+    remove()
     include("debug.jl")
 end


### PR DESCRIPTION
The current breakpoint system immediately "lowers" the high level breakpoints given by a user (a high level breakpoint is for example a breakpoint for a method, or for a file:line) into a set of "lower level breakpoints" (given by a statement index into a FrameCode). This has a major drawback:

- After breakpoint insertion we do not know why a breakpoint was set in a FrameCode. Was it because it was a file:line breakpoint or because it was set on a method or a function etc?
    - This makes it hard for a UI to show the active breakpoints. If a user sets a breakpoint on `convert` you don't want to show 60 breakpoints. From a users p.o.v, they added one breakpoint. That breakpoint can apply to multiple places, but it is still one. A user likely want to toggle / remove all the places where this breakpoint applies collectively.
    - We cannot insert breakpoint in new `FrameCode`s that are being created. That means we lose breakpoints if Revise decide to reevaluate a method because e.g. you fixed your bug and changed a `+` to a `-`. It means you can't set a breakpoint on `foo` and define a new `foo` and have the breakpoint apply.
    - For file:line breakpoints, we need to know at insertion time what signature exists at that point. This can be difficult and currently needs Revise

This PR introduces two "high level breakpoint" structs called `BreakpointSignature` (for breakpoints on methods, signatures etc) and `BreakpointFileLocation` for breakpoints on file locations. Each `breakpoint` invocation will add *one* of these to a list of breakpoints `_breakpoints`. Upon adding a breakpoint, we look through all `FrameCode` we have created so far and insert the breakpoint if it matches. Upon creation of `FrameCode`'s we insert the breakpoint if it matches. Each breakpoint struct has a field `applications::Vector{BreakpointRef}` which is added to as soon as we add a breakpoint to a `FrameCode`. This allows toggling, removal etc by just looping through this list.

This PR should be fairly non-breaking (doesn't break Debugger, but likely breaks Juno).

This PR enables the file:line breakpoints unconditionally (aka even if Revise is not loaded).