### PR TITLE
recurse in builtin expansion if we get a new builtin when expanding

### DIFF
--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -457,3 +457,14 @@ end
         @test last(JuliaInterpreter.debug_command(f, :c)) isa BreakpointRef
     end
 end
+
+@testset "recursive builtins" begin
+    g(args...) = args
+    args = (iterate, g, (1,3))
+
+    h() = Core._apply_iterate(iterate, Core._apply_iterate, args)
+    breakpoint(g)
+    frame, bp = @interpret h()
+    var = JuliaInterpreter.locals(leaf(frame))
+    @test filter(v->v.name === :args, var)[1].value == (1,3)
+end


### PR DESCRIPTION
There are cases (arguably a bit artificial but still) where after we expand a builtin, the function that we are going to run is another builtin, for example:

```
About to run: <(Core._apply_iterate)(iterate, Core._apply_iterate, (iterate, ...)
```

Currently, we cannot step through this since the second `_apply_iterate` will call into C. Solve this by recursing into the expander in the case where the expanded function is another builtin.

