### PR TITLE
always use QuoteNode in eval_code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.8.10"
+version = "0.8.11"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -96,3 +96,9 @@ JuliaInterpreter.step_expr!(fr)
 @test eval_code(fr, "output") == :sym
 eval_code(fr, "output = :foo")
 @test eval_code(fr, "output") == :foo
+
+let f() = (x = GlobalRef(Main, :doesnotexist);)
+    fr = JuliaInterpreter.enter_call(f)
+    JuliaInterpreter.step_expr!(fr)
+    @test eval_code(fr, :var"%1") == GlobalRef(Main, :doesnotexist)
+end

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -97,8 +97,8 @@ JuliaInterpreter.step_expr!(fr)
 eval_code(fr, "output = :foo")
 @test eval_code(fr, "output") == :foo
 
-let f() = (x = GlobalRef(Main, :doesnotexist);)
+let f() = GlobalRef(Main, :doesnotexist)
     fr = JuliaInterpreter.enter_call(f)
     JuliaInterpreter.step_expr!(fr)
-    @test eval_code(fr, :var"%1") == GlobalRef(Main, :doesnotexist)
+    @test eval_code(fr, Symbol("%1")) == GlobalRef(Main, :doesnotexist)
 end


### PR DESCRIPTION
This fixes a pretty nasty segfault in Debugger.jl for me (see https://gist.github.com/simeonschaub/33313623fd14ecbaa147b6e77946154c). @KristofferC Was there a particular reason for introducing `maybe_quote` here and not just quote everything in a QuoteNode?