### PR TITLE
Better handling of CGlobal & :call unnesting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,8 @@ jobs:
           - windows-latest
         arch:
           - x64
+    env:
+      PYTHON: ""
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,10 @@ julia = "1"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TableReader = "70df011a-6618-58d7-8e16-3cf9e384cb47"
@@ -25,4 +27,4 @@ Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Dates", "Distributed", "LinearAlgebra", "Mmap", "SHA", "SparseArrays", "Tensors", "TableReader", "DataFrames"]
+test = ["Test", "Dates", "Distributed", "HTTP", "LinearAlgebra", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "TableReader", "DataFrames"]

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -231,9 +231,14 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     # Intrinsics
     elseif f === Base.cglobal
         if nargs == 1
+            call_expr = copy(call_expr)
+            args2 = args[2]
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         elseif nargs == 2
             call_expr = copy(call_expr)
+            args2 = args[2]
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
             call_expr.args[3] = @lookup(frame, args[3])
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -56,7 +56,7 @@ function renumber_ssa!(stmts::Vector{Any}, ssalookup)
         elseif isa(stmt, Expr)
             replace_ssa!(stmt, ssalookup)
             if (stmt.head === :gotoifnot || stmt.head === :enter) && isa(stmt.args[end], Int)
-                stmt.args[end] = ssalookup[stmt.args[end]]
+                stmt.args[end] = jumplookup(ssalookup, stmt.args[end])
             end
         elseif is_GotoIfNot(stmt)
             cond = stmt.cond

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -212,6 +212,16 @@ val = @interpret(BigInt())
 @test isa(val, BigInt) && val == 0
 @test isa(@interpret(Base.GMP.version()), VersionNumber)
 
+# Issue #455
+using PyCall
+let np = pyimport("numpy")
+    @test @interpret(PyCall.pystring_query(np.zeros)) === Union{}
+end
+# Issue #354 (partial fix)
+using HTTP
+headers = Dict("User-Agent" => "Debugger.jl")
+@test_broken @interpret(HTTP.request("GET", "https://api.github.com/", headers))
+
 # "correct" line numbers
 defline = @__LINE__() + 1
 function f(x)


### PR DESCRIPTION
This supports SSAValue args for cglobal while also fixing a bug
in which a GotoIfNot ended up going to the wrong statement.
The latter was a consequence of incorrect :call unnesting.

Fixes #455
Fixes #454
Fixes #415
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/275
Improves #354