### PR TITLE
JuliaInterpreter v0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
- Fix for change in CodeInfo.slotnames type on julia master (#251)
- Add a way to break on throw (#253)
- Exclude Union{} from is_vararg_type (#254)
- Various performance improvements (#254)

(Release motivated by the initial test failure in https://github.com/timholy/Revise.jl/pull/265)