### PR TITLE
do not generate code for unused SSA values, slots and local variables in `eval_code`

### DIFF
--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -98,5 +98,5 @@ eval_code(fr, "output = :foo")
 let f() = GlobalRef(Main, :doesnotexist)
     fr = JuliaInterpreter.enter_call(f)
     JuliaInterpreter.step_expr!(fr)
-    @test eval_code(fr, Symbol("%1")) == GlobalRef(Main, :doesnotexist)
+    @test eval_code(fr, "var\"%1\"") == GlobalRef(Main, :doesnotexist)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/517