### PR TITLE
add `until_line!` to step to next line lower down in source code

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -46,6 +46,7 @@ JuliaInterpreter.maybe_evaluate_builtin
 JuliaInterpreter.next_call!
 JuliaInterpreter.maybe_next_call!
 JuliaInterpreter.next_line!
+JuliaInterpreter.until_line!
 JuliaInterpreter.maybe_reset_frame!
 JuliaInterpreter.maybe_step_through_wrapper!
 JuliaInterpreter.maybe_step_through_kwprep!


### PR DESCRIPTION
This is like `next_line!` except it guarantees you to move to something "later" in the source code. For example:

```jl
julia> function f(x)
           s = 0
           for i in 1:length(x)
               s = s + 1
           end
           print(s)
           return s
       end
f (generic function with 2 methods)

julia> frame = JuliaInterpreter.enter_call(f, rand(100))
Frame for f(x) in Main at REPL[23]:2
   1* 2  1 ─       s = 0
   2  3  │   %2  = (length)(x)
   3  3  │   %3  = (Colon())(1, %2)
⋮
x = [0.770521, 0.714896, 0.271307, 0.498012, 0.623033, 0.17695, 0.594108, 0.0127458, 0.287482, 0.396186  …  0.632738, 0.0830569, 0.586225, 0.287229, 0.0564309, 0.489518, 0.660743, 0.0207911, 0.908642, 0.925855]

julia>  JuliaInterpreter.until!(frame); frame
Frame for f(x) in Main at REPL[3]:2
   1  2  1 ─       s = 0
   2* 3  │   %2  = (length)(x)
   3  3  │   %3  = (Colon())(1, %2)
   4  3  │         #temp# = (iterate)(%3)
⋮
x = [0.953892, 0.828438, 0.327365, 0.47125, 0.266897, 0.727434, 0.89857, 0.152085, 0.269296, 0.485211  …  0.270606, 0.790149, 0.309138, 0.127694, 0.0475989, 0.674949, 0.762637, 0.769296, 0.407537, 0.476802]
s = 0

julia> JuliaInterpreter.until!(JuliaInterpreter.finish_and_return!, frame); frame
linenumber(frame, pc) <= line = true
Frame for f(x) in Main at REPL[23]:2
⋮
   9  3  │         i = (getfield)(%8, 1)
  10  3  │   %10 = (getfield)(%8, 2)
  11* 4  │         s = (+)(s, 1)
  12  4  │         #temp# = (iterate)(%3, %10)
  13  4  │   %13 = (===)(#temp#, nothing)
⋮
x = [0.770521, 0.714896, 0.271307, 0.498012, 0.623033, 0.17695, 0.594108, 0.0127458, 0.287482, 0.396186  …  0.632738, 0.0830569, 0.586225, 0.287229, 0.0564309, 0.489518, 0.660743, 0.0207911, 0.908642, 0.925855]
s = 0
#temp# = (1, 1)
i = 1

julia>  JuliaInterpreter.until!(frame); frame
Frame for f(x) in Main at REPL[3]:2
⋮
  15  4  └──       goto #4 if not %14
  16  4  3 ─       goto #2
  17* 6  4 ┄       (print)(s)
  18  7  └──       return s
x = [0.953892, 0.828438, 0.327365, 0.47125, 0.266897, 0.727434, 0.89857, 0.152085, 0.269296, 0.485211  …  0.270606, 0.790149, 0.309138, 0.127694, 0.0475989, 0.674949, 0.762637, 0.769296, 0.407537, 0.476802]
s = 100
#temp# = nothing
i = 100

```

Should hook this up to `debug_command` and add tests etc but wanted to float the idea first.

Ref https://github.com/JuliaDebug/Debugger.jl/issues/138

Fixes  https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/175