### PR TITLE
eliminate type instabilities

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -82,8 +82,8 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
         end
     end
 
-    framecode.scope isa Method || return false
     meth = framecode.scope
+    meth isa Method || return false
     bp.f isa Method && return meth === bp.f
     bp.f === extract_function_from_method(meth) || return false
     bp.sig === nothing && return true

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -256,13 +256,13 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     method = whichtt(argtypes)
     if method === nothing
         # Call it to generate the exact error
-        f(allargs[2:end]...)
+        return f(allargs[2:end]...)
     end
     ret = prepare_framecode(method, argtypes; enter_generated=enter_generated)
     # Exceptional returns
     if ret === nothing
         # The generator threw an error. Let's generate the same error by calling it.
-        f(allargs[2:end]...)
+        return f(allargs[2:end]...)
     end
     isa(ret, Compiled) && return ret, argtypes
     # Typical return

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -17,7 +17,7 @@ function lookup_expr(frame, e::Expr)
         if isassigned(frame.framedata.sparams, arg)
             return frame.framedata.sparams[arg]
         else
-            syms = sparam_syms(frame.framecode.scope)
+            syms = sparam_syms(frame.framecode.scope::Method)
             throw(UndefVarError(syms[arg]))
         end
     end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -289,6 +289,7 @@ function build_compiled_call!(stmt::Expr, fcall, code, idx, nargs::Int, sparams:
                         lhs = expr.args[1]
                         return lhs isa SlotNumber && lhs.id === arg.id
                     end
+                    index = index::Int
                     unsafe_convert_expr = code.code[index]::Expr
                     push!(delete_idx, index) # delete the unsafe_convert
                     push!(args, unsafe_convert_expr.args[2])


### PR DESCRIPTION
I self-profiled JET and found some places where we can yet more improve:
```
julia> using JET

julia> tt = (JET.Frame, Bool)
(JuliaInterpreter.Frame, Bool)

julia> @time report_call(JET.step_expr!, tt)
```

<details><summary>On master</summary>

```julia
═════ 28 possible errors found ═════
┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:590 JuliaInterpreter.step_expr!(JuliaInterpreter.finish_and_return!, frame, istoplevel)
│┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:60 JuliaInterpreter.lookup_expr(frame, ##node#261)
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:20 JuliaInterpreter.sparam_syms(Base.getproperty(Base.getproperty(frame, :framecode), :scope))
│││ for one of the union split cases, no matching method found for signature: JuliaInterpreter.sparam_syms(Base.getproperty(Base.getproperty(frame::JuliaInterpreter.Frame, :framecode::Symbol)::JuliaInterpreter.FrameCode, :scope::Symbol)::Union{Method, Module})
││└───────────────────────────────────────────────────────────────────────
│┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:201 JuliaInterpreter.#evaluate_call_recurse!#60(false, #self#, recurse, frame, call_expr)
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:204 JuliaInterpreter.maybe_evaluate_builtin(frame, call_expr, true)
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:139 Core.arrayset(_250, _256)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_250::Any, _256::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:137 Core.arrayset(_244)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_244::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:123 Core.arrayref(_160, _166)
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)(_160::Any, _166::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:135 Core.arrayset()
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)()
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:141 Core.arrayset(_262, _268, _274)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_262::Any, _268::Any, _274::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:205 JuliaInterpreter.isdefined(_478)
││││ invalid builtin function call: JuliaInterpreter.isdefined(_478::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:119 Core.arrayref()
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)()
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:121 Core.arrayref(_154)
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)(_154::Any)
│││└───────────────────────────────────────────────────────────────────────
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:218 Core.kwfunc(JuliaInterpreter.prepare_framecode)(Core.apply_type(Core.NamedTuple, (:enter_generated,))(Core.tuple(enter_generated)), JuliaInterpreter.prepare_framecode, f_invoked, sig)
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:152 JuliaInterpreter.#prepare_framecode#37(enter_generated, _3, method, argtypes)
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:170 Base.getproperty(Core.Compiler, :get_staged)(JuliaInterpreter.specialize_method(method, argtypes, lenv))
│││││┌ @ compiler/utilities.jl:116 Core.Compiler.may_invoke_generator(mi)
││││││┌ @ reflection.jl:1082 Core.Compiler.may_invoke_generator(Core.typeassert(Core.Compiler.getproperty(method, :def), Core.Compiler.Method), Core.Compiler.getproperty(method, :specTypes), Core.Compiler.getproperty(method, :sparam_vals))
│││││││┌ @ reflection.jl:1096 Core.Compiler.methods(Core.Compiler.getproperty(generator, :gen))
││││││││┌ @ reflection.jl:963 #self#(f, Core.Compiler.nothing)
│││││││││┌ @ reflection.jl:963 Core.Compiler.methods(f, Core.apply_type(Core.Compiler.Tuple, Core.apply_type(Core.Compiler.Vararg, Core.Compiler.Any)), mod)
││││││││││┌ @ reflection.jl:942 Core.Compiler.iterate(Core.Compiler._methods(f, t, -1, world), Core.getfield(_5, 2))
│││││││││││┌ @ array.jl:778 Core.Compiler.%(i, Core.Compiler.UInt)
││││││││││││ no matching method found for call signature: Core.Compiler.%(i::Nothing, Core.Compiler.UInt)
│││││││││││└────────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:175 JuliaInterpreter.get_source(Base.getproperty(method, :generator), lenv)
│││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:85 g(env, Base.getproperty(g, :argnames)...)
││││││┌ @ boot.jl:589 Core.Expr(Core.tuple(Core.Symbol("with-static-parameters"), lam), Core.getproperty(g, :spnames)...)
│││││││ no matching method found for call signature: Core.Expr(Core.tuple(Core.Symbol("with-static-parameters")::Symbol, lam::Expr)::Tuple{Symbol, Expr}, Core.getproperty(g::Core.GeneratedFunctionStub, :spnames::Symbol)::Union{Nothing, Vector{Any}}...)
││││││└───────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:190 Core.kwfunc(JuliaInterpreter.FrameCode)(Core.apply_type(Core.NamedTuple, (:generator,))(Core.tuple(generator)), JuliaInterpreter.FrameCode, method, code)
│││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:100 JuliaInterpreter.#FrameCode#1(generator, optimize, _3, scope, src)
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:101 JuliaInterpreter.optimize!(JuliaInterpreter.copy_codeinfo(src), scope)
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:185 JuliaInterpreter.build_compiled_call!(stmt, Base.llvmcall, code, idx, nargs, sparams, evalmod)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:338 JuliaInterpreter.get(JuliaInterpreter.compiled_calls, cc_key, JuliaInterpreter.nothing)
│││││││││┌ @ dict.jl:505 Base.ht_keyindex(h, key)
││││││││││┌ @ dict.jl:291 Base.isequal(key, Base.getindex(keys, index))
│││││││││││┌ @ tuple.jl:349 Base._isequal(t1, t2)
││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
││││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││││││┌ @ tuple.jl:352 Base.getindex(t1, 1)
││││││││││││││││││┌ @ tuple.jl:29 Base.getfield(t, i, $(Expr(:boundscheck)))
│││││││││││││││││││ invalid builtin function call: Base.getfield(t::Tuple{}, i::Int64, $(Expr(:boundscheck)))
││││││││││││││││││└───────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:126 JuliaInterpreter.add_breakpoint_if_match!(framecode, bp)
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:64 JuliaInterpreter.framecode_matches_breakpoint(framecode, bp)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:163 JuliaInterpreter.method_contains_line(meth, Base.getproperty(bp, :line))
│││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:404 JuliaInterpreter.compute_corrected_linerange(method)
││││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:394 JuliaInterpreter.whereis(method)
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 Base.getindex(lin, Base.lastindex(lin))
││││││││││││ for one of the union split cases, no matching method found for signature: Base.getindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}, Base.lastindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}})::Int64)
│││││││││││└──────────────────────────────────────────────────────────────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:124 JuliaInterpreter.add_breakpoint_if_match!(framecode, bp)
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:64 JuliaInterpreter.framecode_matches_breakpoint(framecode, bp)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:88 extract_function_from_method(meth)
│││││││││ for one of the union split cases, no matching method found for signature: extract_function_from_method::JuliaInterpreter.var"#extract_function_from_method#87"(meth::Union{Method, Module})
││││││││└─────────────────────────────────────────────────────────────────────────
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 Base.lastindex(lin)
││││││││││││ for one of the union split cases, no matching method found for signature: Base.lastindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}})
│││││││││││└──────────────────────────────────────────────────────────────────────
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:168 JuliaInterpreter.whereis(framecode, 1)
│││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:359 JuliaInterpreter.whereis(lineinfo, m)
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:107 CodeTracking.String(Base.getproperty(lineinfo, :file))
│││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lineinfo::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││└───────────────────────────────────────────────────────────────────────
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:105 CodeTracking.String(Base.getproperty(lineinfo, :file))
│││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lineinfo::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││└───────────────────────────────────────────────────────────────────────
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:192 JuliaInterpreter.build_compiled_call!(stmt, :ccall, code, idx, nargs, sparams, evalmod)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:293 JuliaInterpreter.push!(delete_idx, index)
│││││││││┌ @ array.jl:929 Base.convert(_, item)
││││││││││ no matching method found for call signature: Base.convert(_::Type{Int64}, item::Nothing)
│││││││││└────────────────
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:105 Base.getproperty(lineinfo, :file)
│││││││││││┌ @ Base.jl:33 Base.getfield(x, f)
││││││││││││ type Expr has no field file
│││││││││││└──────────────
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 CodeTracking.fileline(Base.getindex(Base.getindex(lin, Base.lastindex(lin)), 1))
││││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/utils.jl:54 CodeTracking.String(Base.getproperty(lnn, :file))
│││││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lnn::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││││└───────────────────────────────────────────────────────────────
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:225 Core.kwfunc(JuliaInterpreter.get_call_framecode)(Core.apply_type(Core.NamedTuple, (:enter_generated,))(Core.tuple(enter_generated)), JuliaInterpreter.get_call_framecode, fargs, Base.getproperty(frame, :framecode), Base.getproperty(frame, :pc))
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:11 JuliaInterpreter.#get_call_framecode#55(enter_generated, _3, fargs, parentframe, idx)
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:26 JuliaInterpreter.is_generated(JuliaInterpreter.scopeof(Base.getproperty(fi, :framecode)))
│││││ for one of the union split cases, no matching method found for signature: JuliaInterpreter.is_generated(JuliaInterpreter.scopeof(Base.getproperty(fi::JuliaInterpreter.FrameInstance, :framecode::Symbol)::JuliaInterpreter.FrameCode)::Union{Method, Module})
││││└────────────────────────────────────────────────────────────────────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:63 Core.kwfunc(JuliaInterpreter.prepare_call)(Core.apply_type(Core.NamedTuple, (:enter_generated,))(Core.tuple(enter_generated)), JuliaInterpreter.prepare_call, f, fargs)
│││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:249 JuliaInterpreter.#prepare_call#40(enter_generated, _3, f, allargs)
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:261 Core.kwfunc(JuliaInterpreter.prepare_framecode)(Core.apply_type(Core.NamedTuple, (:enter_generated,))(Core.tuple(enter_generated)), JuliaInterpreter.prepare_framecode, method, argtypes)
│││││││ for one of the union split cases, no matching method found for signature: Core.kwfunc(JuliaInterpreter.prepare_framecode)::JuliaInterpreter.var"#prepare_framecode##kw"(Core.apply_type(Core.NamedTuple, (:enter_generated,)::Tuple{Symbol})::Type{NamedTuple{(:enter_generated,), T} where T<:Tuple}(Core.tuple(enter_generated::Bool)::Tuple{Bool})::NamedTuple{(:enter_generated,), Tuple{Bool}}, JuliaInterpreter.prepare_framecode, method::Union{Nothing, Method}, argtypes::Type)
││││││└────────────────────────────────────────────────────────────────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:269 Base.indexed_iterate(ret, 1)
│││││││┌ @ tuple.jl:89 Base.iterate(I)
││││││││ no matching method found for call signature: Base.iterate(I::Nothing)
│││││││└───────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:269 Base.indexed_iterate(ret, 2, _6)
│││││││┌ @ tuple.jl:94 Base.iterate(I, state)
││││││││ no matching method found for call signature: Base.iterate(I::Nothing, state::Int64)
│││││││└───────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:270 JuliaInterpreter.is_generated(method)
│││││││ for one of the union split cases, no matching method found for signature: JuliaInterpreter.is_generated(method::Union{Nothing, Method})
││││││└────────────────────────────────────────────────────────────────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:72 JuliaInterpreter.is_generated(JuliaInterpreter.scopeof(framecode))
│││││ for one of the union split cases, no matching method found for signature: JuliaInterpreter.is_generated(JuliaInterpreter.scopeof(framecode::Any)::Union{Method, Module})
││││└────────────────────────────────────────────────────────────────────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:80 Base.getproperty(d_methtmp, :next)
│││││┌ @ Base.jl:33 Base.getfield(x, f)
││││││ invalid builtin function call: Base.getfield(x::Nothing, f::Symbol)
│││││└──────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/localmethtable.jl:86 Base.setproperty!(d_methtmp, :next, JuliaInterpreter.nothing)
│││││┌ @ Base.jl:34 Base.fieldtype(Base.typeof(x), f)
││││││ invalid builtin function call: Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
│││││└──────────────
 15.027014 seconds (49.94 M allocations: 2.114 GiB, 5.71% gc time)
Union{Nothing, Int64, JuliaInterpreter.BreakpointRef}
```

</details>

<details><summary>Evaluate each patch on this branch, and re-profile</summary>

```julia
═════ 17 possible errors found ═════
┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:590 JuliaInterpreter.step_expr!(JuliaInterpreter.finish_and_return!, frame, istoplevel)
│┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:201 JuliaInterpreter.#evaluate_call_recurse!#60(false, #self#, recurse, frame, call_expr)
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:204 JuliaInterpreter.maybe_evaluate_builtin(frame, call_expr, true)
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:205 JuliaInterpreter.isdefined(_478)
││││ invalid builtin function call: JuliaInterpreter.isdefined(_478::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:121 Core.arrayref(_154)
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)(_154::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:119 Core.arrayref()
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)()
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:123 Core.arrayref(_160, _166)
││││ invalid builtin function call: Core.arrayref::typeof(Core.arrayref)(_160::Any, _166::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:137 Core.arrayset(_244)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_244::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:135 Core.arrayset()
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)()
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:139 Core.arrayset(_250, _256)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_250::Any, _256::Any)
│││└───────────────────────────────────────────────────────────────────────
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/builtins.jl:141 Core.arrayset(_262, _268, _274)
││││ invalid builtin function call: Core.arrayset::typeof(Core.arrayset)(_262::Any, _268::Any, _274::Any)
│││└───────────────────────────────────────────────────────────────────────
││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/interpret.jl:218 Core.kwfunc(JuliaInterpreter.prepare_framecode)(Core.apply_type(Core.NamedTuple, (:enter_generated,))(Core.tuple(enter_generated)), JuliaInterpreter.prepare_framecode, f_invoked, sig)
│││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:152 JuliaInterpreter.#prepare_framecode#37(enter_generated, _3, method, argtypes)
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:170 Base.getproperty(Core.Compiler, :get_staged)(JuliaInterpreter.specialize_method(method, argtypes, lenv))
│││││┌ @ compiler/utilities.jl:116 Core.Compiler.may_invoke_generator(mi)
││││││┌ @ reflection.jl:1082 Core.Compiler.may_invoke_generator(Core.typeassert(Core.Compiler.getproperty(method, :def), Core.Compiler.Method), Core.Compiler.getproperty(method, :specTypes), Core.Compiler.getproperty(method, :sparam_vals))
│││││││┌ @ reflection.jl:1096 Core.Compiler.methods(Core.Compiler.getproperty(generator, :gen))
││││││││┌ @ reflection.jl:963 #self#(f, Core.Compiler.nothing)
│││││││││┌ @ reflection.jl:963 Core.Compiler.methods(f, Core.apply_type(Core.Compiler.Tuple, Core.apply_type(Core.Compiler.Vararg, Core.Compiler.Any)), mod)
││││││││││┌ @ reflection.jl:942 Core.Compiler.iterate(Core.Compiler._methods(f, t, -1, world), Core.getfield(_5, 2))
│││││││││││┌ @ array.jl:778 Core.Compiler.%(i, Core.Compiler.UInt)
││││││││││││ no matching method found for call signature: Core.Compiler.%(i::Nothing, Core.Compiler.UInt)
│││││││││││└────────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:175 JuliaInterpreter.get_source(Base.getproperty(method, :generator), lenv)
│││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:85 g(env, Base.getproperty(g, :argnames)...)
││││││┌ @ boot.jl:589 Core.Expr(Core.tuple(Core.Symbol("with-static-parameters"), lam), Core.getproperty(g, :spnames)...)
│││││││ no matching method found for call signature: Core.Expr(Core.tuple(Core.Symbol("with-static-parameters")::Symbol, lam::Expr)::Tuple{Symbol, Expr}, Core.getproperty(g::Core.GeneratedFunctionStub, :spnames::Symbol)::Union{Nothing, Vector{Any}}...)
││││││└───────────────
││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/construct.jl:190 Core.kwfunc(JuliaInterpreter.FrameCode)(Core.apply_type(Core.NamedTuple, (:generator,))(Core.tuple(generator)), JuliaInterpreter.FrameCode, method, code)
│││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:100 JuliaInterpreter.#FrameCode#1(generator, optimize, _3, scope, src)
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:126 JuliaInterpreter.add_breakpoint_if_match!(framecode, bp)
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:64 JuliaInterpreter.framecode_matches_breakpoint(framecode, bp)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:163 JuliaInterpreter.method_contains_line(meth, Base.getproperty(bp, :line))
│││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:404 JuliaInterpreter.compute_corrected_linerange(method)
││││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:394 JuliaInterpreter.whereis(method)
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 CodeTracking.fileline(Base.getindex(Base.getindex(lin, Base.lastindex(lin)), 1))
││││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/utils.jl:54 CodeTracking.String(Base.getproperty(lnn, :file))
│││││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lnn::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││││└───────────────────────────────────────────────────────────────
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 Base.lastindex(lin)
││││││││││││ for one of the union split cases, no matching method found for signature: Base.lastindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}})
│││││││││││└──────────────────────────────────────────────────────────────────────
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/breakpoints.jl:168 JuliaInterpreter.whereis(framecode, 1)
│││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/utils.jl:359 JuliaInterpreter.whereis(lineinfo, m)
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:107 CodeTracking.String(Base.getproperty(lineinfo, :file))
│││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lineinfo::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││└───────────────────────────────────────────────────────────────────────
│││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:76 Base.getindex(lin, Base.lastindex(lin))
││││││││││││ for one of the union split cases, no matching method found for signature: Base.getindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}, Base.lastindex(lin::Union{Missing, Vector{Tuple{LineNumberNode, Expr}}})::Int64)
│││││││││││└──────────────────────────────────────────────────────────────────────
││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/types.jl:101 JuliaInterpreter.optimize!(JuliaInterpreter.copy_codeinfo(src), scope)
│││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:185 JuliaInterpreter.build_compiled_call!(stmt, Base.llvmcall, code, idx, nargs, sparams, evalmod)
││││││││┌ @ /Users/aviatesk/julia/packages/JuliaInterpreter/src/optimize.jl:339 JuliaInterpreter.get(JuliaInterpreter.compiled_calls, cc_key, JuliaInterpreter.nothing)
│││││││││┌ @ dict.jl:505 Base.ht_keyindex(h, key)
││││││││││┌ @ dict.jl:291 Base.isequal(key, Base.getindex(keys, index))
│││││││││││┌ @ tuple.jl:349 Base._isequal(t1, t2)
││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
││││││││││││││││┌ @ tuple.jl:352 Base._isequal(Base.tail(t1), Base.tail(t2))
│││││││││││││││││┌ @ tuple.jl:352 Base.getindex(t1, 1)
││││││││││││││││││┌ @ tuple.jl:29 Base.getfield(t, i, $(Expr(:boundscheck)))
│││││││││││││││││││ invalid builtin function call: Base.getfield(t::Tuple{}, i::Int64, $(Expr(:boundscheck)))
││││││││││││││││││└───────────────
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:105 CodeTracking.String(Base.getproperty(lineinfo, :file))
│││││││││││ for one of the union split cases, no matching method found for signature: CodeTracking.String(Base.getproperty(lineinfo::LineNumberNode, :file::Symbol)::Union{Nothing, Symbol})
││││││││││└───────────────────────────────────────────────────────────────────────
││││││││││┌ @ /Users/aviatesk/julia/packages/CodeTracking/src/CodeTracking.jl:105 Base.getproperty(lineinfo, :file)
│││││││││││┌ @ Base.jl:33 Base.getfield(x, f)
││││││││││││ type Expr has no field file
│││││││││││└──────────────
 0.869666 seconds (3.26 M allocations: 210.177 MiB, 11.87% gc time, 1.53% compilation time)
```

</details>