### PR TITLE
Make parametric_type_to_expr recursive (fixes #285)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,14 +13,16 @@ CodeTracking = "0.3.2, 0.4, 0.5"
 julia = "1"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TableReader = "70df011a-6618-58d7-8e16-3cf9e384cb47"
 Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
-test = ["Test", "Dates", "Distributed", "Mmap", "SHA", "Tensors", "TableReader", "DataFrames"]
+test = ["Test", "Dates", "Distributed", "LinearAlgebra", "Mmap", "SHA", "SparseArrays", "Tensors", "TableReader", "DataFrames"]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,6 +102,24 @@ function hasarg(predicate, args)
     return false
 end
 
+function wrap_params(expr, sparams)
+    isempty(sparams) && return expr
+    params = []
+    for p in sparams
+        pname = isexpr(p, :(<:)) ? p.args[1] : p
+        hasarg(isequal(pname), expr.args) && push!(params, p)
+    end
+    return isempty(params) ? expr : Expr(:where, expr, params...)
+end
+
+function scopename(tn::TypeName)
+    modpath = Base.fullname(tn.module)
+    return Expr(:., _scopename(modpath...), QuoteNode(tn.name))
+end
+_scopename(sym) = sym
+_scopename(parent, child) = Expr(:., parent, QuoteNode(child))
+_scopename(parent, child, rest...) = Expr(:., parent, _scopename(child, rest...))
+
 ## Predicates
 
 is_goto_node(@nospecialize(node)) = isa(node, GotoNode) || isexpr(node, :gotoifnot)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -593,3 +593,18 @@ end
 @noinline f_345() = 1
 frame = JuliaInterpreter.enter_call(f_345)
 @test JuliaInterpreter.whereis(frame) == (@__FILE__(), @__LINE__() - 2)
+
+# issue #285
+using LinearAlgebra, SparseArrays, Random
+@testset "issue 285" begin
+    function solveit(A,b)
+        return A\b .+ det(A)
+    end
+
+    Random.seed!(123456)
+    n = 5
+    A = sprand(n,n,0.5)
+    A = A'*A
+    b = rand(n)
+    @test @interpret(solveit(A, b)) == solveit(A, b)
+end


### PR DESCRIPTION
This doesn't work to fix #285 but it's close. The remaining problem is `JuliaInterpreter.CompiledCalls` doesn't know about other modules. Thoughts?

Relevant portion of debugging output from running the test in #285:

```julia
RetType = Ptr{SuiteSparse.CHOLMOD.C_Sparse{Tv<:Union{Complex{Float64}, Float64}}}
t.name = SuiteSparse.CHOLMOD.C_Sparse
t.name = Ptr
parametric_type_to_expr(RetType) = :(Core.Ptr{(SuiteSparse.CHOLMOD).C_Sparse{Tv}})
t.name = SuiteSparse.CHOLMOD.C_Sparse
t.name = Ptr
wrapargs = Any[:arg1, :arg2, :arg3, :arg4, :arg5, :arg6, :arg7, :arg8, :(::(Val){Tv})]
RetType = :(Core.Ptr{(SuiteSparse.CHOLMOD).C_Sparse{Tv}})
evalmod = JuliaInterpreter.CompiledCalls
def = :(function ccall_cholmod_l_allocate_sparse_libcholmod_1d562f76_7e37_11e9_2fa8_d190d118f371(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ::(Val){Tv}) where Tv
      #= /home/tim/.julia/dev/JuliaInterpreter/src/optimize.jl:341 =#
      return ccall(("cholmod_l_allocate_sparse", :libcholmod), Core.Ptr{(SuiteSparse.CHOLMOD).C_Sparse{Tv}}, (UInt64, UInt64, UInt64, Int32, Int32, Int32, Int32, Ptr{Nothing}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
  end)
ERROR: LoadError: UndefVarError: SuiteSparse not defined
Stacktrace:
 [1] top-level scope
 [2] top-level scope at none:0
 [3] eval at ./boot.jl:328 [inlined]
 [4] build_compiled_call!(::Expr, ::Symbol, ::Symbol, ::Array{Any,1}, ::Core.CodeInfo, ::Int64, ::Int64, ::Array{Symbol,1}, ::Module) at /home/tim/.julia/dev/JuliaInterpreter/src/optimize.jl:345
 [5] optimize!(::Core.CodeInfo, ::Method) at /home/tim/.julia/dev/JuliaInterpreter/src/optimize.jl:196
...
```