### PR TITLE
fix #479: buggy handling of ccall

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -783,3 +783,11 @@ end
 
     @test @interpret(foobar()) == foobar()
 end
+
+@testset "issue #479" begin
+    function f()
+        ptr = @cfunction(+, Int, (Int, Int))
+        ccall(ptr::Ptr{Cvoid}, Int, (Int, Int), 1, 2)
+    end
+    @test @interpret(f()) === 3
+end


### PR DESCRIPTION
This was quite annoying to track down. The issue here was that
`replace_ssa!` modifies the passed expression, but it is possible for
there to be multiple references to the same copy of an expression in
`stmts`, so the replacement would be accidentally applied twice
generating wrong code.