### PR TITLE
clean up coverage files generated by test

### DIFF
--- a/test/code_coverage/code_coverage.jl
+++ b/test/code_coverage/code_coverage.jl
@@ -1,5 +1,13 @@
-# delete any present coverage files
-let
+function cleanup_coverage_files()
+    # clean up coverage files for source code
+    dir, _, files = first(walkdir(normpath(@__DIR__, "..", "..", "src")))
+    for file in files
+        if occursin(r".+\.jl\.\d+\.cov", file)
+            rm(joinpath(dir, file))
+        end
+    end
+
+    # clean up coverage files for this file
     dir, _, files = first(walkdir(@__DIR__))
     for file in files
         if occursin(r"coverage_example\.jl\.\d+\.cov", file)
@@ -8,25 +16,33 @@ let
     end
 end
 
-#using DiffUtils
+try
+    # delete any present coverage files
+    cleanup_coverage_files()
 
-@testset "code coverage" begin
-    out = read(`$(Base.julia_cmd()) --startup=no --project=$(dirname(dirname(@__DIR__))) --code-coverage=user
-                $(joinpath(@__DIR__(), "coverage_example.jl"))`, String)
-    @test out == "1 2 fizz 4 "
-    
-    dir, _, files = first(walkdir(@__DIR__))
-    i = findfirst(contains(r"coverage_example\.jl\.\d+\.cov"), files)
-    i === nothing && error("no coverage files found in $dir: $files")
-    cov_file = joinpath(dir, files[i])
-    cov_data = read(cov_file, String)
-    expected = read(joinpath(dir, "coverage_example.jl.cov"), String)
-    if Sys.iswindows()
-        cov_data = replace(cov_data, "\r\n" => "\n")
-        expected = replace(cov_data, "\r\n" => "\n")
+    #using DiffUtils
+
+    @testset "code coverage" begin
+        out = read(`$(Base.julia_cmd()) --startup=no --project=$(dirname(dirname(@__DIR__))) --code-coverage=user
+                    $(joinpath(@__DIR__(), "coverage_example.jl"))`, String)
+        @test out == "1 2 fizz 4 "
+
+        dir, _, files = first(walkdir(@__DIR__))
+        i = findfirst(contains(r"coverage_example\.jl\.\d+\.cov"), files)
+        i === nothing && error("no coverage files found in $dir: $files")
+        cov_file = joinpath(dir, files[i])
+        cov_data = read(cov_file, String)
+        expected = read(joinpath(dir, "coverage_example.jl.cov"), String)
+        if Sys.iswindows()
+            cov_data = replace(cov_data, "\r\n" => "\n")
+            expected = replace(cov_data, "\r\n" => "\n")
+        end
+        #if cov_data != expected
+        #    DiffUtils.diff(cov_data, expected)
+        #end
+        @test cov_data == expected
     end
-    #if cov_data != expected
-    #    DiffUtils.diff(cov_data, expected)
-    #end
-    @test cov_data == expected
+finally
+    # clean up generated files
+    cleanup_coverage_files()
 end

--- a/test/code_coverage/code_coverage.jl
+++ b/test/code_coverage/code_coverage.jl
@@ -1,8 +1,9 @@
-function cleanup_coverage_files()
+function cleanup_coverage_files(pid)
     # clean up coverage files for source code
     dir, _, files = first(walkdir(normpath(@__DIR__, "..", "..", "src")))
     for file in files
-        if occursin(r".+\.jl\.\d+\.cov", file)
+        reg = Regex(string(".+\\.jl\\.$pid\\.cov"))
+        if occursin(reg, file)
             rm(joinpath(dir, file))
         end
     end
@@ -10,39 +11,49 @@ function cleanup_coverage_files()
     # clean up coverage files for this file
     dir, _, files = first(walkdir(@__DIR__))
     for file in files
-        if occursin(r"coverage_example\.jl\.\d+\.cov", file)
+        reg = Regex(string("coverage_example\\.jl\\.$pid\\.cov"))
+        if occursin(reg, file)
             rm(joinpath(dir, file))
         end
     end
 end
 
-try
-    # delete any present coverage files
-    cleanup_coverage_files()
+# using DiffUtils
 
-    #using DiffUtils
+let
+    local pid
+    try
+        @testset "code coverage" begin
+            io = IOBuffer()
+            filepath = normpath(@__DIR__, "coverage_example.jl")
+            cmd = `$(Base.julia_cmd()) --startup=no --project=$(dirname(dirname(@__DIR__)))
+                --code-coverage=user $filepath`
+            p = run(pipeline(cmd; stdout=io); wait=false)
+            pid = Libc.getpid(p)
+            wait(p)
+            out = String(take!(io))
+            @test out == "1 2 fizz 4 "
 
-    @testset "code coverage" begin
-        out = read(`$(Base.julia_cmd()) --startup=no --project=$(dirname(dirname(@__DIR__))) --code-coverage=user
-                    $(joinpath(@__DIR__(), "coverage_example.jl"))`, String)
-        @test out == "1 2 fizz 4 "
+            dir, _, files = first(walkdir(@__DIR__))
+            i = findfirst(contains(r"coverage_example\.jl\.\d+\.cov"), files)
+            i === nothing && error("no coverage files found in $dir: $files")
+            cov_file = joinpath(dir, files[i])
+            cov_data = read(cov_file, String)
+            expected = read(joinpath(dir, "coverage_example.jl.cov"), String)
+            if Sys.iswindows()
+                cov_data = replace(cov_data, "\r\n" => "\n")
+                expected = replace(cov_data, "\r\n" => "\n")
+            end
 
-        dir, _, files = first(walkdir(@__DIR__))
-        i = findfirst(contains(r"coverage_example\.jl\.\d+\.cov"), files)
-        i === nothing && error("no coverage files found in $dir: $files")
-        cov_file = joinpath(dir, files[i])
-        cov_data = read(cov_file, String)
-        expected = read(joinpath(dir, "coverage_example.jl.cov"), String)
-        if Sys.iswindows()
-            cov_data = replace(cov_data, "\r\n" => "\n")
-            expected = replace(cov_data, "\r\n" => "\n")
+            # if cov_data != expected
+            #     DiffUtils.diff(cov_data, expected)
+            # end
+            @test cov_data == expected
         end
-        #if cov_data != expected
-        #    DiffUtils.diff(cov_data, expected)
-        #end
-        @test cov_data == expected
+    finally
+        if @isdefined(pid)
+            # clean up generated files
+            cleanup_coverage_files(pid)
+        end
     end
-finally
-    # clean up generated files
-    cleanup_coverage_files()
 end


### PR DESCRIPTION
I found generated coverage files corresponding to source files a bit noisy, e.g. in a source tree view in my local editor.
I think we can just clean them up after test?