### PR TITLE
fixes maybe problematic condition check of `prepare_thunk`

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -360,8 +360,8 @@ function prepare_thunk(mod::Module, thunk::Expr, recursive::Bool=false; eval::Bo
         error("lowering returned an error, ", thunk)
     elseif recursive
         thunk = Meta.lower(mod, thunk)
-        if isa(thunk, Expr)
-            # If on 2nd attempt to lower it's still an Expr, just evaluate it
+        if !isexpr(thunk, :thunk)
+            # If on 2nd attempt to lower it's still an non-thunk Expr, just evaluate it
             eval && Core.eval(mod, thunk)
             return nothing
         end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -320,6 +320,10 @@ f113(;x) = x
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) == :NoOS 1+1 end)), Nothing)
 @test isa(JuliaInterpreter.prepare_thunk(Main, :(Base.BaseDocs.@kw_str "using")), Nothing)
 
+# https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/419
+@test JuliaInterpreter.prepare_thunk(Main, quote true end) === nothing
+@test JuliaInterpreter.prepare_thunk(Main, quote true end, true) === nothing
+
 @testset "locals" begin
     f_locals(x::Int64, y::T, z::Vararg{Symbol}) where {T} = x
     frame = JuliaInterpreter.enter_call(f_locals, Int64(1), 2.0, :a, :b)


### PR DESCRIPTION
I just looked at the code base and found this condition check is maybe problematic -- we should "escape" (i.e. "just evaluate") if `thunk` is not `isexpr(thunk, :thunk)`.
I don't have a MRE which causes actual problem by this though (and so I didn't add test on this)