### PR TITLE
Compile parametric methods that contain llvmcall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,8 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Distributed", "Dates", "SHA", "Mmap"]
+test = ["Test", "Dates", "Distributed", "Mmap", "SHA", "Tensors"]

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -165,6 +165,11 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
                 generator = false
             end
         end
+        # Currenly, our strategy to deal with llvmcall can't handle parametric functions
+        # (the "mini interpreter" runs in module scope, not method scope)
+        if !isempty(lenv) && (hasarg(isequal(:llvmcall), code.code) || hasarg(a->is_global_ref(a, Base, :llvmcall), code.code))
+            return Compiled()
+        end
         framecode = FrameCode(method, code; generator=generator)
         if is_generated(method) && !enter_generated
             genframedict[(method, argtypes)] = framecode

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,6 +87,19 @@ function scan_ssa_use!(used::BitSet, @nospecialize(stmt))
     end
 end
 
+function hasarg(predicate, args)
+    predicate(args) && return true
+    for a in args
+        predicate(a) && return true
+        if isa(a, Expr)
+            hasarg(predicate, a.args) && return true
+        elseif isa(a, QuoteNode)
+            predicate(a.value) && return true
+        end
+    end
+    return false
+end
+
 ## Predicates
 
 is_goto_node(@nospecialize(node)) = isa(node, GotoNode) || isexpr(node, :gotoifnot)


### PR DESCRIPTION
Part of the problem is detecting the llvmcall (esp in #112), but a bigger issue is that we need to check [`isempty(sparams)`](https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/04d1fb5ce969d7e41df6f7bb9dd52d96049df1bb/src/optimize.jl#L165) because our [mini-interpreter](https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/04d1fb5ce969d7e41df6f7bb9dd52d96049df1bb/src/optimize.jl#L277-L291) runs at toplevel and can't access `Expr(:static_parameter, n)`. I'm sure this is fixable, but this PR is a workaround that skips interpreting such methods altogether. It's probably OK because I think most methods that contain `llvmcall` are low-level and unlikely to be of interest to the majority of people doing debugging.

fixes #112, fixes #288
