### PR TITLE
Respect namespace in method definitions

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -264,7 +264,7 @@ function evaluate_methoddef(frame, node)
     f = node.args[1]
     if isa(f, Symbol)
         mod = moduleof(frame)
-        if Base.isbindingresolved(mod, f)  # `isdefined` accesses the binding, making it impossible to create a new one
+        if Base.isbindingresolved(mod, f) && isdefined(mod, f)  # `isdefined` accesses the binding, making it impossible to create a new one
             f = getfield(mod, f)
         else
             f = Core.eval(moduleof(frame), Expr(:function, f))  # create a new function

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -264,7 +264,19 @@ function evaluate_methoddef(frame, node)
     f = node.args[1]
     if isa(f, Symbol)
         mod = moduleof(frame)
-        f = isdefined(mod, f) ? getfield(mod, f) : Core.eval(moduleof(frame), Expr(:function, f))  # create a new function
+        createnew = true
+        if isdefined(mod, f)
+            flkup = getfield(mod, f)
+            fmod = typeof(flkup).name.module
+            if fmod === scopeof(frame)
+                f = flkup
+                createnew = false
+            end
+        end
+        if createnew
+            @show f typeof(f) moduleof(frame)
+            f = Core.eval(moduleof(frame), Expr(:function, f))  # create a new function
+        end
     end
     length(node.args) == 1 && return f
     sig = @lookup(frame, node.args[2])::SimpleVector

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -244,7 +244,11 @@ module Namespace end
         JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
     end
     @test Namespace.sin(0) == 10
-    @test Base.sin(0) == 0
+    if Base.VERSION >= v"1.5"
+        @test Base.sin(0) == 0
+    else
+        @test_broken Base.sin(0) == 0
+    end
 end
 
 # incremental interpretation solves world-age problems

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -235,6 +235,18 @@ module Toplevel end
    @test Toplevel.Testing.Frame === Frame
 end
 
+# Proper handling of namespaces
+# https://github.com/timholy/Revise.jl/issues/579
+module Namespace end
+@testset "Namespace" begin
+    frame = Frame(Namespace, :(sin(::Int) = 10))
+    while true
+        JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
+    end
+    @test Namespace.sin(0) == 10
+    @test Base.sin(0) == 0
+end
+
 # incremental interpretation solves world-age problems
 # Taken straight from Julia's test/tuple.jl
 module IncTest

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -248,6 +248,7 @@ module Namespace end
         @test Base.sin(0) == 0
     else
         @test_broken Base.sin(0) == 0
+        Core.eval(Base, :(sin(x::Int) = sin(float(x))))    # fix the definition of `sin`
     end
 end
 


### PR DESCRIPTION
The symbol-lookup in `evaluate_methoddef` was not careful about
avoiding extending methods in Base when the method was unqualified.

Fixes https://github.com/timholy/Revise.jl/issues/579

-------------------

Unfortunately, this doesn't currently work:
```julia
julia> using JuliaInterpreter, Test

julia> module Namespace end
Main.Namespace

julia> @testset "Namespace" begin
           frame = Frame(Namespace, :(sin(::Int) = 10))
           while true
               JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
           end
           @test Namespace.sin(0) == 10
           @test Base.sin(0) == 0
       end
f = :sin
typeof(f) = Symbol
moduleof(frame) = Main.Namespace
Namespace: Error During Test at REPL[3]:1
  Got exception outside of a @test
  error in method definition: function Base.sin must be explicitly imported to be extended
  Stacktrace:
    [1] top-level scope
      @ none:0
    [2] top-level scope
      @ none:1
    [3] eval
      @ ./boot.jl:360 [inlined]
    [4] evaluate_methoddef(frame::Frame, node::Expr)
      @ JuliaInterpreter ~/.julia/dev/JuliaInterpreter/src/interpret.jl:278
...
```

What I don't understand is, this does:
```julia
julia> module Namespace end
Main.Namespace

julia> module DefineSin
       createsin() = Core.eval(Main.Namespace, Expr(:function, :sin))
       defsin() = Core.eval(Main.Namespace, :(sin(::Int) = 10))
       end
Main.DefineSin

julia> DefineSin.createsin()
sin (generic function with 0 methods)

julia> DefineSin.defsin()
sin (generic function with 1 method)

julia> Base.sin(0)
0.0

julia> Namespace.sin(0)
10
```
and this basically mimics what's going on in `evaluate_methoddef`. Any ideas?