### PR TITLE
Improve inference for several methods leading to (:)

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -296,7 +296,7 @@ function inplace_lookup!(ex, i, frame)
     if isa(a, SSAValue) || isa(a, SlotNumber)
         ex.args[i] = lookup_var(frame, a)
     elseif isexpr(a, :call)
-        for j = 1:length(a.args)
+        for j = 1:length((a::Expr).args)
             inplace_lookup!(a, j, frame)
         end
     end
@@ -458,7 +458,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                 rhs = node.args[1]
                 push!(data.exception_frames, rhs)
             elseif node.head === :leave
-                for _ = 1:node.args[1]
+                for _ = 1:node.args[1]::Int
                     pop!(data.exception_frames)
                 end
             elseif node.head === :pop_exception

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -421,19 +421,21 @@ function reverse_lookup_globalref!(list)
     # This only handles the function in calls
     for (i, stmt) in enumerate(list)
         if isexpr(stmt, :(=))
-            stmt = stmt.args[2]
+            stmt = (stmt::Expr).args[2]
         end
         if isexpr(stmt, :call)
+            stmt = stmt::Expr
             f = stmt.args[1]
             if isa(f, QuoteNode)
                 f = f.value
                 if isa(f, Function) && !isa(f, Core.IntrinsicFunction)
                     ft = typeof(f)
-                    name = String(ft.name.name)
+                    tn = ft.name::Core.TypeName
+                    name = String(tn.name)
                     if startswith(name, '#')
                         name = name[2:end]
                     end
-                    stmt.args[1] = GlobalRef(ft.name.module, Symbol(name))
+                    stmt.args[1] = GlobalRef(tn.module, Symbol(name))
                 end
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -294,8 +294,8 @@ function lineoffset(framecode::FrameCode)
     return offset
 end
 
-getline(ln) = Int(isexpr(ln, :line) ? ln.args[1] : ln.line)
-getfile(ln) = CodeTracking.maybe_fixup_stdlib_path(String(isexpr(ln, :line) ? ln.args[2] : ln.file))
+getline(ln) = Int(isexpr(ln, :line) ? ln.args[1] : ln.line)::Int
+getfile(ln) = CodeTracking.maybe_fixup_stdlib_path(String(isexpr(ln, :line) ? ln.args[2] : ln.file)::String)
 
 """
     loc = whereis(frame, pc=frame.pc)


### PR DESCRIPTION
This fixes a number of inference problems detect via `MethodAnalysis.findcallers` looking for calls to `Colon(::Int, ::Real)`. (The real culprits I was looking for were elsewhere, but it doesn't pay to have distractors in the tooling.)