### PR TITLE
Fix documentation of `determine_method_for_expr`

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -489,7 +489,7 @@ end
     framecode, frameargs, lenv, argtypes = determine_method_for_expr(expr; enter_generated = false)
 
 Prepare all the information needed to execute a particular `:call` expression `expr`.
-For example, try `JuliaInterpreter.determine_method_for_expr(:($(sum)([1,2])))`.
+For example, try `JuliaInterpreter.determine_method_for_expr(:(\$sum([1,2])))`.
 See [`JuliaInterpreter.prepare_call`](@ref) for information about the outputs.
 """
 function determine_method_for_expr(expr; enter_generated = false)


### PR DESCRIPTION
The `$` character in [this line](https://github.com/aviatesk/JuliaInterpreter.jl/blob/01646ad1f035a8efa7f5a67465972ed72b84cc6c/src/construct.jl#L492) is currently not escaped and is being disappeared from the documentation.

This is better to be fixed since `determine_method_for_expr(:(sin([1, 2])))` is not the correct way to use this function and even causes an error.

- Closes #302 
