### PR TITLE
update with JuliaLang/julia#44448

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,7 +32,13 @@ Like `which` except it operates on the complete tuple-type `tt`.
 """
 function whichtt(@nospecialize(tt))
     # TODO: provide explicit control over world age? In case we ever need to call "old" methods.
-    m = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tt, get_world_counter())
+    @static if VERSION ≥ v"1.9.0-DEV.149"
+        # branch on https://github.com/JuliaLang/julia/pull/44448
+        # for now, actual code execution doesn't ever need to consider overlayed method table
+        m = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), tt, nothing, get_world_counter())
+    else
+        m = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tt, get_world_counter())
+    end
     m === nothing && return nothing
     isa(m, Method) && return m
     return m.func::Method


### PR DESCRIPTION
Now `jl_gf_invoke_lookup` accepts an optional overlayed method table,
but actual code execution (as done by JuliaInterpreter) doesn't need to
care about it at this moment.