### PR TITLE
fixup for name change of #kw##invoke on 1.4

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -10,7 +10,8 @@ function getargs(args, frame)
     return callargs
 end
 
-const kwinvoke_instance = getfield(Core, Symbol("#kw##invoke")).instance
+const kwinvoke_name = isdefined(Core, Symbol("#kw##invoke")) ? Symbol("#kw##invoke") : Symbol("##invoke")
+const kwinvoke_instance = getfield(Core, kwinvoke_name).instance
 
 """
     ret = maybe_evaluate_builtin(frame, call_expr, expand::Bool)
@@ -228,7 +229,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         cargs = getargs(args, frame)
         return Some{Any}(ccall(:jl_f_intrinsic_call, Any, (Any, Ptr{Any}, UInt32), f, cargs, length(cargs)))
     end
-    if isa(f, getfield(Core, Symbol("#kw##invoke")))
+    if isa(f, getfield(Core, kwinvoke_name))
         return Some{Any}(kwinvoke_instance(getargs(args, frame)...))
     end
     return call_expr

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -210,7 +210,8 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
     length(stmts) < 2 && return frame
     last = stmts[end-1]
     isexpr(last, :(=)) && (last = last.args[2])
-    is_kw = isa(scope, Method) && startswith(String(Base.unwrap_unionall(Base.unwrap_unionall(scope.sig).parameters[1]).name.name), "#kw")
+    comp = VERSION < v"1.4.0-DEV.215" ? startswith : endswith
+    is_kw = isa(scope, Method) && comp(String(Base.unwrap_unionall(Base.unwrap_unionall(scope.sig).parameters[1]).name.name), "#kw")
     if is_kw || isexpr(last, :call) && any(isequal(SlotNumber(1)), last.args)
         # If the last expr calls #self# or passes it to an implementation method,
         # this is a wrapper function that we might want to step through

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -228,6 +228,7 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
         frame.framedata.ssavalues[frame.pc] = Wrapper()
         return maybe_step_through_wrapper!(recurse, callee(frame))
     end
+    maybe_step_through_nkw_meta!(frame)
     return frame
 end
 maybe_step_through_wrapper!(frame::Frame) = maybe_step_through_wrapper!(finish_and_return!, frame)
@@ -354,6 +355,15 @@ function unwind_exception(frame::Frame, exc)
     end
     rethrow(exc)
 end
+
+function maybe_step_through_nkw_meta!(frame)
+    stmt = pc_expr(frame)
+    if isexpr(stmt, :meta) && stmt.args[1] == :nkw
+        @assert frame.pc == 1
+        frame.pc += 1
+    end
+end
+
 
 """
     ret = debug_command(recurse, frame, cmd, rootistoplevel=false; line=nothing)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -567,7 +567,7 @@ f(x) = x*x
 module CSVTest
     using Test
     using JuliaInterpreter
-    @static if sizeof(Int) == 8 # TableReader seems to not work on 32 bit
+    @static if sizeof(Int) == 8 && VERSION.minor < 4  # TableReader seems to not work on 32 bit or 1.4
         using TableReader
         const myfile = "smallcsv.csv"
         @test (@interpret readcsv(myfile)) == readcsv(myfile)


### PR DESCRIPTION
Fixes #344 

~~We still have some test failures on master:~~

```
Keyword arguments: Error During Test at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:179
  Test threw exception
  Expression: get_return(frame) == 6
  expected return statement, got (SSAValue(15))(SSAValue(16), JuliaInterpreter.SlotNumber(3), JuliaInterpreter.SlotNumber(4))
  Stacktrace:
   [1] error(::String, ::Expr) at ./error.jl:42
   [2] get_return(::Frame) at /home/kc/JuliaPkgs/JuliaInterpreter.jl/src/interpret.jl:609
   [3] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:179
   [4] top-level scope at /home/kc/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
   [5] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:163

Stepping over kwfunc preparation: Test Failed at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:406
  Expression: frame.pc > 4
   Evaluated: 2 > 4
Stacktrace:
 [1] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:406
 [2] top-level scope at /home/kc/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [3] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:387
Stepping over kwfunc preparation: Test Failed at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:413
  Expression: frame.pc == JuliaInterpreter.nstatements(frame.framecode) - 1
   Evaluated: 2 == 10
Stacktrace:
 [1] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:413
 [2] top-level scope at /home/kc/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
 [3] top-level scope at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/debug.jl:387
```

I think most of this is because our kw_prep stepper doesn't work correctly anymore.