### PR TITLE
allow interpreting TypedSlots

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -419,7 +419,7 @@ function replace_coretypes_list!(list::AbstractVector; rev::Bool)
         end
         if isa(x, Core.SSAValue)
             return SSAValue(x.id)
-        elseif isa(x, Core.SlotNumber)
+        elseif isa(x, Core.SlotNumber) || isa(x, Core.TypedSlot)
             return SlotNumber(x.id)
         end
         return x


### PR DESCRIPTION
This comes up when trying to interpret the output of `code_warntype` for
example. Is this reasonable to support?