### PR TITLE
NFC: normalize `x == ::Symbol` to `x === ::Symbol`

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -154,7 +154,7 @@ Evaluate a `:foreigncall` (from a `ccall`) statement `callexpr` in the context o
 """
 function evaluate_foreigncall(@nospecialize(recurse), frame::Frame, call_expr::Expr)
     head = call_expr.head
-    args = collect_args(recurse, frame, call_expr; isfc = head==:foreigncall)
+    args = collect_args(recurse, frame, call_expr; isfc = head === :foreigncall)
     for i = 2:length(args)
         arg = args[i]
         args[i] = isa(arg, Symbol) ? QuoteNode(arg) : arg
@@ -400,7 +400,7 @@ function eval_rhs(@nospecialize(recurse), frame, node::Expr)
         return length(frame.framedata.exception_frames)
     elseif head === :boundscheck
         return true
-    elseif head === :meta || head === :inbounds || head == :loopinfo ||
+    elseif head === :meta || head === :inbounds || head === :loopinfo ||
            head === :gc_preserve_begin || head === :gc_preserve_end
         return nothing
     elseif head === :method && length(node.args) == 1

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -342,7 +342,7 @@ function build_compiled_call!(stmt::Expr, fcall, code, idx, nargs::Int, sparams:
     f = get(compiled_calls, cc_key, nothing)
     argnames = Any[Symbol(:arg, i) for i = 1:nargs]
     if f === nothing
-        if fcall == :ccall
+        if fcall === :ccall
             ArgType = Expr(:tuple, Any[parametric_type_to_expr(t) for t in ArgType::SimpleVector]...)
         end
         RetType = parametric_type_to_expr(RetType)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -247,7 +247,7 @@ function is_vararg_type(x)
             if isa(x, UnionAll)
                 x = Base.unwrap_unionall(x)
             end
-            return isa(x, DataType) && nameof(x) == :Vararg
+            return isa(x, DataType) && nameof(x) === :Vararg
         end
     else
         return isa(x, typeof(Vararg))
@@ -569,7 +569,7 @@ end
 
 function print_vars(io::IO, vars::Vector{Variable})
     for v in vars
-        v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
+        v.name === Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
         print(io, '\n', v)
     end
 end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -454,7 +454,7 @@ end
         @test ex isa Expr
         found = false
         for arg in ex.args[end].args
-            if arg.args[1] == :i
+            if arg.args[1] === :i
                 found = true
             end
         end
@@ -523,7 +523,7 @@ end
     file_logging = "logging.jl"
     line_logging = 0
     for entry in frame.framecode.src.linetable
-        if entry.file == Symbol(file_logging)
+        if entry.file === Symbol(file_logging)
             line_logging = entry.line
             break
         end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -136,7 +136,7 @@ end
         frame = enter_call_expr(:($(callgenerated)()))
         f, pc = debug_command(frame, :s)
         @test isa(pc, BreakpointRef)
-        @test JuliaInterpreter.scopeof(f).name == :generatedfoo
+        @test JuliaInterpreter.scopeof(f).name === :generatedfoo
         stmt = JuliaInterpreter.pc_expr(f)
         @test JuliaInterpreter.is_return(stmt) && JuliaInterpreter.lookup_return(frame, stmt) === Int
         @test debug_command(frame, :c) === nothing
@@ -149,11 +149,11 @@ end
             lt = JuliaInterpreter.linetable(f, 2)
             @test isexpr(lt, :line) || isa(lt, Core.LineInfoNode)
         @test isa(pc, BreakpointRef)
-        @test JuliaInterpreter.scopeof(f).name == :generatedfoo
+        @test JuliaInterpreter.scopeof(f).name === :generatedfoo
         stmt = JuliaInterpreter.pc_expr(f)
         @test JuliaInterpreter.is_return(stmt) && JuliaInterpreter.lookup_return(f, stmt) === 1
         f2, pc = debug_command(f, :finish)
-        @test JuliaInterpreter.scopeof(f2).name == :callgenerated
+        @test JuliaInterpreter.scopeof(f2).name === :callgenerated
         # Now finish the regular function
         @test debug_command(frame, :finish) === nothing
         @test frame.callee === nothing
@@ -165,7 +165,7 @@ end
             fr, pc = debug_command(fr, :se)
         end
         fr, pc = debug_command(fr, :sg)
-        @test JuliaInterpreter.scopeof(fr).name == :generatedparams
+        @test JuliaInterpreter.scopeof(fr).name === :generatedparams
         fr, pc = debug_command(fr, :finish)
         @test debug_command(fr, :finish) === nothing
         @test JuliaInterpreter.get_return(fr) == (Int, 2)
@@ -335,7 +335,7 @@ end
             break_on(:error)
             fr = JuliaInterpreter.enter_call(f_outer)
             fr, pc = debug_command(JuliaInterpreter.finish_and_return!, fr, :finish)
-            @test fr.framecode.scope.name == :error
+            @test fr.framecode.scope.name === :error
 
             fundef() = undef_func()
             frame = JuliaInterpreter.enter_call(fundef)
@@ -553,8 +553,8 @@ end
     end
     frame = JuliaInterpreter.enter_call(z, 5)
     frame, pc = JuliaInterpreter.debug_command(frame, :sl)
-    @test JuliaInterpreter.scopeof(frame).name == :h
+    @test JuliaInterpreter.scopeof(frame).name === :h
     frame, pc = JuliaInterpreter.debug_command(frame, :finish)
     frame, pc = JuliaInterpreter.debug_command(frame, :sl)
-    @test JuliaInterpreter.scopeof(frame).name == :h
+    @test JuliaInterpreter.scopeof(frame).name === :h
 end

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -33,7 +33,7 @@ frame = JuliaInterpreter.enter_call(evalsym)
 # Step until the local actually end up getting defined
 JuliaInterpreter.step_expr!(frame)
 JuliaInterpreter.step_expr!(frame)
-@test eval_code(frame, "x") == :foo
+@test eval_code(frame, "x") === :foo
 
 # Evaling multiple statements (https://github.com/JuliaDebug/Debugger.jl/issues/188)
 frame = JuliaInterpreter.enter_call(evalfoo1, 1, 2)
@@ -91,9 +91,9 @@ fr = JuliaInterpreter.enter_call(fun)
 fr = JuliaInterpreter.maybe_step_through_wrapper!(fr)
 JuliaInterpreter.step_expr!(fr)
 @test eval_code(fr, "x") == 5
-@test eval_code(fr, "output") == :sym
+@test eval_code(fr, "output") === :sym
 eval_code(fr, "output = :foo")
-@test eval_code(fr, "output") == :foo
+@test eval_code(fr, "output") === :foo
 
 let f() = GlobalRef(Main, :doesnotexist)
     fr = JuliaInterpreter.enter_call(f)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -346,7 +346,7 @@ f113(;x) = x
 @test @interpret(f113(;x=[1,2,3])) == f113(;x=[1,2,3])
 
 # Some expressions can appear nontrivial but lower to nothing
-# @test isa(Frame(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) == :NoOS 1+1 end)), Nothing)
+# @test isa(Frame(Main, :(@static if ccall(:jl_get_UNAME, Any, ()) === :NoOS 1+1 end)), Nothing)
 # @test isa(Frame(Main, :(Base.BaseDocs.@kw_str "using")), Nothing)
 
 @testset "locals" begin
@@ -484,7 +484,7 @@ e = try
         err
     end
 @test e isa UndefVarError
-@test e.var == :S
+@test e.var === :S
 # https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/200
 locs = JuliaInterpreter.locals(JuliaInterpreter.enter_call(foo, ""))
 @test length(locs) == 3 # #self# + 2 variables

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -42,7 +42,7 @@ end
     @test Aborted(frame, i).at.line == 9
     # Check macro
     frame = Frame(modexs[5]...)
-    @test Aborted(frame, 1).at.file == Symbol("fake.jl")
+    @test Aborted(frame, 1).at.file === Symbol("fake.jl")
     @test whereis(frame, 1; macro_caller=true) == ("fake.jl", 11)
 end
 
@@ -120,7 +120,7 @@ module EvalLimited end
     @test EvalLimited.s < 5
     @test length(aborts) == 1
     lin = aborts[1].at
-    if lin.file == Symbol("fake.jl")
+    if lin.file === Symbol("fake.jl")
         @test lin.line ∈ (2, 3, 4, 5)
     else
         @test lin.method === :iterate || lin.method === :getproperty

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -60,7 +60,7 @@ function evaluate_limited!(@nospecialize(recurse), frame::Frame, nstmts::Int, is
         shouldbreak(frame, pc) && return BreakpointRef(frame.framecode, pc), refnstmts[]
         stmt = pc_expr(frame, pc)
         if isa(stmt, Expr)
-            if stmt.head == :call && !isa(recurse, Compiled)
+            if stmt.head === :call && !isa(recurse, Compiled)
                 refnstmts[] = nstmts
                 try
                     rhs = evaluate_call!(limexec!, frame, stmt)
@@ -72,7 +72,7 @@ function evaluate_limited!(@nospecialize(recurse), frame::Frame, nstmts::Int, is
                     new_pc = handle_err(recurse, frame, err)
                 end
                 nstmts = refnstmts[]
-            elseif stmt.head == :(=) && isexpr(stmt.args[2], :call) && !isa(recurse, Compiled)
+            elseif stmt.head === :(=) && isexpr(stmt.args[2], :call) && !isa(recurse, Compiled)
                 refnstmts[] = nstmts
                 try
                     rhs = evaluate_call!(limexec!, frame, stmt.args[2])
@@ -83,7 +83,7 @@ function evaluate_limited!(@nospecialize(recurse), frame::Frame, nstmts::Int, is
                     new_pc = handle_err(recurse, frame, err)
                 end
                 nstmts = refnstmts[]
-            elseif istoplevel && stmt.head == :thunk
+            elseif istoplevel && stmt.head === :thunk
                 code = stmt.args[1]
                 if length(code.code) == 1 && JuliaInterpreter.is_return(code.code[end]) && isexpr(code.code[end].args[1], :method)
                     # Julia 1.2+ puts a :thunk before the start of each method
@@ -105,7 +105,7 @@ function evaluate_limited!(@nospecialize(recurse), frame::Frame, nstmts::Int, is
                     frame.pc = pc + 1
                     return nothing, refnstmts[]
                 end
-            elseif istoplevel && stmt.head == :method && length(stmt.args) == 3
+            elseif istoplevel && stmt.head === :method && length(stmt.args) == 3
                 step_expr!(recurse, frame, stmt, istoplevel)
                 frame.pc = pc + 1
                 return nothing, nstmts - 1


### PR DESCRIPTION
It would be better to use a consistent style in our code base.
This is also aligned with the convention we're using for Julia base.