### PR TITLE
fix next_until! not properly returning breakpoint refs

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -92,9 +92,8 @@ evaluation terminates, `nothing` (if the frame reached a `return`), or a `Breakp
 function next_until!(@nospecialize(predicate), @nospecialize(recurse), frame::Frame, istoplevel::Bool=false)
     pc = step_expr!(recurse, frame, istoplevel)
     while pc !== nothing && !isa(pc, BreakpointRef)
-        if predicate(frame) || shouldbreak(frame, pc)
-            return pc
-        end
+        shouldbreak(frame, pc) && return BreakpointRef(frame.framecode, pc)
+        predicate(frame) && return pc
         pc = step_expr!(recurse, frame, istoplevel)
     end
     return pc

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -449,4 +449,16 @@ struct B{T} end
             break_off(:error)
         end
     end
+
+    @testset "breakpoint in next line" begin
+        function f(a, b)
+            a == 0 && return abs(b)
+            @bp
+            return b
+        end
+        
+        frame = JuliaInterpreter.enter_call(f, 5, 10)
+        frame, pc = JuliaInterpreter.debug_command(frame, :n)
+        @test pc isa BreakpointRef
+    end
 # end


### PR DESCRIPTION
Noticed from a test failure in Debugger.jl