### PR TITLE
Allow caller to specify whether to eval an unlowerable thunk

### DIFF
--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -44,6 +44,8 @@ end
 
     @test JuliaInterpreter.prepare_thunk(Main, :(export foo)) === nothing
     @test JuliaInterpreter.prepare_thunk(Base.Threads, :(global Condition)) === nothing
+    @test_throws ArgumentError JuliaInterpreter.prepare_thunk(Main, :(using NoPkgOfThisName))
+    @test JuliaInterpreter.prepare_thunk(Main, :(using NoPkgOfThisName); eval=false) === nothing
 
     @test !isdefined(Main, :JIInvisible)
     JuliaInterpreter.split_expressions(JIVisible, :(module JIInvisible f() = 1 end))


### PR DESCRIPTION
While I'm not aware of any problems caused by the former setting, when frames are being created for the purpose of analysis rather than execution it seems worth being able to control the evaluation.

Once this merges, OK to release a new version? #395 is a nice new feature, as long as you're comfortable with it I think we should get it out there.