### PR TITLE
Fix typo in signature printing

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -444,7 +444,7 @@ function Base.show(io::IO, bp::BreakpointSignature)
     print(io, bp.f)
     bbsig = bp.sig
     if bbsig !== nothing
-        print(io, '(', join("::" .* string.(bpsig.types), ", "), ')')
+        print(io, '(', join("::" .* string.(bbsig.types), ", "), ')')
     end
     if bp.line !== 0
         print(io, ":", bp.line)


### PR DESCRIPTION
This fixes a type/error introduced in https://github.com/JuliaDebug/JuliaInterpreter.jl/commit/ffc2d3ca86df770057e7f60e5365dc00f941cea5