### PR TITLE
fix evaluation of :foreigncall with sparams

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -165,20 +165,14 @@ function evaluate_foreigncall(@nospecialize(recurse), frame::Frame, call_expr::E
     if !isempty(data.sparams) && scope isa Method
         sig = scope.sig
         args[2] = instantiate_type_in_env(args[2], sig, data.sparams)
-        @static if VERSION < v"1.7.0"
-            arg3 = args[3]
-            if arg3 isa Core.SimpleVector
-                args[3] = Core.svec(map(arg3) do arg
-                    instantiate_type_in_env(arg, sig, data.sparams)
-                end...)
-            else
-                args[3] = instantiate_type_in_env(arg3, sig, data.sparams)
-                args[4] = Core.svec(map(args[4]::Core.SimpleVector) do arg
-                    instantiate_type_in_env(arg, sig, data.sparams)
-                end...)
-            end
+        arg3 = args[3]
+        if (@static VERSION < v"1.7.0" && arg3 isa Core.SimpleVector) ||
+            head === :foreigncall
+            args[3] = Core.svec(map(arg3) do arg
+                instantiate_type_in_env(arg, sig, data.sparams)
+            end...)
         else
-            args[3] = instantiate_type_in_env(args[3], sig, data.sparams)
+            args[3] = instantiate_type_in_env(arg3, sig, data.sparams)
             args[4] = Core.svec(map(args[4]::Core.SimpleVector) do arg
                 instantiate_type_in_env(arg, sig, data.sparams)
             end...)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -909,3 +909,12 @@ f_fma() = Base.have_fma(Float64)
     @test (@interpret a^b) === a^b
 end
 end
+
+# issue 536
+function foo_536(y::T) where {T}
+    x = "A"
+    return ccall(:memcmp, Cint, (Ptr{UInt8}, Ref{T}, Csize_t),
+            pointer(x), Ref(y), 1) == 0
+end
+@test !@interpret foo_536(0x00)
+@test @interpret foo_536(UInt8('A'))


### PR DESCRIPTION
The fix in #505 should have only applied to `:cfunction`, not
`:foreigncall`.

fixes #536
