### PR TITLE
Add an "egal" variant of `is_quotenode`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -144,6 +144,7 @@ Tests whether `g` is equal to `GlobalRef(mod, name)`.
 is_global_ref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name == name
 
 is_quotenode(@nospecialize(q), @nospecialize(val)) = isa(q, QuoteNode) && q.value == val
+is_quotenode_egal(@nospecialize(q), @nospecialize(val)) = isa(q, QuoteNode) && q.value === val
 
 function is_quoted_type(@nospecialize(a), name::Symbol)
     if isa(a, QuoteNode)
@@ -171,14 +172,14 @@ is_dummy(bpref::BreakpointRef) = bpref.stmtidx == 0 && bpref.err === nothing
 
 if VERSION >= v"1.4.0-DEV.304"
     function unpack_splatcall(stmt)
-        if isexpr(stmt, :call) && length(stmt.args) >= 3 && is_quotenode(stmt.args[1], Core._apply_iterate)
+        if isexpr(stmt, :call) && length(stmt.args) >= 3 && is_quotenode_egal(stmt.args[1], Core._apply_iterate)
             return true, stmt.args[3]
         end
         return false, nothing
     end
 else
     function unpack_splatcall(stmt)
-        if isexpr(stmt, :call) && length(stmt.args) >= 2 && is_quotenode(stmt.args[1], Core._apply)
+        if isexpr(stmt, :call) && length(stmt.args) >= 2 && is_quotenode_egal(stmt.args[1], Core._apply)
             return true, stmt.args[2]
         end
         return false, nothing


### PR DESCRIPTION
To prevent invalidations one wants to avoid `==` and use `===` in circumstances where types can't be inferred.

I should have thought of this earlier, as it would have saved some uglification.