### PR TITLE
add ability to evaluate ssavalues and locals

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -493,6 +493,9 @@ julia> JuliaInterpreter.locals(frame)
  #self# = capture
  x = Core.Box(2)
 ```
+
+"Special" values like SSA values and slots (shown in lowered code as e.g. `%3` and `@_4`
+respectively) can be evaluated using the syntax `var"%3"` and `var"@_4"` respectively.
 """
 function eval_code end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -508,7 +508,7 @@ function eval_code(frame::Frame, expr)
     end
     # see https://github.com/JuliaLang/julia/issues/31255 for the Symbol("") check
     vars = filter(v -> v.name != Symbol(""), locals(frame))
-    defined_ssa = findall(!=(0), [isassigned(data.ssavalues, i) for i in 1:length(data.ssavalues)])
+    defined_ssa = findall(x -> x!=0, [isassigned(data.ssavalues, i) for i in 1:length(data.ssavalues)])
     defined_locals = findall(x -> x isa Some, data.locals)
     res = gensym()
     eval_expr = Expr(:let,

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -73,3 +73,14 @@ fr, bp = debug_command(fr, :c)
 @test eval_code(fr, "garbage") == ones(10)
 eval_code(fr, "non_accessible_variable = 5.0")
 @test eval_code(fr, "non_accessible_variable") == 5.0
+
+if VERSION >= v"1.4" # for var"" syntax
+    # Evaluating SSAValues
+    f(x) = x^2
+    frame = JuliaInterpreter.enter_call(f, 5)
+    JuliaInterpreter.step_expr!(frame)
+    JuliaInterpreter.step_expr!(frame)
+    # This could change with changes to Julia lowering
+    @test eval_code(frame, "var\"%2\"") == Val(2)
+    @test eval_code(frame, "var\"@_1\"") == f
+end


### PR DESCRIPTION
```
1|debug>
In sin(x) at special/trig.jl:30
  3  │          Core.NewvarNode(:(n))
  4  │          absx = (abs)(x)
  5  │    %5  = absx
  6  │    %6  = ($(Expr(:static_parameter, 1)))(π)
> 7  │    %7  = (/)(%6, 4)
  8  │    %8  = (<)(%5, %7)
  9  └───       goto #6 if not %8
 10  2 ── %10 = absx
 11  │    %11 = (eps)($(Expr(:static_parameter, 1)))

About to run: (/)(3.141592653589793, 4)
1|julia> var"%5", var"%6"
(2.0, 3.141592653589793)
```