### PR TITLE
Don't interpret methods calling iolock_begin

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -181,7 +181,9 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
         end
         # Currenly, our strategy to deal with llvmcall can't handle parametric functions
         # (the "mini interpreter" runs in module scope, not method scope)
-        if !isempty(lenv) && (hasarg(isequal(:llvmcall), code.code) || hasarg(a->is_global_ref(a, Base, :llvmcall), code.code))
+        if (!isempty(lenv) && (hasarg(isequal(:llvmcall), code.code) ||
+                              hasarg(a->is_global_ref(a, Base, :llvmcall), code.code))) ||
+                hasarg(isequal(:iolock_begin), code.code)
             return Compiled()
         end
         framecode = FrameCode(method, code; generator=generator)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,6 +95,8 @@ function hasarg(predicate, args)
             hasarg(predicate, a.args) && return true
         elseif isa(a, QuoteNode)
             predicate(a.value) && return true
+        elseif isa(a, GlobalRef)
+            predicate(a.name) && return true
         end
     end
     return false

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -585,3 +585,6 @@ module DataFramesTest
     end
     @test @interpret(df_debug1()) == df_debug1()
 end
+
+# issue #330
+@test @interpret(Base.PipeEndpoint()) isa Base.PipeEndpoint


### PR DESCRIPTION
This is a temporary workaround for #330