### PR TITLE
JuliaInterpreter 0.5.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
Note that this is against the newly-created `release-0.5` branch. See #284 for a release that will be on `master`.

- Support self-referential struct definitions (#283)
- Fix nightly (#286)
