### PR TITLE
Handle deeper call nesting in `struct`

### DIFF
--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -455,3 +455,19 @@ end
     JuliaInterpreter.finish!(frame, true)
     @test Toplevel.RecursiveType(Vector{Toplevel.RecursiveType}()) isa Toplevel.RecursiveType
 end
+
+# https://github.com/timholy/Revise.jl/issues/420
+module ToplevelParameters
+Base.@kwdef struct MyStruct
+   x::Array{<:Real, 1} = [.05]
+end
+end
+@testset "Nested references in type definitions" begin
+    ex = quote
+        Base.@kwdef struct MyStruct
+           x::Array{<:Real, 1} = [.05]
+        end
+    end
+    frame = JuliaInterpreter.prepare_thunk(ToplevelParameters, ex)
+    @test JuliaInterpreter.finish!(frame, true) === nothing
+end


### PR DESCRIPTION
PR #363 broke certain types of structure definition. Hopefully this fixes it!

Fixes https://github.com/timholy/Revise.jl/issues/420