### PR TITLE
setup `_INACTIVE_EXCEPTION`, which can be distinguished from thrown objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.8.15"
+version = "0.8.16"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -76,6 +76,7 @@ JuliaInterpreter.dummy_breakpoint
 Frame
 JuliaInterpreter.FrameCode
 JuliaInterpreter.FrameData
+JuliaInterpreter._INACTIVE_EXCEPTION
 JuliaInterpreter.FrameInstance
 JuliaInterpreter.BreakpointState
 JuliaInterpreter.BreakpointRef

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -299,7 +299,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         resize!(sparams, 0)
         empty!(exception_frames)
         resize!(last_reference, ns)
-        last_exception[] = nothing
+        last_exception[] = _INACTIVE_EXCEPTION.instance
     else
         locals = Vector{Union{Nothing,Some{Any}}}(nothing, ns)
         ssavalues = Vector{Any}(undef, ng)
@@ -307,7 +307,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         exception_frames = Int[]
         last_reference = Vector{Int}(undef, ns)
         callargs = Any[]
-        last_exception = Ref{Any}(nothing)
+        last_exception = Ref{Any}(_INACTIVE_EXCEPTION.instance)
     end
     fill!(last_reference, 0)
     if isa(framecode.scope, Method)

--- a/src/types.jl
+++ b/src/types.jl
@@ -187,6 +187,14 @@ struct FrameData
     callargs::Vector{Any}  # a temporary for processing arguments of :call exprs
 end
 
+"""
+    _INACTIVE_EXCEPTION
+
+Represents a case where no exceptions are thrown yet.
+End users will not see this singleton type, otherwise it usually means there is missing
+error handling in the interpretation process.
+"""
+struct _INACTIVE_EXCEPTION end
 
 """
 `Frame` represents the current execution state in a particular call frame.


### PR DESCRIPTION
Previously `FrameData.last_exception` is initialized with `nothing`,
which can't be distinguished from thrown objects, which technically can
be `nothing` as well.
This PR setups `_INACTIVE_EXCEPTION` singleton type and make
`FrameData.last_exception` initialized with it.