### PR TITLE
Fix invalidations from StaticArrays' `map!`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -727,7 +727,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
     scope = scopeof(frame)
     if scope isa Method
         method = scope
-        method_args = something.(frame.framedata.locals[1:method.nargs]) :: Vector{Any}
+        method_args = [something(frame.framedata.locals[i]) for i in 1:method.nargs]
         atypes = Tuple{mapany(_Typeof, method_args)...}
         sig = method.sig
         sparams = Core.svec(frame.framedata.sparams...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -727,7 +727,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
     scope = scopeof(frame)
     if scope isa Method
         method = scope
-        method_args = something.(frame.framedata.locals[1:method.nargs])
+        method_args = something.(frame.framedata.locals[1:method.nargs]) :: Vector{Any}
         atypes = Tuple{mapany(_Typeof, method_args)...}
         sig = method.sig
         sparams = Core.svec(frame.framedata.sparams...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -732,7 +732,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
         sig = method.sig
         sparams = Core.svec(frame.framedata.sparams...)
         mi = Core.Compiler.specialize_method(method, atypes, sparams)
-        fname = frame.framecode.scope.name
+        fname = method.name
     else
         mi = frame.framecode.src
         fname = gensym()


### PR DESCRIPTION
This fixes a source of invalidations for StaticArrays when loaded together with Revise.

![image](https://user-images.githubusercontent.com/26799210/187733234-f22eb2aa-cd51-459d-a6a1-cbbd5e05c315.png)

Previously, the now-annotated call site was inferred as `AbstractVector`, and the call to `mapany` then went through a completely uinferred call to `map!` (e.g., since `length(AbstractVector)` infers to `Any`).

I don't know if this is the ideal fix, but it at least seems correct and fixes the invalidation.