### PR TITLE
Add :sr debug command for stepping until return statement

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -422,6 +422,7 @@ Perform one "debugger" command. The keyword arguments are not used for all debug
 - `:n`: advance to the next line
 - `:s`: step into the next call
 - `:sl` step into the last call on the current line (e.g. steps into `f` if the line is `f(g(h(x)))`).
+- `:sr` step until the current function will return
 - `:until`: advance the frame to line `line` if given, otherwise advance to the line after the current line
 - `:c`: continue execution until termination or reaching a breakpoint
 - `:finish`: finish the current frame and return to the parent
@@ -462,6 +463,10 @@ function debug_command(@nospecialize(recurse), frame::Frame, cmd::Symbol, rootis
                 next_call!(recurse, frame, istoplevel)
             end
             return debug_command(recurse, frame, :s, rootistoplevel; line)
+        end
+        if cmd === :sr
+            maybe_next_until!(frame -> is_return(pc_expr(frame)), recurse, frame, istoplevel)
+            return frame, frame.pc
         end
         enter_generated = false
         if cmd === :sg

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -558,3 +558,25 @@ end
     frame, pc = JuliaInterpreter.debug_command(frame, :sl)
     @test JuliaInterpreter.scopeof(frame).name === :h
 end
+
+@testset "step until return" begin
+    function f(x)
+        if x == 1
+            return 2
+        end
+        return 3
+    end
+    frame = JuliaInterpreter.enter_call(f, 1)
+    frame, _ = JuliaInterpreter.debug_command(frame, :sr)
+    @test JuliaInterpreter.get_return(frame) == f(1)
+    frame = JuliaInterpreter.enter_call(f, 4)
+    frame, _ = JuliaInterpreter.debug_command(frame, :sr)
+    @test JuliaInterpreter.get_return(frame) == f(4)
+    function g()
+        y = f(1) + f(2)
+        return y
+    end
+    frame = JuliaInterpreter.enter_call(g)
+    frame, _ = JuliaInterpreter.debug_command(frame, :sr)
+    @test JuliaInterpreter.get_return(frame) == g()
+end


### PR DESCRIPTION
This adds a new command `:sr` ("**s**tep (to) **r**eturn") for stepping until the current function is about to return. I find myself wanting this quite often since I want to inspect the state at that point.