### PR TITLE
Store SSAValues used by :abstract_type and :primitive_type

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -285,6 +285,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         callargs = olddata.callargs
         resize!(locals, ns)
         fill!(locals, nothing)
+        resize!(ssavalues, 0)
         resize!(ssavalues, ng)
         # for check_isdefined to work properly, we need sparams to start out unassigned
         resize!(sparams, 0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,9 +62,13 @@ function find_used(code::CodeInfo)
     stmts = code.code
     for stmt in stmts
         scan_ssa_use!(used, stmt)
-        if isexpr(stmt, :struct_type)  # this one is missed by Core.Compiler.userefs
-            for a in stmt.args
-                scan_ssa_use!(used, a)
+        if isa(stmt, Expr)
+            head = stmt.head
+            if head === :struct_type || head === :abstract_type || head === :primitive_type
+                # these are missed by Core.Compiler.userefs, see https://github.com/JuliaLang/julia/pull/30936
+                for a in stmt.args
+                    scan_ssa_use!(used, a)
+                end
             end
         end
     end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -440,3 +440,10 @@ end
     pop!(LOAD_PATH)
     rm(tmpdir, recursive=true)
 end
+
+@testset "`used` for abstract types" begin
+    ex = :(abstract type AbstractType <: AbstractArray{Union{Int,Missing},2} end)
+    frame = JuliaInterpreter.prepare_thunk(Toplevel, ex)
+    JuliaInterpreter.finish!(frame, true)
+    @test isabstracttype(Toplevel.AbstractType)
+end


### PR DESCRIPTION
Formerly we were not recording such SSAValues as being used by later 
statements. Responsible for https://discourse.julialang.org/t/subtyping-with-union-as-type-parameter/32326

Incidentally, this also ensures that ssavalues are undefined upon frame start. Initially, the error message was rather strange. With some debugging statements, formerly we had
```julia
frame.framecode.used = BitSet([])
frame.framedata.ssavalues = Any[Main.Toplevel.NonFrame, svec("An expr that produces an `export nffoo` that doesn't produce a Frame\n"), :module => Main.Toplevel.NonFrame, Dict{Symbol,Any}(:typesig => Union{},:module => Main.Toplevel.NonFrame,:linenumber => 1,:binding => Main.Toplevel.NonFrame,:path => "none"), Base.Docs.DocStr(svec("An expr that produces an `export nffoo` that doesn't produce a Frame\n"), nothing, Dict{Symbol,Any}(:typesig => Union{},:module => Main.Toplevel.NonFrame,:linenumber => 1,:binding => Main.Toplevel.NonFrame,:path => "none"))]
`used` for abstract types: Error During Test at /home/tim/.julia/dev/JuliaInterpreter/test/toplevel.jl:444
  Got exception outside of a @test
  TypeError: in Type, in parameter, expected Type, got Pair{Symbol,Module}
  Stacktrace:
   [1] lookup_or_eval(::Any, ::Frame, ::Any) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:94
   [2] evaluate_abstracttype(::Any, ::Frame, ::Expr) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:319
   [3] step_expr!(::Any, ::Frame, ::Any, ::Bool) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:468
```
(the results depend on what tests were run previously) and now we have
```
frame.framecode.used = BitSet([])
frame.framedata.ssavalues = Any[#undef, #undef, #undef, #undef, #undef]
`used` for abstract types: Error During Test at /home/tim/.julia/dev/JuliaInterpreter/test/toplevel.jl:444
  Got exception outside of a @test
  UndefRefError: access to undefined reference
  Stacktrace:
   [1] getindex at ./array.jl:744 [inlined]
   [2] lookup_var at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:4 [inlined]
   [3] lookup_or_eval(::Any, ::Frame, ::Any) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:77
   [4] lookup_or_eval(::Any, ::Frame, ::Any) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:87
   [5] evaluate_abstracttype(::Any, ::Frame, ::Expr) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:319
   [6] step_expr!(::Any, ::Frame, ::Any, ::Bool) at /home/tim/.julia/dev/JuliaInterpreter/src/interpret.jl:468
```
