### PR TITLE
Replace the slow slotname Dict with a counter ("age")-based mechanism

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -265,56 +265,49 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
 end
 
 function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=empty_svec, caller_will_catch_err::Bool=false)
-    if isa(framecode.scope, Method)
-        meth, src = framecode.scope::Method, framecode.src
-        slotnames = src.slotnames::SlotNamesType
-        ssavt = src.ssavaluetypes
-        ng = isa(ssavt, Int) ? ssavt : length(ssavt::Vector{Any})
-        nargs, meth_nargs = length(argvals), Int(meth.nargs)
-        if length(junk) > 0
-            olddata = pop!(junk)
-            locals, ssavalues, sparams = olddata.locals, olddata.ssavalues, olddata.sparams
-            exception_frames, last_reference = olddata.exception_frames, olddata.last_reference
-            last_exception = olddata.last_exception
-            callargs = olddata.callargs
-            resize!(locals, length(src.slotflags))
-            resize!(ssavalues, ng)
-            # for check_isdefined to work properly, we need sparams to start out unassigned
-            resize!(sparams, 0)
-            empty!(exception_frames)
-            empty!(last_reference)
-            last_exception[] = nothing
-        else
-            locals = Vector{Union{Nothing,Some{Any}}}(undef, length(src.slotflags))
-            ssavalues = Vector{Any}(undef, ng)
-            sparams = Vector{Any}(undef, 0)
-            exception_frames = Int[]
-            last_reference = Dict{Symbol,Int}()
-            callargs = Any[]
-            last_exception = Ref{Any}(nothing)
-        end
-        for i = 1:meth_nargs
-            last_reference[slotnames[i]::Symbol] = i
-            if meth.isva && i == meth_nargs
-                locals[i] = nargs < i ? Some{Any}(()) : (let i=i; Some{Any}(ntuple(k->argvals[i+k-1], nargs-i+1)); end)
-                break
-            end
-            locals[i] = nargs >= i ? Some{Any}(argvals[i]) : Some{Any}(())
-        end
-        # add local variables initially undefined
-        for i = (meth_nargs+1):length(slotnames)
-            locals[i] = nothing
-        end
-    else
-        src = framecode.src
-        locals = Vector{Union{Nothing,Some{Any}}}(undef, length(src.slotflags))  # src.slotflags is concretely typed, unlike slotnames
+    src = framecode.src
+    slotnames = src.slotnames::SlotNamesType
+    ssavt = src.ssavaluetypes
+    ng, ns = isa(ssavt, Int) ? ssavt : length(ssavt::Vector{Any}), length(src.slotflags)
+    if length(junk) > 0
+        olddata = pop!(junk)
+        locals, ssavalues, sparams = olddata.locals, olddata.ssavalues, olddata.sparams
+        exception_frames, last_reference = olddata.exception_frames, olddata.last_reference
+        last_exception = olddata.last_exception
+        callargs = olddata.callargs
+        resize!(locals, ns)
         fill!(locals, nothing)
-        ssavalues = Vector{Any}(undef, length(src.code))
-        sparams = Any[]
+        resize!(ssavalues, ng)
+        # for check_isdefined to work properly, we need sparams to start out unassigned
+        resize!(sparams, 0)
+        empty!(exception_frames)
+        resize!(last_reference, ns)
+        last_exception[] = nothing
+    else
+        locals = Vector{Union{Nothing,Some{Any}}}(nothing, ns)
+        ssavalues = Vector{Any}(undef, ng)
+        sparams = Vector{Any}(undef, 0)
         exception_frames = Int[]
-        last_reference = Dict{Symbol,Int}()
+        last_reference = Vector{Int}(undef, ns)
         callargs = Any[]
         last_exception = Ref{Any}(nothing)
+    end
+    fill!(last_reference, 0)
+    if isa(framecode.scope, Method)
+        meth = framecode.scope::Method
+        nargs, meth_nargs = length(argvals), Int(meth.nargs)
+        islastva = meth.isva && nargs >= meth_nargs
+        for i = 1:meth_nargs-islastva
+            if nargs >= i
+                locals[i], last_reference[i] = Some{Any}(argvals[i]), 1
+            else
+                locals[i] = Some{Any}(())
+            end
+        end
+        if islastva
+            locals[meth_nargs] =  (let i=meth_nargs; Some{Any}(ntuple(k->argvals[i+k-1], nargs-i+1)); end)
+            last_reference[meth_nargs] = 1
+        end
     end
     resize!(sparams, length(lenv))
     # Add static parameters to environment

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -332,9 +332,9 @@ function do_assignment!(frame, @nospecialize(lhs), @nospecialize(rhs))
     if isa(lhs, SSAValue)
         data.ssavalues[lhs.id] = rhs
     elseif isa(lhs, SlotNumber)
+        counter = (frame.assignment_counter += 1)
         data.locals[lhs.id] = Some{Any}(rhs)
-        slotnames = code.src.slotnames::SlotNamesType
-        data.last_reference[slotnames[lhs.id]::Symbol] = lhs.id
+        data.last_reference[lhs.id] = counter
     elseif isa(lhs, GlobalRef)
         Core.eval(lhs.mod, :($(lhs.name) = $(QuoteNode(rhs))))
     elseif isa(lhs, Symbol)

