### PR TITLE
generalize next_until! to take a frame and add maybe_next_until!

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -38,13 +38,14 @@ JuliaInterpreter.finish_and_return!
 JuliaInterpreter.finish_stack!
 JuliaInterpreter.get_return
 JuliaInterpreter.next_until!
+JuliaInterpreter.maybe_next_until!
 JuliaInterpreter.through_methoddef_or_done!
 JuliaInterpreter.evaluate_call!
 JuliaInterpreter.evaluate_foreigncall
 JuliaInterpreter.maybe_evaluate_builtin
+JuliaInterpreter.next_call!
 JuliaInterpreter.maybe_next_call!
 JuliaInterpreter.next_line!
-JuliaInterpreter.next_call!
 JuliaInterpreter.maybe_reset_frame!
 JuliaInterpreter.maybe_step_through_wrapper!
 JuliaInterpreter.maybe_step_through_kwprep!

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -86,7 +86,7 @@ finish_stack!(frame::Frame, istoplevel::Bool=false) = finish_stack!(finish_and_r
     pc = next_until!(predicate, frame, istoplevel=false)
 
 Execute the current statement. Then step through statements of `frame` until the next
-statement satifies `predicate(frame)`. `pc` will be the index of the statement at which
+statement satisfies `predicate(frame)`. `pc` will be the index of the statement at which
 evaluation terminates, `nothing` (if the frame reached a `return`), or a `BreakpointRef`.
 """
 function next_until!(@nospecialize(predicate), @nospecialize(recurse), frame::Frame, istoplevel::Bool=false)


### PR DESCRIPTION
This is breaking since it is changing the argument type of the `predicate`.

The `maybe_next_until!` was added because it felt weird to have a `maybe` version of the less general `next_call!` but not one for `next_until!`.