### PR TITLE
Improve handling of duplicate slotnames

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -188,16 +188,10 @@ function shouldbreak(frame::Frame, pc::Int)
 end
 
 function prepare_slotfunction(framecode::FrameCode, body::Union{Symbol,Expr})
-    uslotnames = Set{Symbol}()
     framename, dataname = gensym("frame"), gensym("data")
     assignments = Expr[:($dataname = $framename.framedata)]
     default = Unassigned()
-    for slotname in framecode.src.slotnames
-        if slotname ∉ uslotnames
-            push!(uslotnames, slotname)
-        else
-            continue
-        end
+    for slotname in unique(framecode.src.slotnames)
         list = framecode.slotnamelists[slotname]
         if length(list) == 1
             maxexpr = :($dataname.last_reference[$(list[1])] > 0 ? $(list[1]) : 0)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -193,9 +193,6 @@ function prepare_slotfunction(framecode::FrameCode, body::Union{Symbol,Expr})
     assignments = Expr[:($dataname = $framename.framedata)]
     default = Unassigned()
     for slotname in framecode.src.slotnames
-        if slotname === Symbol("")
-            continue
-        end
         if slotname ∉ uslotnames
             push!(uslotnames, slotname)
         else

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -189,19 +189,18 @@ end
 
 function prepare_slotfunction(framecode::FrameCode, body::Union{Symbol,Expr})
     uslotnames = Set{Symbol}()
-    slotnames  = Symbol[]
-    for name in framecode.src.slotnames
-        if name ∉ uslotnames
-            push!(slotnames, name)
-            push!(uslotnames, name)
-        end
-    end
     framename, dataname = gensym("frame"), gensym("data")
     assignments = Expr[:($dataname = $framename.framedata)]
     default = Unassigned()
-    for i = 1:length(slotnames)
-        slotname = framecode.src.slotnames[i]
-        qslotname = QuoteNode(slotname)
+    for slotname in framecode.src.slotnames
+        if slotname === Symbol("")
+            continue
+        end
+        if slotname ∉ uslotnames
+            push!(uslotnames, slotname)
+        else
+            continue
+        end
         list = framecode.slotnamelists[slotname]
         if length(list) == 1
             maxexpr = :($dataname.last_reference[$(list[1])] > 0 ? $(list[1]) : 0)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -451,7 +451,13 @@ end
         f = JuliaInterpreter.enter_call(duplnames, (1,2))
         ex = JuliaInterpreter.prepare_slotfunction(f.framecode, :(i==1))
         @test ex isa Expr
-        @test ex.args[end].args[end-1].args[1] == :i
+        found = false
+        for arg in ex.args[end].args
+            if arg.args[1] == :i
+                found = true
+            end
+        end
+        @test found
         @test last(JuliaInterpreter.debug_command(f, :c)) isa BreakpointRef
     end
 end


### PR DESCRIPTION
Turns out that we can sometimes end up with duplicate slotnames, which breaks the current logic in `prepare_slotfunction`.

E.g. 
```
function debug(x)
    for iter in Iterators.CartesianIndices(x)
        i = iter[1]
        c = i
        a, b, c, d = tmp()
    end
    return x
end
```
results in 
```
julia> c = @code_lowered debug((1,2,3));

julia> c.slotnames
10-element Vector{Symbol}:
 Symbol("#self#")
 :x
 Symbol("")
 Symbol("")
 :iter
 :d
 :b
 :a
 :c
 :i
 ```
which means that we never insert the proper assignment for `i` (because `Symbol("")` is in there twice).