--- a/src/types.jl
+++ b/src/types.jl
@@ -70,6 +70,7 @@ struct FrameCode
     src::CodeInfo
     methodtables::Vector{Union{Compiled,TypeMapEntry}} # line-by-line method tables for generic-function :call Exprs
     breakpoints::Vector{BreakpointState}
+    slotnamelists::Dict{Symbol,Vector{Int}}
     used::BitSet
     generator::Bool   # true if this is for the expression-generator of a @generated function
 end
@@ -89,8 +90,13 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true)
             src.code[i] = nothing
         end
     end
+    slotnamelists = Dict{Symbol,Vector{Int}}()
+    for (i, sym) in enumerate(src.slotnames)
+        list = get(slotnamelists, sym, Int[])
+        slotnamelists[sym] = push!(list, i)
+    end
     used = find_used(src)
-    framecode = FrameCode(scope, src, methodtables, breakpoints, used, generator)
+    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator)
     if scope isa Method
         for bp in _breakpoints
             # Manual union splitting
@@ -151,9 +157,7 @@ struct FrameData
     exception_frames::Vector{Int}
     last_exception::Base.RefValue{Any}
     caller_will_catch_err::Bool
-    # A vector from names to the slotnumber of that name
-    # for which a reference was last encountered.
-    last_reference::Dict{Symbol,Int}
+    last_reference::Vector{Int}
     callargs::Vector{Any}  # a temporary for processing arguments of :call exprs
 end
 
@@ -176,10 +180,11 @@ mutable struct Frame
     framecode::FrameCode
     framedata::FrameData
     pc::Int
+    assignment_counter::Int
     caller::Union{Frame,Nothing}
     callee::Union{Frame,Nothing}
 end
-Frame(framecode, framedata, pc=1, caller=nothing) = Frame(framecode, framedata, pc, caller, nothing)
+Frame(framecode, framedata, pc=1, caller=nothing) = Frame(framecode, framedata, pc, 1, caller, nothing)
 
 caller(frame) = frame.caller
 callee(frame) = frame.callee
@@ -331,7 +336,7 @@ struct BreakpointSignature <: AbstractBreakpoint
     enabled::Ref{Bool}
     instances::Vector{BreakpointRef}
 end
-same_location(bp2::BreakpointSignature, bp::BreakpointSignature) = 
+same_location(bp2::BreakpointSignature, bp::BreakpointSignature) =
     bp2.f == bp.f && bp2.sig == bp.sig && bp2.line == bp.line
 function Base.show(io::IO, bp::BreakpointSignature)
     print(io, bp.f)
@@ -369,7 +374,7 @@ struct BreakpointFileLocation <: AbstractBreakpoint
     enabled::Ref{Bool}
     instances::Vector{BreakpointRef}
 end
-same_location(bp2::BreakpointFileLocation, bp::BreakpointFileLocation) = 
+same_location(bp2::BreakpointFileLocation, bp::BreakpointFileLocation) =
     bp2.path == bp.path && bp2.abspath == bp.abspath && bp2.line == bp.line
 function Base.show(io::IO, bp::BreakpointFileLocation)
     print(io, bp.path, ':', bp.line)
@@ -378,4 +383,3 @@ function Base.show(io::IO, bp::BreakpointFileLocation)
         print(io, " [disabled]")
     end
 end
-

--- a/src/types.jl
+++ b/src/types.jl
@@ -180,7 +180,7 @@ mutable struct Frame
     framecode::FrameCode
     framedata::FrameData
     pc::Int
-    assignment_counter::Int
+    assignment_counter::Int64
     caller::Union{Frame,Nothing}
     callee::Union{Frame,Nothing}
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -116,6 +116,24 @@ struct Squarer end
     @test !any(v->v.name == :b, var)
     @test filter(v->v.name == :a, var)[1].value == 2
 
+    # Method with local scope (two slots with same name)
+    ln = @__LINE__
+    function ftwoslots()
+        y = 1
+        z = let y = y
+                y = y + 2
+                rand()
+            end
+        y = y + 1
+        return z
+    end
+    bp = breakpoint(@__FILE__, ln+5, :(y > 2))
+    frame, bp2 = @interpret ftwoslots()
+    var = JuliaInterpreter.locals(leaf(frame))
+    @test filter(v->v.name == :y, var)[1].value == 3
+    remove(bp)
+    bp = breakpoint(@__FILE__, ln+8, :(y > 2))
+    @test isa(@interpret(ftwoslots()), Float64)
 
     # Direct return
     @breakpoint gcd(1,1) a==5


### PR DESCRIPTION
Old benchmarks:
```
          "recursive other 1_000" => Trial(7.510 ms)
          "recursive self 1_000" => Trial(2.450 ms)
          "long function 5_000" => Trial(33.257 ms)
          "throw long 1_000" => Trial(14.002 ms)
          "tight loop 10_000" => Trial(213.216 ms)
```

vs this branch:
```
         "recursive other 1_000" => Trial(7.502 ms)
          "recursive self 1_000" => Trial(1.996 ms)
          "long function 5_000" => Trial(30.500 ms)
          "throw long 1_000" => Trial(13.406 ms)
          "tight loop 10_000" => Trial(174.004 ms)
```

Take with a grain of salt, there is a fair amount of variance. But the last one is consistently cut to about 80% of the original.