### PR TITLE
Avoid errors on toplevel expressions that don't return frames

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -464,7 +464,7 @@ function split_expressions!(modexs, docexprs, lex::Expr, mod::Module, ex::Expr; 
             push!(docexs, ex)
         end
     else
-        if isempty(lex.args)
+        if isempty(lex.args) || (isexpr(ex, :global) && all(item->isa(item, LineNumberNode), lex.args))
             push!(modexs, (mod, copy(ex)))
         else
             push!(lex.args, ex)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -499,6 +499,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                     Core.eval(mod, Expr(:toplevel,
                         :(for modex in $modexs
                               newframe = ($prepare_thunk)(modex)
+                              newframe === nothing && continue
                               while true
                                   ($through_methoddef_or_done!)($recurse, newframe) === nothing && break
                               end


### PR DESCRIPTION
Encountered some problems while working on https://github.com/timholy/Revise.jl/issues/301