### PR TITLE
Create a "junk yard" even for Frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 deps/build.log
 docs/build/
 test/results.md
+Manifest.toml

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, JuliaInterpreter, Test, CodeTracking
 DocMeta.setdocmeta!(JuliaInterpreter, :DocTestSetup, :(
     begin
         using JuliaInterpreter
-        empty!(JuliaInterpreter.junk)
+        JuliaInterpreter.clear_caches()
         JuliaInterpreter.remove()
     end); recursive=true)
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -146,7 +146,7 @@ Sometimes you might have a whole sequence of expressions you want to run.
 In such cases, your first thought should be `prepare_thunk`.
 Here's a demonstration:
 
-```jldoctest; setup=(using JuliaInterpreter; empty!(JuliaInterpreter.junk))
+```jldoctest; setup=(using JuliaInterpreter; JuliaInterpreter.clear_caches())
 using Test
 
 ex = quote

--- a/src/types.jl
+++ b/src/types.jl
@@ -184,7 +184,20 @@ mutable struct Frame
     caller::Union{Frame,Nothing}
     callee::Union{Frame,Nothing}
 end
-Frame(framecode, framedata, pc=1, caller=nothing) = Frame(framecode, framedata, pc, 1, caller, nothing)
+function Frame(framecode, framedata, pc=1, caller=nothing)
+    if length(junk_frames) > 0
+        frame = pop!(junk_frames)
+        frame.framecode = framecode
+        frame.framedata = framedata
+        frame.pc = pc
+        frame.assignment_counter = 1
+        frame.caller = caller
+        frame.callee = nothing
+        return frame
+    else
+        return Frame(framecode, framedata, pc, 1, caller, nothing)
+    end
+end
 
 caller(frame) = frame.caller
 callee(frame) = frame.callee

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ if !isdefined(@__MODULE__, :read_and_parse)
     include("utils.jl")
 end
 
-JuliaInterpreter.debug_recycle[] = true
+Core.eval(JuliaInterpreter, :(debug_recycle() = true))
 
 @testset "Main tests" begin
     include("interpret.jl")


### PR DESCRIPTION
This avoids creating all the tiny `Frame` objects over and over.

Running the tight loop benchmark:

```jl
# Master
julia> @btime @interpret f(X)
  215.089 ms (1979122 allocations: 64.04 MiB)

# PR
julia> @btime @interpret f(X)
  207.504 ms (1749055 allocations: 49.24 MiB)
```

The time difference is not that big but the allocations are only 75% and it is possible this will start to matter more when other things are more optimized.