### PR TITLE
also break on `Core.kwfunc(f)` when setting a breakpoint on  `f`.

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -96,7 +96,10 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
     meth = framecode.scope
     meth isa Method || return false
     bp.f isa Method && return meth === bp.f
-    bp.f === extract_function_from_method(meth) || return false
+    f = extract_function_from_method(meth)
+    if !(bp.f === f || Core.kwfunc(bp.f) === f)
+        return false
+    end
     bp.sig === nothing && return true
     return bp.sig <: meth.sig
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -489,9 +489,9 @@ end
     ln = @__LINE__
     function f_emptylines()
         sin(2.0)
-    
-    
-    
+
+
+
         return sin(2.0)
     end
 
@@ -544,7 +544,7 @@ end
         for _ in 1:line_logging-5
             print(io, "\n")
         end
-        print(io, 
+        print(io,
         """
         function f_check(x)
             sin(x)
@@ -576,4 +576,12 @@ end
             @test ln == line_logging
         end
     end
+end
+
+@testset "breakpoint in kwfuncs" begin
+    fkw(;x=1) = x
+    breakpoint(fkw)
+    g() = fkw(; x=1)
+    frame, bp = @interpret g()
+    @test isa(frame, Frame) && isa(bp, JuliaInterpreter.BreakpointRef)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/371