### PR TITLE
refactor out returning from a frame

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -59,10 +59,8 @@ function finish_stack!(@nospecialize(recurse), frame::Frame, rootistoplevel::Boo
         ret = finish_and_return!(recurse, frame, istoplevel)
         isa(ret, BreakpointRef) && return ret
         frame === frame0 && return ret
-        recycle(frame)
-        frame = caller(frame)
+        frame = return_from(frame)
         frame === nothing && return ret
-        frame.callee = nothing
         pc = frame.pc
         if isassign(frame, pc)
             lhs = getlhs(pc)
@@ -325,10 +323,8 @@ function maybe_reset_frame!(@nospecialize(recurse), frame::Frame, @nospecialize(
     isa(pc, BreakpointRef) && return leaf(frame), pc
     if pc === nothing
         val = get_return(frame)
-        recycle(frame)
-        frame = caller(frame)
+        frame = return_from(frame)
         frame === nothing && return nothing
-        frame.callee = nothing
         ssavals = frame.framedata.ssavalues
         is_wrapper = isassigned(ssavals, frame.pc) && ssavals[frame.pc] === Wrapper()
         maybe_assign!(frame, val)
@@ -353,9 +349,7 @@ function unwind_exception(frame::Frame, exc)
             frame.framedata.last_exception[] = exc
             return frame
         end
-        recycle(frame)
-        frame = caller(frame)
-        frame === nothing || (frame.callee = nothing)
+        frame = return_from(frame)
     end
     rethrow(exc)
 end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -34,6 +34,13 @@ const debug_recycle = Base.RefValue(false)
     push!(junk, frame.framedata)
 end
 
+function return_from(frame::Frame)
+    recycle(frame)
+    frame = caller(frame)
+    frame === nothing || (frame.callee = nothing)
+    return frame
+end
+
 function clear_caches()
     empty!(junk)
     empty!(framedict)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -246,7 +246,7 @@ function evaluate_call_recurse!(@nospecialize(recurse), frame::Frame, call_expr:
     end
     isa(ret, BreakpointRef) && return ret
     frame.callee = nothing
-    recycle(newframe)
+    return_from(newframe)
     return ret
 end
 
@@ -494,7 +494,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                         finish!(recurse, newframe, true)
                         frame.callee = nothing
                     end
-                    recycle(newframe)
+                    return_from(newframe)
                 elseif node.head == :global
                     # error("fixme")
                 elseif node.head == :toplevel
@@ -506,7 +506,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                               while true
                                   ($through_methoddef_or_done!)($recurse, newframe) === nothing && break
                               end
-                              $recycle(newframe)
+                              $return_from(newframe)
                           end)))
                 elseif node.head == :error
                     error("unexpected error statement ", node)
@@ -581,10 +581,8 @@ function handle_err(@nospecialize(recurse), frame, err)
         return BreakpointRef(frame.framecode, frame.pc, err)
     end
     if isempty(data.exception_frames)
-        is_root_frame = frame.caller === nothing
-        if !is_root_frame && !err_will_be_thrown_to_top_level
-            frame.caller.callee = nothing
-            recycle(frame)
+        if !err_will_be_thrown_to_top_level
+            return_from(frame)
         end
         # Check for world age errors, which generally indicate a failure to go back to toplevel
         if isa(err, MethodError)


### PR DESCRIPTION
We might want to use a linear stack of memory in the future. It is then important that we unwind correctly (i.e return to the saved "stack pointer" after exiting the function).

This PR factors out a pattern we commonly used when returning from a function to simplify adding future functionality when this happens. I called it `unwind` but perhaps something like `return_from` is better?