### PR TITLE
CI: less redundancy, push coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,6 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
-          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -45,3 +44,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - master
+    tags: '*'
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -16,6 +19,7 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Right now PRs from non-fork branches run twice on each platform.
This eliminates the redundancy.

~Also test 1.6 explicitly.~ Nvm, no binary yet.

Also push coverage.