### PR TITLE
Improve inference in several places

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -156,7 +156,7 @@ end
 
 function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointFileLocation)
     if framecode.scope isa Method
-        meth = framecode.scope
+        meth = framecode.scope::Method
         methpath = CodeTracking.maybe_fix_path(String(meth.file))
         ispath(methpath) && (methpath = realpath(methpath))
         if bp.abspath == methpath || endswith(methpath, bp.path)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -158,7 +158,7 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
                         argtypes, sig)::SimpleVector
     enter_generated &= is_generated(method)
     if is_generated(method) && !enter_generated
-        framecode = get(genframedict, (method, argtypes), nothing)
+        framecode = get(genframedict, (method, argtypes::Type), nothing)
     else
         framecode = get(framedict, method, nothing)
     end
@@ -505,7 +505,7 @@ function queuenext!(iter::ExprSplitter)
             end
         end
     elseif head === :macrocall
-        iter.lnn = ex.args[2]
+        iter.lnn = ex.args[2]::LineNumberNode
     elseif head === :block || head === :toplevel
         # Container expression
         idx = iter.index[end]

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -100,7 +100,6 @@ function lookup_or_eval(@nospecialize(recurse), frame, @nospecialize(node))
                 error("unknown call f ", f)
             end
         else
-            dump(ex)
             error("unknown expr ", ex)
         end
     elseif isa(node, Int) || isa(node, Number)   # Number is slow, requires subtyping
@@ -425,10 +424,10 @@ const _location = Dict{Tuple{Method,Int},Int}()
 
 function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplevel::Bool)
     pc, code, data = frame.pc, frame.framecode, frame.framedata
-    if !is_leaf(frame)
-        show_stackloc(frame)
-        @show node
-    end
+    # if !is_leaf(frame)
+    #     show_stackloc(frame)
+    #     @show node
+    # end
     @assert is_leaf(frame)
     local rhs
     # For debugging:
@@ -557,9 +556,9 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
     end
     @isdefined(rhs) && isa(rhs, BreakpointRef) && return rhs
     if isassign(frame, pc)
-        if !@isdefined(rhs)
-            @show frame node
-        end
+        # if !@isdefined(rhs)
+        #     @show frame node
+        # end
         lhs = SSAValue(pc)
         do_assignment!(frame, lhs, rhs)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -208,7 +208,7 @@ function is_bodyfunc(@nospecialize(arg))
         arg = arg.value
     end
     if isa(arg, Function)
-        fname = String(typeof(arg).name.name)
+        fname = String((typeof(arg).name::Core.TypeName).name)
         return startswith(fname, "##") && match(r"#\d+$", fname) !== nothing
     end
     return false
@@ -319,8 +319,8 @@ function CodeTracking.whereis(framecode::FrameCode, pc::Int)
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
     lineinfo = linetable(framecode, codeloc)
-    return isa(framecode.scope, Method) ?
-        whereis(lineinfo, framecode.scope) : (getfile(lineinfo), getline(lineinfo))
+    m = framecode.scope
+    return isa(m, Method) ? whereis(lineinfo, m) : (getfile(lineinfo), getline(lineinfo))
 end
 CodeTracking.whereis(frame::Frame, pc::Int=frame.pc) = whereis(frame.framecode, pc)
 


### PR DESCRIPTION
This disabling of the debugging statements may be a bit unfortunate,
but we haven't needed them lately and they are easy to uncomment.

xref https://github.com/timholy/CodeTracking.jl/pull/73