### PR TITLE
Improve inference and add precompiles in ExprSplitter

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -23,6 +23,8 @@ function _precompile_()
     @assert precompile(Tuple{Type{Frame}, Module, Expr})
     @assert precompile(Tuple{Type{ExprSplitter}, Module, Expr})
     # @assert precompile(Tuple{typeof(Core.kwfunc(ExprSplitter)), NamedTuple{(:lnn,),Tuple{LineNumberNode}}, typeof(ExprSplitter), Module, Expr})
+    @assert precompile(Tuple{typeof(queuenext!), ExprSplitter})
+    @assert precompile(Tuple{typeof(Base.iterate), ExprSplitter})  # won't entirely work, but any dependents might help
     @assert precompile(Tuple{typeof(prepare_framedata), FrameCode, Vector{Any}, SimpleVector, Bool})
     @assert precompile(Tuple{typeof(prepare_args), Any, Vector{Any}, Vector{Any}})
     @assert precompile(Tuple{typeof(prepare_call), Any, Vector{Any}})

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -233,12 +233,13 @@ Test whether expression `ex` is a `@doc` expression.
 function is_doc_expr(@nospecialize(ex))
     docsym = Symbol("@doc")
     if isexpr(ex, :macrocall)
+        ex::Expr
         a = ex.args[1]
         is_global_ref(a, Core, docsym) && return true
         isa(a, Symbol) && a == docsym && return true
         if isexpr(a, :.)
             mod, name = (a::Expr).args[1], (a::Expr).args[2]
-            return mod === :Core && isa(name, QuoteNode) && name.value == docsym
+            return mod === :Core && isa(name, QuoteNode) && name.value === docsym
         end
     end
     return false


### PR DESCRIPTION
These make a substantial contribution to reducing latency for Revise 3, specifically in the area of handling atsign-require blocks.