### PR TITLE
fix builtin detection

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -35,7 +35,8 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     # Builtins and intrinsics have empty method tables. We can circumvent
     # a long "switch" check by looking for this.
     mt = typeof(f).name.mt
-    if isa(mt, Core.MethodTable)
+    # For some reason Core._apply_iterate does not have an empty MT
+    if isa(mt, Core.MethodTable) && f !== Core._apply_iterate
         isempty(mt) || return call_expr
     end
     # Builtins


### PR DESCRIPTION
There is a shortcut that says that any builtin/intrinsic has an empty method table but this is not true on nightly for `Core._apply_iterate`:

```
julia> typeof(Core._apply_iterate).name.mt
# 1 method for builtin function "_apply_iterate":
[1] _apply_iterate(...) in Core
```

This takes the number of failures on nightly from 9 to 1 and makes Debugger.jl pass again on nightly.