### PR TITLE
allow setting breakpoint on type constructors

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -1,3 +1,5 @@
+using Base: Callable
+
 const _breakpoints = AbstractBreakpoint[]
 
 """
@@ -111,10 +113,10 @@ end
 breakpoint(radius2, Tuple{Int,Int}, :(y > x))
 ```
 """
-function breakpoint(f::Union{Method, Function}, sig=nothing, line::Integer=0, condition::Condition=nothing)
-    if sig !== nothing && f isa Function
+function breakpoint(f::Union{Method, Callable}, sig=nothing, line::Integer=0, condition::Condition=nothing)
+    if sig !== nothing && f isa Callable
         sig = Base.to_tuple_type(sig)
-        sig = Tuple{typeof(f), sig.parameters...}
+        sig = Tuple{_Typeof(f), sig.parameters...}
     end
     bp = BreakpointSignature(f, sig, line, condition, Ref(true), BreakpointRef[])
     add_to_existing_framecodes(bp)
@@ -129,9 +131,9 @@ function breakpoint(f::Union{Method, Function}, sig=nothing, line::Integer=0, co
     firehooks(breakpoint, bp)
     return bp
 end
-breakpoint(f::Union{Method, Function}, sig, condition::Condition) = breakpoint(f, sig, 0, condition)
-breakpoint(f::Union{Method, Function}, line::Integer, condition::Condition=nothing) = breakpoint(f, nothing, line, condition)
-breakpoint(f::Union{Method, Function}, condition::Condition) = breakpoint(f, nothing, 0, condition)
+breakpoint(f::Union{Method, Callable}, sig, condition::Condition) = breakpoint(f, sig, 0, condition)
+breakpoint(f::Union{Method, Callable}, line::Integer, condition::Condition=nothing) = breakpoint(f, nothing, line, condition)
+breakpoint(f::Union{Method, Callable}, condition::Condition) = breakpoint(f, nothing, 0, condition)
 
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -416,14 +416,14 @@ A `BreakpointSignature` is a breakpoint that is set on methods or functions.
 
 Fields:
 
-- `f::Union{Method, Function}`: A method or function that the breakpoint should apply to.
+- `f::Union{Method, Function, Type}`: A method or function that the breakpoint should apply to.
 - `sig::Union{Nothing, Type}`: if `f` is a `Method`, always equal to `nothing`. Otherwise, contains the method signature
    as a tuple type for what methods the breakpoint should apply to.
 
 For common fields shared by all breakpoints, see [`AbstractBreakpoint`](@ref).
 """
 struct BreakpointSignature <: AbstractBreakpoint
-    f::Union{Method, Function}
+    f::Union{Method, Base.Callable}
     sig::Union{Nothing, Type}
     line::Int # 0 is a sentinel for first statement
     condition::Condition

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -468,3 +468,19 @@ end
     var = JuliaInterpreter.locals(leaf(frame))
     @test filter(v->v.name === :args, var)[1].value == (1,3)
 end
+
+struct Constructor
+    x::Int
+end
+Constructor(x::AbstractString, y::Int) = Constructor(x)
+
+@testset "constructors" begin
+    breakpoint(Constructor, Tuple{String, Int})
+    frame, bp = @interpret Constructor("foo", 3)
+    @test bp isa BreakpointRef
+    @test @interpret Constructor(3) isa Constructor
+
+    breakpoint(Constructor)
+    frame, bp = @interpret Constructor(2)
+    @test bp isa BreakpointRef
+end


### PR DESCRIPTION
Note that the following does still not work:

```jl
julia> struct Constructor{T}
           x::T
       end

julia> breakpoint(Constructor)
Constructor

julia> @interpret Constructor{Int}(2) # no breakpoint
Constructor{Int64}(2)

julia> @interpret Constructor(2) # works
(Frame for Constructor(x::T) where T in Main at REPL[2]:2
b 1 2  1 ─ %1 = Core.apply_type($(QuoteNode(Constructor)), $(Expr(:static_parameter, 1)))
  2 2  │   %2 = (%1)(x)
  3 2  └──      return %2
x = 2
T = Int64
var = T
body = Constructor{T}, breakpoint(Constructor(x::T) where T in Main at REPL[2]:2, line 2))

```