### PR TITLE
Simplify precompiles

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -457,14 +457,14 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                     return (frame.pc = node.args[2]::Int)
                 end
             elseif node.head === :enter
-                rhs = node.args[1]
+                rhs = node.args[1]::Int
                 push!(data.exception_frames, rhs)
             elseif node.head === :leave
                 for _ = 1:node.args[1]::Int
                     pop!(data.exception_frames)
                 end
             elseif node.head === :pop_exception
-                n = lookup_var(frame, node.args[1])
+                n = lookup_var(frame, node.args[1]::SSAValue)::Int
                 deleteat!(data.exception_frames, n+1:length(data.exception_frames))
             elseif node.head === :return
                 return nothing
@@ -484,7 +484,7 @@ function step_expr!(@nospecialize(recurse), frame, @nospecialize(node), istoplev
                     end
                     Core.eval(mod, Expr(:const, name))
                 elseif node.head === :thunk
-                    newframe = Frame(moduleof(frame), node.args[1])
+                    newframe = Frame(moduleof(frame), node.args[1]::CodeInfo)
                     if isa(recurse, Compiled)
                         finish!(recurse, newframe, true)
                     else

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,48 +1,19 @@
+module __JIInternal__
+public(x::String) = false
+end
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert precompile(Tuple{typeof(maybe_evaluate_builtin), Frame, Expr, Bool})
-    @assert precompile(Tuple{typeof(getargs), Vector{Any}, Frame})
-    @assert precompile(Tuple{typeof(get_call_framecode), Vector{Any}, FrameCode, Int})
-    @assert precompile(evaluate_call_recurse!, (Function, Frame, Expr))
-    @assert precompile(evaluate_call_compiled!, (Compiled, Frame, Expr))
-    @assert precompile(Tuple{typeof(evaluate_foreigncall), Any, Frame, Expr})
-    @assert precompile(Tuple{typeof(evaluate_methoddef), Frame, Expr})
-    @assert precompile(Tuple{typeof(lookup_global_refs!), Expr})
-    @assert precompile(Tuple{typeof(lookup_or_eval), Any, Frame, Any})
-    @assert precompile(Tuple{typeof(eval_rhs), Any, Frame, Expr})
-    @assert precompile(Tuple{typeof(step_expr!), Any, Frame, Any, Bool})
-    for f in (finish!, finish_and_return!, finish_stack!, next_call!, maybe_next_call!, next_line!)
-        @assert precompile(Tuple{typeof(f), Any, Frame})
-        @assert precompile(Tuple{typeof(f), Any, Frame, Bool})
+    @interpret sum(rand(10))
+    expr = quote
+        public(x::Integer) = true
+        module Private
+            private(y::String) = false
+        end
+        const threshold = 0.1
     end
-    @assert precompile(Tuple{typeof(through_methoddef_or_done!), Any, Frame})
-    @assert precompile(Tuple{Type{Frame}, Module, Expr})
-    @assert precompile(Tuple{Type{ExprSplitter}, Module, Expr})
-    # @assert precompile(Tuple{typeof(Core.kwfunc(ExprSplitter)), NamedTuple{(:lnn,),Tuple{LineNumberNode}}, typeof(ExprSplitter), Module, Expr})
-    @assert precompile(Tuple{typeof(queuenext!), ExprSplitter})
-    @assert precompile(Tuple{typeof(Base.iterate), ExprSplitter})  # won't entirely work, but any dependents might help
-    @assert precompile(Tuple{typeof(prepare_framedata), FrameCode, Vector{Any}, SimpleVector, Bool})
-    @assert precompile(Tuple{typeof(prepare_args), Any, Vector{Any}, Vector{Any}})
-    @assert precompile(Tuple{typeof(prepare_call), Any, Vector{Any}})
-    @assert precompile(Tuple{typeof(Core.kwfunc(prepare_call)), NamedTuple{(:enter_generated,),Tuple{Bool}}, typeof(prepare_call), Function, Vector{Any}})
-    # For some reason the PC statement below returns `false` on earlier Julia versions
-    precompile(Tuple{typeof(Core.kwfunc(prepare_framecode)), NamedTuple{(:enter_generated,),Tuple{Bool}}, typeof(prepare_framecode), Method, Any})
-    @assert precompile(Tuple{typeof(prepare_frame), FrameCode, Vector{Any}, Core.SimpleVector})
-    @assert precompile(Tuple{typeof(extract_args), Module, Expr})
-    @assert precompile(Tuple{typeof(enter_call), Int, Int})
-    @assert precompile(Tuple{typeof(enter_call_expr), Expr})
-    @assert precompile(Tuple{typeof(optimize!), Core.CodeInfo, Module})
-    @assert precompile(Tuple{typeof(optimize!), Core.CodeInfo, Method})
-    @assert precompile(Tuple{typeof(build_compiled_call!), Expr, Symbol, Core.CodeInfo, Int, Int, Vector{Symbol}, Module})
-    @assert precompile(Tuple{typeof(renumber_ssa!), Vector{Any}, Vector{Int}})
-    @assert precompile(Tuple{typeof(set_structtype_const), Module, Symbol})
-    @assert precompile(Tuple{typeof(namedtuple), Vector{Any}})
-    @assert precompile(Tuple{typeof(resolvefc), Frame, Any})
-    @assert precompile(Tuple{typeof(check_isdefined), Frame, Any})
-    @assert precompile(Tuple{typeof(find_used), Core.CodeInfo})
-    @assert precompile(Tuple{typeof(do_assignment!), Frame, Any, Any})
-    @assert precompile(Tuple{typeof(pc_expr), Frame})
-    @assert precompile(Tuple{typeof(append_any), Any})
-    @assert precompile(Tuple{typeof(append_any), Any, Vararg{Any, 100}})
-    @assert precompile(Tuple{typeof(whichtt), Any})
+    for (mod, ex) in ExprSplitter(__JIInternal__, expr)
+        frame = Frame(mod, ex)
+        debug_command(frame, :c, true)
+    end
 end


### PR DESCRIPTION
This switches to "do a little work" for precompilation,
rather than explicitly spelling out the specific signatures.
This should be more maintainable and potentially more
exhaustive (or could be made to be so) since it
precompiles across runtime dispatch boundaries.

There are also a couple of improvements in `step_expr!`
inference that I made while trying to track down some
invalidations. These weren't the cause, but they don't
hurt.