### PR TITLE
Don't interpret `Base.load_state_acquire`

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -100,8 +100,10 @@ function set_compiled_methods()
     end
 
     # Does an atomic operation via llvmcall (this fixes #354)
-    for m in methods(Base.load_state_acquire)
-        push!(compiled_methods, m)
+    if isdefined(Base, :load_state_acquire)
+        for m in methods(Base.load_state_acquire)
+            push!(compiled_methods, m)
+        end
     end
 
     ###########

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -99,6 +99,11 @@ function set_compiled_methods()
         end
     end
 
+    # Does an atomic operation via llvmcall (this fixes #354)
+    for m in methods(Base.load_state_acquire)
+        push!(compiled_methods, m)
+    end
+
     ###########
     # Modules #
     ###########

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -229,10 +229,10 @@ using PyCall
 let np = pyimport("numpy")
     @test @interpret(PyCall.pystring_query(np.zeros)) === Union{}
 end
-# Issue #354 (partial fix)
+# Issue #354
 using HTTP
 headers = Dict("User-Agent" => "Debugger.jl")
-@test_broken @interpret(HTTP.request("GET", "https://api.github.com/", headers))
+@test @interpret(HTTP.request("GET", "https://api.github.com/", headers))
 
 # "correct" line numbers
 defline = @__LINE__() + 1

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -232,7 +232,7 @@ end
 # Issue #354
 using HTTP
 headers = Dict("User-Agent" => "Debugger.jl")
-@test @interpret(HTTP.request("GET", "https://api.github.com/", headers))
+@test @interpret(HTTP.request("GET", "https://api.github.com/", headers)) isa HTTP.Messages.Response
 
 # "correct" line numbers
 defline = @__LINE__() + 1


### PR DESCRIPTION
This has an llvmcall doing an atomic operation...just avoid the hassle
and call it directly.

Fixes #354