### PR TITLE
check if newmod is module in split_expressions!

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -438,6 +438,7 @@ function split_expressions!(modexs, docexprs, lex::Expr, mod::Module, ex::Expr; 
         newname = ex.args[2]::Symbol
         if isdefined(mod, newname)
             newmod = getfield(mod, newname)
+            newmod isa Module || throw(ErrorException("invalid redefinition of constant $(newname)"))
         else
             if (id = Base.identify_package(mod, String(newname))) !== nothing && haskey(Base.loaded_modules, id)
                 newmod = Base.root_module(id)


### PR DESCRIPTION
This throws a more informative error when calling `split_expressions!` on e.g.
```
struct Foo end
module Foo end
```