### PR TITLE
update to https://github.com/JuliaLang/julia/pull/41018

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -255,10 +255,10 @@ function parametric_type_to_expr(@nospecialize(t::Type))
     if Base.isvarargtype(t)
         return Expr(:(...), t.parameters[1])
     end
-    if t.hasfreetypevars
+    if Base.has_free_typevars(t)
         params = map(t.parameters) do @nospecialize(p)
             isa(p, TypeVar) ? p.name :
-            isa(p, DataType) && p.hasfreetypevars ? parametric_type_to_expr(p) : p
+            isa(p, DataType) && Base.has_free_typevars(p) ? parametric_type_to_expr(p) : p
         end
         return Expr(:curly, scopename(t.name), params...)::Expr
     end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -791,3 +791,16 @@ end
     end
     @test @interpret(f()) === 3
 end
+
+@testset "https://github.com/JuliaLang/julia/pull/41018" begin
+    m = Module()
+    @eval m begin
+        struct Foo
+            foo::Int
+            bar
+        end
+    end
+    # this shouldn't throw "type DataType has no field hasfreetypevars"
+    # even after https://github.com/JuliaLang/julia/pull/41018
+    @test Int === @interpret Core.Compiler.getfield_tfunc(m.Foo, Core.Compiler.Const(:foo))
+end


### PR DESCRIPTION
Now `DataType`s don't have `hasfreetypevars` field.
We can use `Base.has_free_typevars` instead while keeping backward compat.