### PR TITLE
Don't look up `invoke` args twice

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -177,11 +177,11 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(ifelse(getargs(args, frame)...))
         end
     elseif f === invoke
-            argswrapped = getargs(args, frame)
             if !expand
+                argswrapped = getargs(args, frame)
                 return Some{Any}(invoke(argswrapped...))
             end
-            return Expr(:call, invoke, argswrapped...)
+            return Expr(:call, invoke, args[2:end]...)
     elseif f === isa
         if nargs == 2
             return Some{Any}(isa(@lookup(frame, args[2]), @lookup(frame, args[3])))

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -693,6 +693,10 @@ end
     f(m::AbstractMatrix{T}) where {T} = T
     D = Diagonal([1.0, 2.0])
     @test @interpret(f(D)) === f(D)
+
+    # issue #441
+    flog() = @info "logging macros"
+    @test @interpret flog() === nothing
 end
 
 struct A396


### PR DESCRIPTION
`evaluate_call_recurse!` calls `maybe_evaluate_builtin`, and if
that doesn't return a `Some{Any}`, it uses the output as the
new `call_expr`. The next thing it does is look up the args.
Consequently, to avoid double-lookup, our expansion of `invoke` should
return the non-looked-up arguments.

Fixes #441
Closes #440