### PR TITLE
Fix some ChainRulesCore invalidations

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -230,7 +230,7 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
         end
     end
 
-    has_selfarg = isexpr(last, :call) && any(x -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
+    has_selfarg = isexpr(last, :call) && any(@nospecialize(x) -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
     issplatcall, _callee = unpack_splatcall(last)
     if is_kw || has_selfarg || (issplatcall && is_bodyfunc(_callee))
         # If the last expr calls #self# or passes it to an implementation method,

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -230,7 +230,7 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
         end
     end
 
-    has_selfarg = isexpr(last, :call) && any(isequal(SlotNumber(1)), last.args)
+    has_selfarg = isexpr(last, :call) && any(x -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
     issplatcall, _callee = unpack_splatcall(last)
     if is_kw || has_selfarg || (issplatcall && is_bodyfunc(_callee))
         # If the last expr calls #self# or passes it to an implementation method,


### PR DESCRIPTION
ChainRulesCore gets loaded by a lot of packages. Its fallback methods
```julia
==(a, b::AbstractThunk)
==(a::AbstractThunk, b)
```
invalidate a lot of things, including much of the Serialization stdlib. But at least we can protect JuliaInterpreter.