### PR TITLE
also count the number of arguments to cache the compiled ccall

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -317,7 +317,7 @@ function build_compiled_foreigncall!(stmt::Expr, code, sparams::Vector{Symbol}, 
     end
     args = stmt.args[6:end]
     # When the ccall is dynamic we pass the pointer as an argument so can reuse the function
-    cc_key = ((dynamic_ccall ? :ptr : cfunc), RetType, ArgType, evalmod, length(sparams))  # compiled call key
+    cc_key = ((dynamic_ccall ? :ptr : cfunc), RetType, ArgType, evalmod, length(sparams), length(args))  # compiled call key
     f = get(compiled_calls, cc_key, nothing)
     if f === nothing
         ArgType = Expr(:tuple, Any[parametric_type_to_expr(t) for t in ArgType::SimpleVector]...)

--- a/test/core.jl
+++ b/test/core.jl
@@ -29,5 +29,5 @@ using Test
     @test JuliaInterpreter.get_return_node(stmt) isa Core.SSAValue
 
     @test string(JuliaInterpreter.parametric_type_to_expr(Base.Iterators.Stateful{String})) ∈
-        ("Base.Iterators.Stateful{String, VS}", "(Base.Iterators).Stateful{String, VS}")
+        ("Base.Iterators.Stateful{String, VS}", "(Base.Iterators).Stateful{String, VS}", "Base.Iterators.Stateful{String, VS, N}")
 end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -974,3 +974,8 @@ using LoopVectorization
     f_lv!(B)
     @test A ≈ B
 end
+
+@testset "nargs foreigncall #560" begin
+    @test (@interpret string("", "pcre_h.jl")) == string("", "pcre_h.jl")
+    @test (@interpret Base.strcat("", "build_h.jl")) ==  Base.strcat("", "build_h.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using JuliaInterpreter
 using Test
 using Logging
 
-include("check_builtins.jl")
 
 @test isempty(detect_ambiguities(JuliaInterpreter, Base, Core))
 
@@ -13,6 +12,7 @@ end
 Core.eval(JuliaInterpreter, :(debug_mode() = true))
 
 @testset "Main tests" begin
+    include("check_builtins.jl")
     include("core.jl")
     include("interpret.jl")
     include("toplevel.jl")


### PR DESCRIPTION
There is a funny call here https://github.com/JuliaLang/julia/blob/6740224b94a28dab629767ccfb8fe55e415361bd/base/strings/string.jl#L90 which apparently does not pass the argument as root which the standard foreigncall to this function does.

Fixes #560 