### PR TITLE
fix breakage on master due to _apply_iterate

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -94,7 +94,7 @@ end
 @test_broken stc == sti
 
 # issue #3
-@test @interpret(joinpath("/home/julia/base", "sysimg.jl")) == "/home/julia/base/sysimg.jl"
+@test @interpret(joinpath("/home/julia/base", "sysimg.jl")) == joinpath("/home/julia/base", "sysimg.jl")
 @test @interpret(10.0^4) == 10.0^4
 # issue #6
 @test @interpret(Array.body.body.name) === Array.body.body.name
@@ -607,4 +607,9 @@ using LinearAlgebra, SparseArrays, Random
     A = A'*A
     b = rand(n)
     @test @interpret(solveit(A, b)) == solveit(A, b)
+end
+
+@testset "issue 351" begin
+    f() = map(x -> 2x, 1:10)
+    @test @interpret(f()) == f()
 end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -567,7 +567,7 @@ f(x) = x*x
 module CSVTest
     using Test
     using JuliaInterpreter
-    @static if sizeof(Int) == 8 && VERSION.minor < 4  # TableReader seems to not work on 32 bit or 1.4
+    @static if sizeof(Int) == 8 && VERSION.minor < 3  # TableReader seems to not work on 32 bit or 1.4, 1.3
         using TableReader
         const myfile = "smallcsv.csv"
         @test (@interpret readcsv(myfile)) == readcsv(myfile)

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -36,7 +36,11 @@ using Test
     @test Aborted(frame, i).at.line == 9
     # Check macro
     frame = JuliaInterpreter.prepare_thunk(modexs[5])
-    @test Aborted(frame, 1).at.file == Symbol("util.jl")
+    if VERSION < v"1.4.0-DEV.475"
+        @test Aborted(frame, 1).at.file == Symbol("util.jl")
+    else
+        @test Aborted(frame, 1).at.file == Symbol("fake.jl")
+    end
 end
 
 module EvalLimited end


### PR DESCRIPTION
There is still an error in master in `limits.jl`:

```
Abort: Test Failed at /home/kc/JuliaPkgs/JuliaInterpreter.jl/test/limits.jl:39
  Expression: (Aborted(frame, 1)).at.file == Symbol("util.jl")
   Evaluated: var"fake.jl" == var"util.jl"
```

@timholy, do you have any idea about that one?