### PR TITLE
rejigger the code to compute the method instance in stacktraces

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -738,7 +738,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
         argt = Tuple{mapany(_Typeof, method_args)...}
         sig = method.sig
         atype, sparams = ccall(:jl_type_intersection_with_env, Any, (Any, Any), argt, sig)::SimpleVector
-        mi = Core.Compiler.specialize_method(method, atype, sparams)
+        mi = Core.Compiler.specialize_method(method, atype, sparams::SimpleVector)
         fname = method.name
     else
         mi = frame.framecode.src

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -735,10 +735,10 @@ function Base.StackTraces.StackFrame(frame::Frame)
     if scope isa Method
         method = scope
         method_args = [something(frame.framedata.locals[i]) for i in 1:method.nargs]
-        atypes = Tuple{mapany(_Typeof, method_args)...}
+        argt = Tuple{mapany(_Typeof, method_args)...}
         sig = method.sig
-        sparams = Core.svec(frame.framedata.sparams...)
-        mi = Core.Compiler.specialize_method(method, atypes, sparams)
+        atype, sparams = ccall(:jl_type_intersection_with_env, Any, (Any, Any), argt, sig)::SimpleVector
+        mi = Core.Compiler.specialize_method(method, atype, sparams)
         fname = method.name
     else
         mi = frame.framecode.src

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -565,6 +565,17 @@ finally
     break_off(:error)
 end
 
+f_562(x::Union{Vector{T}, Nothing}) where {T} = x + 1
+try
+    break_on(:error)
+    local frame, bp = @interpret f_562(nothing)
+    
+    stacktrace_lines = split(sprint(Base.display_error, bp.err, leaf(frame)), '\n')
+    @test stacktrace_lines[1] == "ERROR: MethodError: no method matching +(::Nothing, ::Int64)"
+finally
+    break_off(:error)
+end
+
 # https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/154
 q = QuoteNode([1])
 @test @interpret deepcopy(q) == q


### PR DESCRIPTION
this works around a bug that occurs when there is an undefined sparams

Fixes #562 