### PR TITLE
Push a few ccalling methods onto compiled_methods

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -106,6 +106,13 @@ function set_compiled_methods()
         end
     end
 
+    # This is about performance, not safety (issue #462)
+    push!(compiled_methods, which(nameof, (Module,)))
+    push!(compiled_methods, which(Base.binding_module, (Module, Symbol)))
+    push!(compiled_methods, which(Base.unsafe_pointer_to_objref, (Ptr,)))
+    push!(compiled_methods, which(Vector{Int}, (UndefInitializer, Int)))
+    push!(compiled_methods, which(fill!, (Vector{Int8}, Int)))
+
     ###########
     # Modules #
     ###########


### PR DESCRIPTION
These methods trigger compilation of `build_compiled_call!` during
Revise.revise(). Since they are essentially `ccall`-wrappers already,
there's not a lot of value in interpreting them.

Saves another ~100ms off the latency.

Closes #462