### PR TITLE
remove more legacy code

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -160,6 +160,8 @@ JuliaInterpreter.finish_and_return!(frame)
 # output
 
 Test Passed
+  Expression: x + y == 3
+   Evaluated: 3 == 3
 ```
 
 ## Toplevel code and world age
@@ -189,32 +191,38 @@ The reason for this error becomes clearer if we examine `frame` or look directly
 ```julia
 julia> Meta.lower(Main, ex)
 :($(Expr(:thunk, CodeInfo(
+    @ none within `top-level scope`
 1 ─      $(Expr(:thunk, CodeInfo(
-1 ─     global ##17#18
-│       const ##17#18
-│       $(Expr(:struct_type, Symbol("##17#18"), :((Core.svec)()), :((Core.svec)()), :(Core.Function), :((Core.svec)()), false, 0))
-└──     return
+    @ none within `top-level scope`
+1 ─      global var"#3#4"
+│        const var"#3#4"
+│   %3 = Core._structtype(Main, Symbol("#3#4"), Core.svec(), Core.svec(), Core.svec(), false, 0)
+│        var"#3#4" = %3
+│        Core._setsuper!(var"#3#4", Core.Function)
+│        Core._typebody!(var"#3#4", Core.svec())
+└──      return nothing
 )))
-│   %2 = (Core.svec)(##17#18, Core.Any)
-│   %3 = (Core.svec)()
-│   %4 = (Core.svec)(%2, %3)
-│        $(Expr(:method, false, :(%4), CodeInfo(quote
-    (Core.apply_type)(Base.Val, 2)
-    (%1)()
-    (Base.literal_pow)(^, x, %2)
-    return %3
-end)))
-│        #17 = %new(##17#18)
-│   %7 = #17
-│   %8 = (Base.vect)(1, 2, 3)
+│   %2 = Core.svec(var"#3#4", Core.Any)
+│   %3 = Core.svec()
+│   %4 = Core.svec(%2, %3, $(QuoteNode(:(#= REPL[18]:1 =#))))
+│        $(Expr(:method, false, :(%4), CodeInfo(
+    @ REPL[18]:1 within `none`
+1 ─ %1 = Core.apply_type(Base.Val, 2)
+│   %2 = (%1)()
+│   %3 = Base.literal_pow(^, x, %2)
+└──      return %3
+)))
+│        #3 = %new(var"#3#4")
+│   %7 = #3
+│   %8 = Base.vect(1, 2, 3)
 │   %9 = map(%7, %8)
 └──      return %9
 ))))
 ```
 
 All of the code before the `%7` line is devoted to defining the anonymous function `x->x^2`:
-it creates a new "anonymous type" (here written as `##17#18`), and then defines a "call
-function" for this type, equivalent to `(##17#18)(x) = x^2`.
+it creates a new "anonymous type" (here written as `var"#3#4"`), and then defines a "call
+function" for this type, equivalent to `(var"#3#4")(x) = x^2`.
 
 In some cases one can fix this simply by indicating that we want to run this frame at top level:
 

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -320,38 +320,6 @@ function inplace_lookup!(ex, i, frame)
     return ex
 end
 
-function evaluate_structtype(@nospecialize(recurse), frame, node)
-    grsvec!(ex::Expr) = (ex.args[1] = GlobalRef(Core, :svec); return ex)
-
-    name, mod = structname(frame, node)
-    supertype = lookup_or_eval(recurse, frame, node.args[4])::Type
-    ismutable = node.args[6]::Bool
-    ninit = node.args[7]::Int
-    newstructexpr = Expr(:struct_type, name, nothing, nothing, supertype, nothing, ismutable, ninit)
-    for idx in (2, 3, 5)
-        ex = newstructexpr.args[idx] = grsvec!(copy(node.args[idx]::Expr))
-        for i = 2:length(ex.args)
-            inplace_lookup!(ex, i, frame)
-        end
-    end
-    Core.eval(mod, newstructexpr)
-end
-
-function evaluate_abstracttype(@nospecialize(recurse), frame, node)
-    name, mod = structname(frame, node)
-    params = lookup_or_eval(recurse, frame, node.args[2])::SimpleVector
-    supertype = lookup_or_eval(recurse, frame, node.args[3])::Type
-    Core.eval(mod, Expr(:abstract_type, name, params, supertype))
-end
-
-function evaluate_primitivetype(@nospecialize(recurse), frame, node)
-    name, mod = structname(frame, node)
-    params = lookup_or_eval(recurse, frame, node.args[2])::SimpleVector
-    nbits = node.args[3]::Int
-    supertype = lookup_or_eval(recurse, frame, node.args[4])::Type
-    Core.eval(mod, Expr(:primitive_type, name, params, nbits, supertype))
-end
-
 function do_assignment!(frame, @nospecialize(lhs), @nospecialize(rhs))
     code, data = frame.framecode, frame.framedata
     if isa(lhs, SSAValue)
@@ -503,12 +471,6 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
             elseif istoplevel
                 if node.head === :method && length(node.args) > 1
                     evaluate_methoddef(frame, node)
-                elseif node.head === :struct_type
-                    evaluate_structtype(recurse, frame, node)
-                elseif node.head === :abstract_type
-                    evaluate_abstracttype(recurse, frame, node)
-                elseif node.head === :primitive_type
-                    evaluate_primitivetype(recurse, frame, node)
                 elseif node.head === :module
                     error("this should have been handled by split_expressions")
                 elseif node.head === :using || node.head === :import || node.head === :export

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -218,14 +218,12 @@ function optimize!(code::CodeInfo, scope)
     for (i, stmt) in enumerate(old_code)
         loc = old_codelocs[i]
         if isa(stmt, Expr)
-            if !is_type_definition(stmt)  # https://github.com/timholy/Revise.jl/issues/417
+            inner = extract_inner_call!(stmt, length(new_code)+1)
+            while inner !== nothing
+                push!(new_code, inner)
+                push!(new_codelocs, loc)
+                ssainc[i] += 1
                 inner = extract_inner_call!(stmt, length(new_code)+1)
-                while inner !== nothing
-                    push!(new_code, inner)
-                    push!(new_codelocs, loc)
-                    ssainc[i] += 1
-                    inner = extract_inner_call!(stmt, length(new_code)+1)
-                end
             end
         end
         push!(new_code, stmt)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -5,11 +5,6 @@ function _precompile_()
     @assert precompile(Tuple{typeof(get_call_framecode), Vector{Any}, FrameCode, Int})
     @assert precompile(evaluate_call_recurse!, (Function, Frame, Expr))
     @assert precompile(evaluate_call_compiled!, (Compiled, Frame, Expr))
-    for f in (evaluate_structtype,
-              evaluate_abstracttype,
-              evaluate_primitivetype)
-        @assert precompile(Tuple{typeof(f), Any, Frame, Expr})
-    end
     @assert precompile(Tuple{typeof(evaluate_foreigncall), Any, Frame, Expr})
     @assert precompile(Tuple{typeof(evaluate_methoddef), Frame, Expr})
     @assert precompile(Tuple{typeof(lookup_global_refs!), Expr})

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,25 +58,11 @@ pc_expr(framecode::FrameCode, pc) = pc_expr(framecode.src, pc)
 pc_expr(frame::Frame, pc) = pc_expr(frame.framecode, pc)
 pc_expr(frame::Frame) = pc_expr(frame, frame.pc)
 
-function is_type_definition(stmt)
-    if isa(stmt, Expr)
-        head = stmt.head
-        return head === :struct_type || head === :abstract_type || head === :primitive_type
-    end
-    return false
-end
-
 function find_used(code::CodeInfo)
     used = BitSet()
     stmts = code.code
     for stmt in stmts
         scan_ssa_use!(used, stmt)
-        if is_type_definition(stmt)
-            # these are missed by Core.Compiler.userefs, see https://github.com/JuliaLang/julia/pull/30936
-            for a in stmt.args
-                scan_ssa_use!(used, a)
-            end
-        end
     end
     return used
 end


### PR DESCRIPTION
We can eliminate this code since `:struct_type`/`:abstract_type`/`:primitive_type`
expressions no longer exist in v1.6 and higher.