### PR TITLE
Improve robustness of `framecode_lines`

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6,4 +6,21 @@ using Test
     @test !JuliaInterpreter.is_quoted_type(QuoteNode(Int32), :Int64)
     @test !JuliaInterpreter.is_quoted_type(QuoteNode(Int32(0)), :Int32)
     @test !JuliaInterpreter.is_quoted_type(Int32, :Int32)
+
+    function buildexpr()
+        items = [7, 3]
+        ex = quote
+            X = $items
+            for x in X
+                println(x)
+            end
+        end
+        return ex
+    end
+    frame = JuliaInterpreter.enter_call(buildexpr)
+    lines = JuliaInterpreter.framecode_lines(frame.framecode.src)
+    # Test that the :copyast ends up on the same line as the println
+    if isdefined(Base.IRShow, :show_ir_stmt)   # only works on Julia 1.6 and higher
+        @test any(str->occursin(":copyast", str) && occursin("println", str), lines)
+    end
 end


### PR DESCRIPTION
If we try the new test in this PR on 1.4:

```julia
julia> function buildexpr()
           items = [7, 3]
           ex = quote
               X = $items
               for x in X
                   println(x)
               end
           end
           return ex
       end
buildexpr (generic function with 1 method)

julia> frame = JuliaInterpreter.enter_call(buildexpr)
Frame for buildexpr() in Main at REPL[2]:2
  1 2  1 ─      items = (Base.vect)(7, 3)
  2 3  │   %2 = (Core._expr)(:(=), :X, items)
  3 3  │   %3 = $(Expr(:copyast, :($(QuoteNode(:(for x = X
⋮

julia> lines = JuliaInterpreter.framecode_lines(frame.framecode.src)
8-element Array{SubString{String},1}:
 "1 ─     _J2 = (Base.vect)(7, 3)"
 "│       (Core._expr)(:(=), :X, _J2)"
 "│       \$(Expr(:copyast, :(\$(QuoteNode(:(for x = X"
 "      #= REPL[2]:6 =#"
 "      println(x)"
 "  end))))))"
 "│       _J3 = (Core._expr)(:block, :(#= REPL[2]:4 =#), %J2, :(#= REPL[2]:5 =#), %J3)"
 "└──     return _J3"
```

8 lines, but the code only has 5 statements:
```julia
julia> length(frame.framecode.src.code)
5
```

In contrast, with this PR on a recent master of Julia 1.6,
```julia
julia> lines = JuliaInterpreter.framecode_lines(frame.framecode.src)
5-element Array{String,1}:
 "1 ─      _2 = Base.vect(7, 3)"
 "│   %2 = Core._expr(:(=), :X, _2)"
 "│   %3 = \$(Expr(:copyast, :(\$(QuoteNode(:(for x = X\n      #= REPL[2]:6 =#\n      println(x)\n  end))))))"
 "│        _3 = Core._expr(:block, \$(QuoteNode(:(#= REPL[2]:4 =#))), %2, \$(QuoteNode(:(#= REPL[2]:5 =#))), %3)"
 "└──      return _3"
```

5 lines. Yeah.

I've verified that Debugger seems to work correctly with both, though. I'm not exactly sure how that happens. So maybe this isn't as useful as I thought?