### PR TITLE
add closed over variables to locals and fix code evaluation on them

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -263,15 +263,20 @@ Important fields:
 - `value::Any`: the value of the local variable.
 - `name::Symbol`: the name of the variable as given in the source code.
 - `isparam::Bool`: if the variable is a type parameter, for example `T` in `f(x::T) where {T} = x`.
+- `is_captured_closure::Bool`: if the variable has been captured by a closure
 """
 struct Variable
     value::Any
     name::Symbol
     isparam::Bool
+    is_captured_closure::Bool
 end
+Variable(value, name) = Variable(value, name, false, false)
+Variable(value, name, isparam) = Variable(value, name, isparam, false)
 Base.show(io::IO, var::Variable) = (print(io, var.name, " = "); show(io,var.value))
 Base.isequal(var1::Variable, var2::Variable) =
-    var1.value == var2.value && var1.name == var2.name && var1.isparam == var2.isparam
+    var1.value == var2.value && var1.name == var2.name && var1.isparam == var2.isparam &&
+    var1.is_captured_closure == var2.is_captured_closure
 
 # A type that is unique to this package for which there are no valid operations
 struct Unassigned end


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/250

```jl
julia> function debugfun(non_accessible_variable)
           garbage = ones(10)
           map(1:10) do i
               a = 5
               @bp
               garbage[i] + non_accessible_variable[i]
               non_accessible_variable = 3
           end
       end
debugfun (generic function with 1 method)

julia> @run debugfun(randn(10))
Hit breakpoint:
In #3(i) at REPL[2]:4
 2      garbage = ones(10)
 3      map(1:10) do i
 4          a = 5
●5          @bp
>6          garbage[i] + non_accessible_variable[i]
 7          non_accessible_variable = 3
 8      end
 9  end

About to run: <(getfield)(var"#3#4"{Array{Float64,1}}(Core.Box([0.9940955858203274, -1.0692459508673031, 0.378124117...>
1|julia> garbage[1]
1.0

1|julia> non_accessible_variable[2]
-1.0692459508673031

1|julia> non_accessible_variable = 3
3

1|julia> non_accessible_variable
3
```