### PR TITLE
Widen allowed type of a CodeInfo.linetable

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -268,7 +268,7 @@ function linetable(arg)
     if isa(arg, FrameCode)
         arg = arg.src
     end
-    return (arg::CodeInfo).linetable::Vector{Any}
+    return (arg::CodeInfo).linetable::Union{Vector{Core.LineInfoNode},Vector{Any}}  # issue #264
 end
 linetable(arg, i::Integer) = linetable(arg)[i]::Union{Expr,LineTypes}
 


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/264

CC @mbauman.
