### PR TITLE
Try harder to unwrap UnionAlls

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -247,7 +247,9 @@ end
 
 function parametric_type_to_expr(@nospecialize(t::Type))
     t isa Core.TypeofBottom && return t
-    t isa UnionAll && (t = t.body)
+    while t isa UnionAll
+        t = t.body
+    end
     t = t::DataType
     if Base.isvarargtype(t)
         return Expr(:(...), t.parameters[1])

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -735,3 +735,7 @@ end
         @test @interpret(f("asd")) == 3
     end
 end
+
+@testset "#466 parametric_type_to_expr" begin
+    @test JuliaInterpreter.parametric_type_to_expr(Array) == :(Core.Array{T, N})
+end


### PR DESCRIPTION
This fixes the issue reported [here](https://github.com/julia-vscode/julia-vscode/issues/1693#issuecomment-781377955):
```
shell> cat test.csv
StartDate,Q2_Id
Start Date,"Please upload your savefile if you can - it'll be named something like __InterceptionXX.gz. You'll find it at:

Documents\My Games\Wesnoth\saves\ on Windows,or

~/.local/share/wesnoth//saves/ on Linux - ID"
2020-08-23 04:52:09,
2020-08-23 05:08:02,
2020-08-23 10:06:36,F_3smplS6AiQMH7Gy
julia> using CSV

julia> @interpret CSV.File("test.csv")
ERROR: TypeError: in typeassert, expected DataType, got Type{Array{T,N} where N}
Stacktrace:
 [1] parametric_type_to_expr(::Type) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/optimize.jl:251
 [2] build_compiled_call!(::Expr, ::Symbol, ::Core.CodeInfo, ::Int64, ::Int64, ::Array{Symbol,1}, ::Module) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/optimize.jl:342
 [3] optimize!(::Core.CodeInfo, ::Method) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/optimize.jl:192
 [4] JuliaInterpreter.FrameCode(::Method, ::Core.CodeInfo; generator::Bool, optimize::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/types.jl:101
 [5] prepare_framecode(::Method, ::Any; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/construct.jl:190
 [6] prepare_call(::Any, ::Array{Any,1}; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/construct.jl:261
 [7] get_call_framecode(::Array{Any,1}, ::JuliaInterpreter.FrameCode, ::Int64; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/localmethtable.jl:63
 [8] evaluate_call_recurse!(::Any, ::Frame, ::Expr; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:224
 [9] evaluate_call_recurse! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:201 [inlined]
 [10] eval_rhs(::Any, ::Frame, ::Expr) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:394
 [11] step_expr!(::Any, ::Frame, ::Any, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:537
 [12] step_expr! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:587 [inlined]
 [13] finish!(::Any, ::Frame, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:14
 [14] finish_and_return! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:29 [inlined]
 [15] evaluate_call_recurse!(::Any, ::Frame, ::Expr; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:239
 ... (the last 7 lines are repeated 2 more times)
 [30] evaluate_call_recurse! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:201 [inlined]
 [31] eval_rhs(::Any, ::Frame, ::Expr) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:394
 [32] step_expr!(::Any, ::Frame, ::Any, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:450
 [33] step_expr! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:587 [inlined]
 [34] finish!(::Any, ::Frame, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:14
 [35] finish_and_return! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:29 [inlined]
 [36] evaluate_call_recurse!(::Any, ::Frame, ::Expr; enter_generated::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:239
 [37] evaluate_call_recurse! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:201 [inlined]
 [38] eval_rhs(::Any, ::Frame, ::Expr) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:394
 [39] step_expr!(::Any, ::Frame, ::Any, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:537
 ... (the last 7 lines are repeated 3 more times)
 [61] step_expr! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/interpret.jl:587 [inlined]
 [62] finish!(::Any, ::Frame, ::Bool) at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:14
 [63] finish_and_return! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:29 [inlined]
 [64] finish_and_return! at /home/pfitzseb/.julia/packages/JuliaInterpreter/hFiJ2/src/commands.jl:33 [inlined] (repeats 2 times)
```

Not entirely sure how to get a MWE from there, so I haven't added a test.