### PR TITLE
Fix toplevel-global behaviour in ExprSplitter

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -436,7 +436,7 @@ function push_modex!(iter::ExprSplitter, mod::Module, ex::Expr)
         # Issue #427
         modifies_scope = false
         for a in ex.args
-            if isa(a, Expr) && a.head ∈ (:local, :global)
+            if Meta.isexpr(a, :local)
                 modifies_scope = true
                 break
             end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -435,10 +435,12 @@ function push_modex!(iter::ExprSplitter, mod::Module, ex::Expr)
     if ex.head === :toplevel || ex.head === :block
         # Issue #427
         modifies_scope = false
-        for a in ex.args
-            if Meta.isexpr(a, :local)
-                modifies_scope = true
-                break
+        if ex.head === :block
+            for a in ex.args
+                if isa(a, Expr) && a.head ∈ (:local, :global)
+                    modifies_scope = true
+                    break
+                end
             end
         end
         push!(iter.index, modifies_scope ? 0 : 1)

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -540,3 +540,15 @@ end
     modexs = collect(ExprSplitter(@__MODULE__, ex))
     @test length(modexs) == 3
 end
+
+@testset "toplevel global" begin
+    ex = :(begin
+        global foo_g = 10
+        sin(foo_g)
+    end)
+    modexs = collect(ExprSplitter(@__MODULE__, ex))
+    for (mod, ex) in modexs
+        @test JuliaInterpreter.finish!(Frame(mod, ex), true) === nothing
+    end
+    @test length(modexs) == 2
+end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -550,5 +550,5 @@ end
     for (mod, ex) in modexs
         @test JuliaInterpreter.finish!(Frame(mod, ex), true) === nothing
     end
-    @test length(modexs) == 2
+    @test length(modexs) == 1
 end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -541,14 +541,24 @@ end
     @test length(modexs) == 3
 end
 
-@testset "toplevel global" begin
-    ex = :(begin
-        global foo_g = 10
-        sin(foo_g)
-    end)
+@testset "toplevel scope annotation" begin
+    ex = Base.parse_input_line("""
+    global foo_g = 10
+    sin(foo_g)
+    """)
     modexs = collect(ExprSplitter(@__MODULE__, ex))
     for (mod, ex) in modexs
         @test JuliaInterpreter.finish!(Frame(mod, ex), true) === nothing
     end
-    @test length(modexs) == 1
+    @test length(modexs) == 2
+
+    ex = Base.parse_input_line("""
+    local foo = 10
+    sin(42)
+    """)
+    modexs = collect(ExprSplitter(@__MODULE__, ex))
+    for (mod, ex) in modexs
+        @test JuliaInterpreter.finish!(Frame(mod, ex), true) === nothing
+    end
+    @test length(modexs) == 2
 end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2571.

This seems to be correct, but I don't quite understand the original reasoning for including the `:global` case in `push_modex!`.