### PR TITLE
Interpreted methods

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -91,6 +91,7 @@ JuliaInterpreter.framedict
 JuliaInterpreter.genframedict
 JuliaInterpreter.compiled_methods
 JuliaInterpreter.compiled_modules
+JuliaInterpreter.interpreted_methods
 ```
 
 ## Utilities

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -21,6 +21,13 @@ rather than recursed into via the interpreter.
 const compiled_methods = Set{Method}()
 
 """
+`meth ∈ interpreted_methods` indicates that `meth` should *not* be run using [`Compiled`](@ref)
+and recursed into via the interpreter. This takes precedence over [`compiled_methods`](@ref) and
+[`compiled_modules`](@ref).
+"""
+const interpreted_methods = Set{Method}()
+
+"""
 `mod ∈ compiled_modules` indicates that any method in `mod` should be run using [`Compiled`](@ref)
 rather than recursed into via the interpreter.
 """
@@ -150,7 +157,7 @@ end
 
 function prepare_framecode(method::Method, @nospecialize(argtypes); enter_generated=false)
     sig = method.sig
-    if method.module ∈ compiled_modules || method ∈ compiled_methods
+    if (method.module ∈ compiled_modules || method ∈ compiled_methods) && !(method ∈ interpreted_methods)
         return Compiled()
     end
     # Get static parameters

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -510,3 +510,25 @@ end
         @test pc isa BreakpointRef
     end
 # end
+
+module Foo
+    using ..JuliaInterpreter
+    function f(x)
+        x
+        @bp
+        x
+    end
+end
+@testset "interpreted methods" begin
+    g(x) = Foo.f(x)
+
+    push!(JuliaInterpreter.compiled_modules, Foo)
+    frame = JuliaInterpreter.enter_call(g, 5)
+    frame, pc = JuliaInterpreter.debug_command(frame, :n)
+    @test !(pc isa BreakpointRef)
+
+    push!(JuliaInterpreter.interpreted_methods, first(methods(Foo.f)))
+    frame = JuliaInterpreter.enter_call(g, 5)
+    frame, pc = JuliaInterpreter.debug_command(frame, :n)
+    @test pc isa BreakpointRef
+end


### PR DESCRIPTION
This adds `JuliaInterpreter.interpreted_methods` as an easy way to compile all methods in a module except for a few of them (this takes precedence over both `compiled_methods` and `compiled_modules`)

Makes the implementation of [this proposal](https://discourse.julialang.org/t/debugging-in-juno-extremely-slow/53801/10?u=pfitzseb) much easier.