### PR TITLE
Use gensyms when extracting variables

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -619,10 +619,11 @@ end
 function extract_args(__module__, ex0)
     if isa(ex0, Expr)
         if any(a->(isexpr(a, :kw) || isexpr(a, :parameters)), ex0.args)
+            arg1, args, kwargs = gensym("arg1"), gensym("args"), gensym("kwargs")
             return quote
-                local arg1 = $(ex0.args[1])
-                local args, kwargs = $separate_kwargs($(ex0.args[2:end]...))
-                tuple(Core.kwfunc(arg1), kwargs, arg1, args...)
+                $arg1 = $(ex0.args[1])
+                $args, $kwargs = $separate_kwargs($(ex0.args[2:end]...))
+                tuple(Core.kwfunc($arg1), $kwargs, $arg1, $args...)
             end
         elseif ex0.head == :.
             return Expr(:tuple, :getproperty, ex0.args...)

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -68,6 +68,8 @@ struct B{T} end
             @test debug_command(frame, :finish) === nothing
             @test frame.caller === frame.callee === nothing
             @test get_return(frame) == complicated_keyword_stuff(args...; kwargs...)
+
+            @test @interpret(complicated_keyword_stuff(args...; kwargs...)) == complicated_keyword_stuff(args...; kwargs...)
         end
 
         f22() = string(:(a+b))
@@ -477,7 +479,7 @@ struct B{T} end
             @bp
             return b
         end
-        
+
         frame = JuliaInterpreter.enter_call(f, 5, 10)
         frame, pc = JuliaInterpreter.debug_command(frame, :n)
         @test pc isa BreakpointRef


### PR DESCRIPTION
The `local` mechanism only works inside `macro`
Fixes

```julia
julia> args = (1,)
(1,)

julia> kwargs = ()
()

julia> @interpret complicated_keyword_stuff(args...; kwargs...)
ERROR: UndefVarError: kwargs not defined
Stacktrace:
 [1] top-level scope at /home/tim/.julia/dev/JuliaInterpreter/src/construct.jl:624
```

whereas the call works if you name `args` and `kwargs` something different.