### PR TITLE
improve builtins consistency check

### DIFF
--- a/.github/workflows/check_builtins.yml
+++ b/.github/workflows/check_builtins.yml
@@ -25,5 +25,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - run: julia -e 'import Pkg; Pkg.add(["DeepDiffs", "Test"])'
       - uses: julia-actions/julia-buildpkg@v1
       - run: julia test/check_builtins.jl

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1.6"
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -28,4 +29,4 @@ Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Dates", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "Test"]
+test = ["DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "Test"]

--- a/test/check_builtins.jl
+++ b/test/check_builtins.jl
@@ -1,12 +1,15 @@
-using Test
+using Test, DeepDiffs
 
-@static if VERSION >= v"1.9.0-"
+@static if !Base.GIT_VERSION_INFO.tagged_commit # only run on nightly
     @testset "Check builtin.jl consistency" begin
         builtins_path = joinpath(@__DIR__, "..", "src", "builtins.jl")
         old_builtins = read(builtins_path, String)
         include("../bin/generate_builtins.jl")
         new_builtins = read(builtins_path, String)
-        print(builtins_path, old_builtins)
-        @test old_builtins == new_builtins
+        consistent = old_builtins == new_builtins
+        if !consistent
+            println(deepdiff(old_builtins, new_builtins))
+        end
+        @test consistent
     end
 end

--- a/test/check_builtins.jl
+++ b/test/check_builtins.jl
@@ -1,6 +1,7 @@
 using Test, DeepDiffs
 
-@static if !Base.GIT_VERSION_INFO.tagged_commit # only run on nightly
+@static if !Base.GIT_VERSION_INFO.tagged_commit && # only run on nightly
+    !Sys.iswindows() # TODO: Understand why this fails, probably some line endings
     @testset "Check builtin.jl consistency" begin
         builtins_path = joinpath(@__DIR__, "..", "src", "builtins.jl")
         old_builtins = read(builtins_path, String)


### PR DESCRIPTION
Use DeepDiffs.jl for printing nice diffs and only print diff if
something actually changed. Also stop hardcoding 1.9 as check for the
build being a nightly version.
