### PR TITLE
Add hooks to breakpoint changes

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -108,3 +108,9 @@ JuliaInterpreter.Variable
 JuliaInterpreter.locals
 JuliaInterpreter.whichtt
 ```
+
+## Hooks
+```@docs
+JuliaInterpreter.on_breakpoints_updated
+JuliaInterpreter.firehooks
+```

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -15,7 +15,7 @@ using CodeTracking
 
 export @interpret, Compiled, Frame, root, leaf,
        BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove, toggle,
-       debug_command, @bp, break_on, break_off
+       debug_command, @bp, break_on, break_off, breakpoint_update_hooks
 
 module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall) as well as ccalls

--- a/src/JuliaInterpreter.jl
+++ b/src/JuliaInterpreter.jl
@@ -15,7 +15,7 @@ using CodeTracking
 
 export @interpret, Compiled, Frame, root, leaf,
        BreakpointRef, breakpoint, @breakpoint, breakpoints, enable, disable, remove, toggle,
-       debug_command, @bp, break_on, break_off, breakpoint_update_hooks
+       debug_command, @bp, break_on, break_off, on_breakpoints_updated
 
 module CompiledCalls
 # This module is for handling intrinsics that must be compiled (llvmcall) as well as ccalls

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -119,7 +119,13 @@ function breakpoint(f::Union{Method, Function}, sig=nothing, line::Integer=0, co
     bp = BreakpointSignature(f, sig, line, condition, Ref(true), BreakpointRef[])
     add_to_existing_framecodes(bp)
     idx = findfirst(bp2 -> same_location(bp, bp2), _breakpoints)
-    idx === nothing ? push!(_breakpoints, bp) : (_breakpoints[idx] = bp)
+    if idx === nothing  # creating new
+        push!(_breakpoints, bp)
+    else  #Replace existing breakpoint
+        old_bp = _breakpoints[idx]
+        _breakpoints[idx] = bp
+        firehooks(remove, old_bp)
+    end
     firehooks(breakpoint, bp)
     return bp
 end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -202,7 +202,7 @@ breakpoint!(frame::Frame, pc=frame.pc, condition::Condition=nothing) =
 
 function update_states!(bp::AbstractBreakpoint)
     foreach(bpref -> update_state!(bpref, bp.enabled[]), bp.instances)
-    firehooks(update_state!, bp)
+    firehooks(update_states!, bp)
 end
 update_state!(bp::BreakpointRef, v::Bool) = bp[] = v
 

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -16,18 +16,34 @@ Register a one-argument function to be called after any update to the set of all
 breakpoints. This includes their creation, deletion, enabling and disabling.
 
 The function `f` should take two inputs:
-First argument is the function doing to update, such as `::typeof(breakpoint)` for the
-creation, or `::typeof(remove)` for the deletion.
-Second argument is the breakpoint object that was changed.
+ - First argument is the function doing to update, this is provided to allow to dispatch
+   on its type. It will be one:
+   -  `::typeof(breakpoint)` for the creation,
+   -  `::typeof(remove)` for the deletion.
+   -  `::typeof(update_states)` for disable/enable/toggleing
+ - Second argument is the breakpoint object that was changed.
+
 If only desiring to handle some kinds of update, `f` should have fallback methods
 to do nothing in the general case.
 
 !!! warning
-    This feature is experimental, and may be modified or removed without the tagging of a
-    breaking release.
+    This feature is experimental, and may be modified or removed in a minor release.
 """
 on_breakpoints_updated(f) = push!(breakpoint_update_hooks, f)
 
+
+"""
+    firehooks(hooked_fun, bp::AbstractBreakpoint)
+
+Trigger all hooks that were registered with [`on_breakpoints_updated`](@ref),
+passing them the `hooked_fun` and the `bp`.
+This should be called whenever the set of breakpoints is updated.
+`hooked_fun` is the function doing the update, and `bp` is the relevent breakpoint being
+updated _after_ the update is applied.
+
+!!! warning
+    This feature is experimental, and may be modified or removed in a minor release.
+"""
 function firehooks(hooked_fun, bp::AbstractBreakpoint)
     for hook in breakpoint_update_hooks
         try

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -12,7 +12,7 @@ const breakpoint_update_hooks = []
 """
     on_breakpoints_updated(f)
 
-Register a one-argument function to be called after any update to the global set of
+Register a one-argument function to be called after any update to the set of all
 breakpoints. This includes their creation, deletion, enabling and disabling.
 
 The function `f` should take two inputs:

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -334,12 +334,12 @@ end
     bp = breakpoint(f_break)
     @test hook_hit
 
-    @testset "update_state! $op hits hook" for op in (disable, enable, toggle)
+    @testset "update_states! $op hits hook" for op in (disable, enable, toggle)
         empty!(breakpoint_update_hooks)
         hook_hit = false
         push!(
             breakpoint_update_hooks,
-            (f, _) -> hook_hit = f == JuliaInterpreter.update_state!,
+            (f, _) -> hook_hit = f == JuliaInterpreter.update_states!,
         )
         op(bp)
         @test hook_hit

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -327,14 +327,14 @@ end
     remove()
     f_break(x) = x
 
-    # Check creating hits hooks
+    # Check creating hits hook
     empty!(breakpoint_update_hooks)
-    hook_hit = 0
+    hook_hit = false
     push!(breakpoint_update_hooks, (f,_)->hook_hit = f == breakpoint)
     bp = breakpoint(f_break)
     @test hook_hit
 
-    @testset "update_state! $op" for op in (disable, enable, toggle)
+    @testset "update_state! $op hits hook" for op in (disable, enable, toggle)
         empty!(breakpoint_update_hooks)
         hook_hit = false
         push!(
@@ -345,7 +345,7 @@ end
         @test hook_hit
     end
 
-    # Test removing
+    # Test removing hits hooks
     empty!(breakpoint_update_hooks)
     hook_hit = false
     push!(breakpoint_update_hooks, (f,_)->hook_hit = f === remove)


### PR DESCRIPTION
Closes #261

I think the hooks fire too often.
For when creating breakpoints,
so there are two broken tests.

I only made 1 hook for all changes because I started to argue with myself as to if removal should trigger both the removal hook and the disable hook,
and concluded that i could just have one hook for everything than worry about those details,
that can be determined from the `BreakpointRef` anyway.