### PR TITLE
Interpret most of Core.Compiler

### DIFF
--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -70,11 +70,43 @@ function set_compiled_methods()
     push!(compiled_methods, which(subtypes, Tuple{Module, Type}))
     push!(compiled_methods, which(subtypes, Tuple{Type}))
 
+    # Anything that ccalls jl_typeinf_begin cannot currently be handled
+    for finf in (Core.Compiler.typeinf_code, Core.Compiler.typeinf_ext, Core.Compiler.typeinf_type)
+        for m in methods(finf)
+            push!(compiled_methods, m)
+        end
+    end
+
     push!(compiled_modules, Base.Threads)
 end
 
 function __init__()
     set_compiled_methods()
+    # If we interpret into Core.Compiler, we need to take precautions to avoid needing
+    # inference of JuliaInterpreter methods in the middle of a `ccall(:jl_typeinf_begin, ...)`
+    # block.
+    # for (sym, RT, AT) in ((:jl_typeinf_begin, Cvoid, ()),
+    #                       (:jl_typeinf_end, Cvoid, ()),
+    #                       (:jl_isa_compileable_sig, Int32, (Any, Any)),
+    #                       (:jl_compress_ast, Any, (Any, Any)),
+    #                       # (:jl_set_method_inferred, Ref{Core.CodeInstance}, (Any, Any, Any, Any, Int32, UInt, UInt)),
+    #                       (:jl_method_instance_add_backedge, Cvoid, (Any, Any)),
+    #                       (:jl_method_table_add_backedge, Cvoid, (Any, Any, Any)),
+    #                       (:jl_new_code_info_uninit, Ref{CodeInfo}, ()),
+    #                       (:jl_uncompress_argnames, Vector{Symbol}, (Any,)),
+    #                       (:jl_get_tls_world_age, UInt, ()),
+    #                       (:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint)),
+    #                       (:jl_value_ptr, Any, (Ptr{Cvoid},)),
+    #                       (:jl_value_ptr, Ptr{Cvoid}, (Any,)))
+    #     fname = Symbol(:ccall_, sym)
+    #     qsym = QuoteNode(sym)
+    #     argnames = [Symbol(:arg_, string(i)) for i = 1:length(AT)]
+    #     TAT = Expr(:tuple, [parametric_type_to_expr(t) for t in AT]...)
+    #     def = :($fname($(argnames...)) = ccall($qsym, $RT, $TAT, $(argnames...)))
+    #     f = Core.eval(Core.Compiler, def)
+    #     compiled_calls[(qsym, RT, Core.svec(AT...), Core.Compiler)] = f
+    #     precompile(f, AT)
+    # end
 end
 
 include("precompile.jl")

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -2,7 +2,7 @@ module JuliaInterpreter
 
 using Base.Meta
 import Base: +, -, convert, isless
-using Core: CodeInfo, SSAValue, SlotNumber, TypeMapEntry, SimpleVector, LineInfoNode, GotoNode, Slot,
+using Core: CodeInfo, TypeMapEntry, SimpleVector, LineInfoNode, GotoNode, Slot,
             GeneratedFunctionStub, MethodInstance, NewvarNode, TypeName
 
 using UUIDs
@@ -18,7 +18,7 @@ export @interpret, Compiled, Frame, root, leaf,
        debug_command, @bp, break_on, break_off
 
 module CompiledCalls
-# This module is for handling intrinsics that must be compiled (llvmcall)
+# This module is for handling intrinsics that must be compiled (llvmcall) as well as ccalls
 end
 
 # "Backport" of https://github.com/JuliaLang/julia/pull/31536
@@ -70,7 +70,6 @@ function set_compiled_methods()
     push!(compiled_methods, which(subtypes, Tuple{Module, Type}))
     push!(compiled_methods, which(subtypes, Tuple{Type}))
 
-    push!(compiled_modules, Core.Compiler)
     push!(compiled_modules, Base.Threads)
 end
 

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -213,7 +213,7 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
     last = stmts[end-1]
     isexpr(last, :(=)) && (last = last.args[2])
     is_kw = isa(scope, Method) && startswith(String(Base.unwrap_unionall(Base.unwrap_unionall(scope.sig).parameters[1]).name.name), "#kw")
-    if is_kw || isexpr(last, :call) && any(isequal(Core.SlotNumber(1)), last.args)
+    if is_kw || isexpr(last, :call) && any(isequal(SlotNumber(1)), last.args)
         # If the last expr calls #self# or passes it to an implementation method,
         # this is a wrapper function that we might want to step through
         while frame.pc != length(stmts)-1

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -178,7 +178,8 @@ function bypass_builtins(frame, call_expr, pc)
         if isa(tme, Compiled)
             fargs = collect_args(frame, call_expr)
             f = to_function(fargs[1])
