### PR TITLE
Fix `is_doc_expr` by constraining number of args

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -226,6 +226,7 @@ function is_doc_expr(@nospecialize(ex))
     docsym = Symbol("@doc")
     if isexpr(ex, :macrocall)
         ex::Expr
+        length(ex.args) == 4 || return false
         a = ex.args[1]
         is_global_ref(a, Core, docsym) && return true
         isa(a, Symbol) && a == docsym && return true

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -36,6 +36,16 @@ end
     io = IOBuffer()
     show(io, @doc(Main.DocStringTest))
     @test occursin("Special", String(take!(io)))
+    # issue #538
+    @test !JuliaInterpreter.is_doc_expr(:(Core.@doc "string"))
+    ex = quote
+        @doc("no docstring")
+
+        sum
+    end
+    modexs = collect(ExprSplitter(Main, ex))
+    m, ex = first(modexs)
+    @test !JuliaInterpreter.is_doc_expr(ex.args[2])
 
     @test !isdefined(Main, :JIInvisible)
     collect(ExprSplitter(JIVisible, :(module JIInvisible f() = 1 end)))


### PR DESCRIPTION
Solution as discussed in issue #538.

Without this change the first added test fails and the `collect` from the second test throws the `BoundsError` from #538 by calling `iterate(::ExprSplitter)`.