### PR TITLE
Only eval tuple specification to ccall, use dynamic semantics otherwise.

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -283,7 +283,7 @@ function build_compiled_call!(stmt, fcall, code, idx, nargs, sparams, evalmod)
     end
     dynamic_ccall = false
     if isa(cfunc, Expr)   # specification by tuple, e.g., (:clock, "libc")
-        cfunc = eval(cfunc)
+        cfunc = something(static_eval(cfunc), cfunc)
     end
     if isa(cfunc, Symbol)
         cfunc = QuoteNode(cfunc)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -561,3 +561,11 @@ function Base.display_error(io::IO, er, frame::Frame)
     showerror(IOContext(io, :limit => true), er, frame)
     println(io)
 end
+
+function static_eval(ex)
+    try
+        eval(ex)
+    catch
+        nothing
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/383. Couldn't immediately come up with a test case that resulted in the invalid reinterpret.

Ultimately this is only a workaround, Base has a `static_eval` that returns NULL if the arguments aren't static (as with #383): https://github.com/JuliaLang/julia/blob/4e609128ff5c23424b175be300360ab07e90cba9/src/ccall.cpp#L541