-            if parentmodule(f) === JuliaInterpreter.CompiledCalls
+            fmod = parentmodule(f)
+            if fmod === JuliaInterpreter.CompiledCalls || fmod === Core.Compiler
                 return Some{Any}(Base.invokelatest(f, fargs[2:end]...))
             else
                 return Some{Any}(f(fargs[2:end]...))

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -342,23 +342,23 @@ function build_compiled_call!(stmt, methname, fcall, typargs, code, idx, nargs, 
     return delete_idx
 end
 
-function replace_coretypes!(src)
+function replace_coretypes!(src; rev::Bool=false)
     if isa(src, CodeInfo)
-        replace_coretypes_list!(src.code)
+        replace_coretypes_list!(src.code; rev=rev)
     elseif isa(src, Expr)
-        replace_coretypes_list!(src.args)
+        replace_coretypes_list!(src.args; rev=rev)
     end
     return src
 end
 
-function replace_coretypes_list!(list)
+function replace_coretypes_list!(list; rev::Bool)
     for (i, stmt) in enumerate(list)
-        if isa(stmt, Core.SSAValue)
-            list[i] = SSAValue(stmt.id)
-        elseif isa(stmt, Core.SlotNumber)
-            list[i] = SlotNumber(stmt.id)
+        if isa(stmt, rev ? SSAValue : Core.SSAValue)
+            list[i] = rev ? Core.SSAValue(stmt.id) : SSAValue(stmt.id)
+        elseif isa(stmt, rev ? SlotNumber : Core.SlotNumber)
+            list[i] = rev ? Core.SlotNumber(stmt.id) : SlotNumber(stmt.id)
         elseif isa(stmt, Expr)
-            replace_coretypes!(stmt)
+            replace_coretypes!(stmt; rev=rev)
         end
     end
     return nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,6 +11,15 @@ struct NewSSAValue
     id::Int
 end
 
+# Our own replacements for Core types. We need to do this to ensure we can tell the difference
+# between "data" (Core types) and "code" (our types) if we step into Core.Compiler
+struct SSAValue
+    id::Int
+end
+struct SlotNumber
+    id::Int
+end
+
 # Breakpoint support
 truecondition(frame) = true
 falsecondition(frame) = false
@@ -70,7 +79,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true)
     if optimize
         src, methodtables = optimize!(copy_codeinfo(src), scope)
     else
-        src = copy_codeinfo(src)
+        src = replace_coretypes!(copy_codeinfo(src))
         methodtables = Vector{Union{Compiled,TypeMapEntry}}(undef, length(src.code))
     end
     breakpoints = Vector{BreakpointState}(undef, length(src.code))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -281,7 +281,9 @@ function print_framecode(io::IO, framecode::FrameCode; pc=0, range=1:nstatements
     offset = lineoffset(framecode)
     ndline = isempty(lt) ? 0 : ndigits(getline(lt[end]) + offset)
     nullline = " "^ndline
-    code = framecode_lines(framecode)
+    src = copy_codeinfo(framecode.src)
+    replace_coretypes!(src; rev=true)
+    code = framecode_lines(src)
     isfirst = true
     for (stmtidx, stmtline) in enumerate(code)
         stmtidx ∈ range || continue

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -337,7 +337,7 @@ f113(;x) = x
     end
     frame = JuliaInterpreter.enter_call(f_multi, 1)
     nlocals = length(frame.framedata.locals)
-    @test_throws UndefVarError JuliaInterpreter.lookup_var(frame, Core.SlotNumber(nlocals))
+    @test_throws UndefVarError JuliaInterpreter.lookup_var(frame, JuliaInterpreter.SlotNumber(nlocals))
     stack = [frame]
     locals = JuliaInterpreter.locals(frame)
     @test length(locals) == 2
@@ -383,7 +383,7 @@ end
         end
     end
     @test @interpret(test_never_different(10)) === nothing
-  
+
 end
 
 # https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/130

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -516,3 +516,10 @@ end
 # Test exception type for undefined variables
 f() = s = s + 1
 @test_throws UndefVarError @interpret f()
+
+# Handling of SSAValues
+function f()
+    z = [Core.SSAValue(5),]
+    repr(z[1])
+end
+@test @interpret f() == f()


### PR DESCRIPTION
This opens most of `Core.Compiler` to the interpreter. The unfortunate exceptions are some of the most interesting functions, the various `typeinf_*` functions: so far I have been unable to avoid segfaults from anything that starts a `ccall(:jl_typeinf_begin, ...)` block. However, hopefully this is still a considerable improvement from where we are currently. (Thoughts, @vchuravy?)

There are three substantive changes:
- Avoid using `Core.SlotNumber` and `Core.SSAValue`. Instead, we define equivalent types here and replace the values that come by from `Base.uncompressed_ast` with the local equivalents. This allows us to distinguish an `SSAValue` generated as a value from `Core.Compiler` methods vs one that's being used by the interpreter. Disadvantage: I suspect frame printing is broken. That's one reason this is a WIP.
- `ccall`s made from `Core.Compiler` have to have their compiled variants evaluated in `Core.Compiler` rather than `JuliaInterpreter.CompiledCalls`. The reason is that `Core.Compiler.unsafe_convert != Base.unsafe_convert` and `Core.Compiler.cconvert != Base.cconvert` and these end up getting used by Julia internally when implementing our compiled variants.
- In a (failed) attempt to avoid those segfaults, I set up a mechanism to re-used previous compiled `ccall` functions. As a consequence one no longer needs one per call site, it's just one per type signature. This seems useful on its own, even if it didn't fix the core problem I was trying to solve.

Fixes #257. Fixes #242. Closes #258.
