### PR TITLE
bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
A new semver incompat version should make us be able to upgrade things without hurry.

cc @pfitzseb, @timholy 

(See my upgrade PR to Debugger.jl, pretty much just using JuliaInterpreter.eval_code instead, https://github.com/JuliaDebug/Debugger.jl/pull/204/files).