### PR TITLE
WIP: handle toplevel anonymous functions

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -194,7 +194,8 @@ function evaluate_call_compiled!(::Compiled, frame::Frame, call_expr::Expr; ente
     fargs = collect_args(frame, call_expr)
     f = fargs[1]
     popfirst!(fargs)  # now it's really just `args`
-    return f(fargs...)
+    # TODO `invokelatest` is only needed for toplevel functions, don't use it when interpreting local code
+    return Base.invokelatest(f, fargs...)
 end
 
 function evaluate_call_recurse!(@nospecialize(recurse), frame::Frame, call_expr::Expr; enter_generated::Bool=false)

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -509,4 +509,12 @@ end
         frame, pc = JuliaInterpreter.debug_command(frame, :n)
         @test pc isa BreakpointRef
     end
+
+    @testset "toplevel functions in compiled mode" begin
+        frame = Frame(@__MODULE__, quote
+            foo() = nothing
+            foo()
+        end)
+        @test (debug_command(Compiled(), frame, :c, true); true) # just check this doesn't yield `The applicable method may be too new: ...`
+    end
 # end


### PR DESCRIPTION
While debugging https://github.com/aviatesk/JET.jl/issues/104, I found
the same could happen for JuliaInterpreter.

This issue doesn't happen when interpreting an local frame, so ideally
we want to use `Base.invokelatest` only when interpreting a toplevel
frame. But it needs some refactoring on the whole interpret.jl code
base, and so I want to leave it as a future work if you're okay.