### PR TITLE
Improve file/line attribution for macros

### DIFF
--- a/test/limits.jl
+++ b/test/limits.jl
@@ -1,3 +1,7 @@
+using JuliaInterpreter
+using CodeTracking
+using Test
+
 # This is a test-for-tests, verifying the code in utils.jl.
 if !isdefined(@__MODULE__, :read_and_parse)
     include("utils.jl")
@@ -43,6 +47,7 @@ end
     else
         @test Aborted(frame, 1).at.file == Symbol("fake.jl")
     end
+    @test whereis(frame, 1; macro_caller=true) == ("fake.jl", 11)
 end
 
 module EvalLimited end
@@ -79,7 +84,7 @@ module EvalLimited end
     end
     """; filename="fake.jl")
     if length(ex.args) == 2
-        # Sadly, parse_input_line doesn't insert line info at toplevel, so do it manually
+        # Sadly, on some Julia versions parse_input_line doesn't insert line info at toplevel, so do it manually
         insert!(ex.args, 2, LineNumberNode(2, Symbol("fake.jl")))
         insert!(ex.args, 1, LineNumberNode(1, Symbol("fake.jl")))
     end

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -42,11 +42,7 @@ end
     @test Aborted(frame, i).at.line == 9
     # Check macro
     frame = Frame(modexs[5]...)
-    if VERSION < v"1.4.0-DEV.475"
-        @test Aborted(frame, 1).at.file == Symbol("util.jl")
-    else
-        @test Aborted(frame, 1).at.file == Symbol("fake.jl")
-    end
+    @test Aborted(frame, 1).at.file == Symbol("fake.jl")
     @test whereis(frame, 1; macro_caller=true) == ("fake.jl", 11)
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -38,7 +38,8 @@ end
 function Aborted(frame::Frame, pc)
     src = frame.framecode.src
     lineidx = src.codelocs[pc]
-    return Aborted(src.linetable[lineidx])
+    lineinfo = JuliaInterpreter.linetable(frame, lineidx; macro_caller=true)
+    return Aborted(lineinfo)
 end
 
 """


### PR DESCRIPTION
This makes it easier to identify the caller of a macro.
This fixes a test failure on nightly.

xref #498