### PR TITLE
Look up correct framecode for invoke

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -214,12 +214,13 @@ function evaluate_call_recurse!(@nospecialize(recurse), frame::Frame, call_expr:
     end
     if fargs[1] === Core.invoke # invoke needs special handling
         f_invoked = which(fargs[2], fargs[3])
-        sig = Tuple{_Typeof.(fargs)...}
+        fargs_pruned = [fargs[2]; fargs[4:end]]
+        sig = Tuple{_Typeof.(fargs_pruned)...}
         ret = prepare_framecode(f_invoked, sig; enter_generated=enter_generated)
         isa(ret, Compiled) && invoke(fargs[2:end]...)
         framecode, lenv = ret
-        fargs = [fargs[2]; fargs[4:end]]
         lenv === nothing && return framecode  # this was a Builtin
+        fargs = fargs_pruned
     else
         framecode, lenv = get_call_framecode(fargs, frame.framecode, frame.pc; enter_generated=enter_generated)
         if lenv === nothing

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -613,3 +613,11 @@ end
     f() = map(x -> 2x, 1:10)
     @test @interpret(f()) == f()
 end
+
+@testset "invoke" begin
+    # Example provided by jmert in #352
+    f(d::Diagonal{T}) where {T} = invoke(f, Tuple{AbstractMatrix}, d)
+    f(m::AbstractMatrix{T}) where {T} = T
+    D = Diagonal([1.0, 2.0])
+    @test @interpret(f(D)) === f(D)
+end


### PR DESCRIPTION
Prior to this the tests failed due to the following:
```julia
julia> using JuliaInterpreter

julia> sin(1)
0.8414709848078965

julia> @interpret sin(1)
0.8370984093755471
```
This turns out to be due to the new [`evalpoly`](https://github.com/JuliaLang/julia/blob/f39cdc0c7da8230b102051681c9378ce15d90235/base/math.jl#L106-L117), it was looking up the wrong framecode. This might have been a bug on all previous versions, but only detected now because of the change from macro to generated function.