### PR TITLE
fix some cases of setting breakpoints in functions that contain macro expansions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -27,4 +28,4 @@ Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Dates", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "Test"]
+test = ["DataFrames", "Dates", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "Test"]

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -105,7 +105,6 @@ JuliaInterpreter.is_doc_expr
 JuliaInterpreter.is_global_ref
 CodeTracking.whereis
 JuliaInterpreter.linenumber
-JuliaInterpreter.statementnumber
 JuliaInterpreter.Variable
 JuliaInterpreter.locals
 JuliaInterpreter.whichtt

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -62,11 +62,20 @@ function add_to_existing_framecodes(bp::AbstractBreakpoint)
     end
 end
 
-function add_breakpoint_if_match!(framecode::FrameCode, bp::AbstractBreakpoint)
+function add_breakpoint_if_match!(framecode::FrameCode, bp::BreakpointSignature)
     if framecode_matches_breakpoint(framecode, bp)
-        stmtidx = bp.line === 0 ? 1 : statementnumber(framecode, bp.line)
-        breakpoint!(framecode, stmtidx, bp.condition, bp.enabled[])
-        push!(bp.instances, BreakpointRef(framecode, stmtidx))
+        scope = framecode.scope
+        matching_file = if scope isa Method
+            scope.file
+        else
+            # TODO: make more precise?
+            first(framecode.src.linetable).file
+        end
+        stmtidxs = bp.line === 0 ? [1] : statementnumbers(framecode, bp.line, matching_file::Symbol)
+        stmtidxs === nothing && return
+        breakpoint!(framecode, stmtidxs, bp.condition, bp.enabled[])
+        foreach(stmtidx -> push!(bp.instances, BreakpointRef(framecode, stmtidx)), stmtidxs)
+        return
     end
 end
 
@@ -156,29 +165,24 @@ function breakpoint(file::AbstractString, line::Integer, condition::Condition=no
     return bp
 end
 
-function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointFileLocation)
-    if framecode.scope isa Method
-        meth = framecode.scope::Method
-        methpath = CodeTracking.maybe_fix_path(String(meth.file))
-        ispath(methpath) && (methpath = realpath(methpath))
-        if bp.abspath == methpath || endswith(methpath, bp.path)
-            return method_contains_line(meth, bp.line)
-        else
-            return false
-        end
-    else
-        w = whereis(framecode, 1)
-        w === nothing && return false
-        path, _ = w
-        path = CodeTracking.maybe_fix_path(path)
-        ispath(path) && (path = realpath(path))
-
-        if bp.abspath == path || endswith(path, bp.path)
-            return toplevel_code_contains_line(framecode, bp.line)
-        else
-            return false
+function add_breakpoint_if_match!(framecode::FrameCode, bp::BreakpointFileLocation)
+    framecode_contains_file = false
+    matching_file = nothing
+    for file in framecode.unique_files
+        filepath = CodeTracking.maybe_fix_path(String(file))
+        if Base.samefile(bp.abspath, filepath) || endswith(filepath, bp.path)
+            framecode_contains_file = true
+            matching_file = file
+            break
         end
     end
+    framecode_contains_file || return nothing
+
+    stmtidxs = bp.line === 0 ? [1] : statementnumbers(framecode, bp.line, matching_file::Symbol)
+    stmtidxs === nothing && return
+    breakpoint!(framecode, stmtidxs, bp.condition, bp.enabled[])
+    foreach(stmtidx -> push!(bp.instances, BreakpointRef(framecode, stmtidx)), stmtidxs)
+    return
 end
 
 function shouldbreak(frame::Frame, pc::Int)
@@ -240,6 +244,8 @@ function breakpoint!(framecode::FrameCode, pc, condition::Condition=nothing, ena
         framecode.breakpoints[stmtidx] = BreakpointState(enabled, Core.eval(mod, fex))
     end
 end
+breakpoint!(framecode::FrameCode, pcs::AbstractArray, condition::Condition=nothing, enabled=true) = 
+    foreach(pc -> breakpoint!(framecode, pc, condition, enabled), pcs)
 breakpoint!(frame::Frame, pc=frame.pc, condition::Condition=nothing) =
     breakpoint!(frame.framecode, pc, condition)
 

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -35,14 +35,14 @@ const compiled_modules = Set{Module}()
 
 const junk_framedata = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
 const junk_frames = Frame[]
-debug_recycle() = false
+debug_mode() = false
 @noinline function _check_frame_not_in_junk(frame)
     @assert frame.framedata ∉ junk_framedata
     @assert frame ∉ junk_frames
 end
 
 @inline function recycle(frame)
-    debug_recycle() && _check_frame_not_in_junk(frame)
+    debug_mode() && _check_frame_not_in_junk(frame)
     push!(junk_framedata, frame.framedata)
     push!(junk_frames, frame)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -97,6 +97,7 @@ struct FrameCode
     used::BitSet
     generator::Bool   # true if this is for the expression-generator of a @generated function
     report_coverage::Bool
+    unique_files::Set{Symbol}
 end
 
 const BREAKPOINT_EXPR = :($(QuoteNode(getproperty))($JuliaInterpreter, :__BREAKPOINT_MARKER__))
@@ -131,7 +132,14 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true)
     end
     used = find_used(src)
     report_coverage = do_coverage(moduleof(scope))
-    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage)
+
+    lt = linetable(src)
+    unique_files = Set{Symbol}()
+    for entry in lt
+        push!(unique_files, entry.file)
+    end
+
+    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files)
     if scope isa Method
         for bp in _breakpoints
             # Manual union splitting

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,7 +38,9 @@ function whichtt(@nospecialize(tt))
         # for now, actual code execution doesn't ever need to consider overlayed method table
         result = Core.Compiler._findsup(tt, nothing, get_world_counter())
         result === nothing && return nothing
-        return first(result).method
+        fresult = first(result)
+        fresult === nothing && return nothing
+        return fresult.method
     else
         m = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tt, get_world_counter())
         m === nothing && return nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -399,7 +399,7 @@ function statementnumbers(framecode::FrameCode, line::Integer, file::Symbol)
     lt = linetable(framecode)
 
     # Check if the exact line number exist
-    idxs = findall(entry -> entry.line == line + offset && entry.file == file, lt)
+    idxs = findall(entry -> entry.line + offset == line && entry.file == file, lt)
     locs = codelocs(framecode)
     if !isempty(idxs)
         stmtidxs = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using JuliaInterpreter
 using Test
+using Logging
 
 @test isempty(detect_ambiguities(JuliaInterpreter, Base, Core))
 
@@ -7,7 +8,7 @@ if !isdefined(@__MODULE__, :read_and_parse)
     include("utils.jl")
 end
 
-Core.eval(JuliaInterpreter, :(debug_recycle() = true))
+Core.eval(JuliaInterpreter, :(debug_mode() = true))
 
 @testset "Main tests" begin
     include("core.jl")


### PR DESCRIPTION
The current breakpoint code assumed:

- That all lineinfo for a method has the same file as the definition of the method.
- That the lines in the lineinfo was sorted.
- That a given `(file, line)` would only exist once in a method.

None of these are true in the presence of macro expansion. This PR makes us be a bit more careful about not doing any of the incorrect assumptions above. Now, for example, if there is a function like

```jl
function f(x)
    x += 1
    @info "..."
    x += 1
    @info "..."
    return x
end
```

and a breakpoint is added at `logging.jl:370` (where the `@info` macro is expanded) it will actually stop twice there. Also, if you happen to add a breakpoint to a method at line 370 and the method contains an `@info` statement, it will no longer stop in `logging.jl:370`.

Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/526
