### PR TITLE
Fix kw pattern matching, other changes on 1.9+

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -213,7 +213,8 @@ that supply default positional arguments or handle keywords. `cframe` is the lea
 which execution should start.
 """
 function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
-    code, src = frame.framecode, code.src
+    code = frame.framecode
+    src = code.src
     stmts, scope = src.code, code.scope::Method
     length(stmts) < 2 && return frame
     last = stmts[end-1]

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -225,13 +225,17 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
         if unwrap1 isa DataType
             param1 = Base.unwrap_unionall(unwrap1.parameters[1])
             if param1 isa DataType
-                is_kw = endswith(String(param1.name.name), "#kw")
+                is_kw = isdefined(Core, :kwcall) ? param1.name.name === Symbol("#kwcall") :
+                                                   endswith(String(param1.name.name), "#kw")
             end
         end
     end
 
     has_selfarg = isexpr(last, :call) && any(@nospecialize(x) -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
     issplatcall, _callee = unpack_splatcall(last)
+    if isa(_callee, SSAValue)
+        _callee = stmts[_callee.id]
+    end
     if is_kw || has_selfarg || (issplatcall && is_bodyfunc(_callee))
         # If the last expr calls #self# or passes it to an implementation method,
         # this is a wrapper function that we might want to step through
@@ -253,6 +257,13 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
 end
 maybe_step_through_wrapper!(frame::Frame) = maybe_step_through_wrapper!(finish_and_return!, frame)
 
+if isdefined(Core, :kwcall)
+    const kwhandler = Core.kwcall
+    const kwextrastep = 0
+else
+    const kwhandler = Core.kwfunc
+    const kwextrastep = 1
+end
 
 """
     frame = maybe_step_through_kwprep!(recurse, frame)
@@ -267,19 +278,19 @@ function maybe_step_through_kwprep!(@nospecialize(recurse), frame::Frame, istopl
     stmt = pc_expr(frame, pc)
     if isa(stmt, Tuple{Symbol,Vararg{Symbol}})
         # Check to see if we're creating a NamedTuple followed by kwfunc call
-        pccall = pc + 5
+        pccall = pc + 4 + kwextrastep
         if pccall <= n
             stmt1 = src.code[pc+1]
             # We deliberately check isexpr(stmt, :call) rather than is_call(stmt): if it's
             # assigned to a local, it's *not* kwarg preparation.
             if isexpr(stmt1, :call) && is_quotenode_egal(stmt1.args[1], Core.apply_type) && is_quoted_type(stmt1.args[2], :NamedTuple)
                 stmt4, stmt5 = src.code[pc+4], src.code[pc+5]
-                if isexpr(stmt4, :call) && is_quotenode_egal(stmt4.args[1], Core.kwfunc)
+                if isexpr(stmt4, :call) && is_quotenode_egal(stmt4.args[1], kwhandler)
                     while pc < pccall
                         pc = step_expr!(recurse, frame, istoplevel)
                     end
                     return frame
-                elseif isexpr(stmt5, :call) && is_quotenode_egal(stmt5.args[1], Core.kwfunc) && pccall+1 <= n
+                elseif isexpr(stmt5, :call) && is_quotenode_egal(stmt5.args[1], kwhandler) && pccall+1 <= n
                     # This happens when the call is scoped by a module
                     pccall += 1
                     while pc < pccall
@@ -321,12 +332,12 @@ function maybe_step_through_kwprep!(@nospecialize(recurse), frame::Frame, istopl
                     end
                 elseif is_quotenode_egal(f, Base.merge) && ((pccall = pc + 7) <= n)
                     stmtk = src.code[pccall-1]
-                    if isexpr(stmtk, :call) && is_quotenode_egal(stmtk.args[1], Core.kwfunc)
+                    if isexpr(stmtk, :call) && is_quotenode_egal(stmtk.args[1], kwhandler)
                         for i = 1:4
                             pc = step_expr!(recurse, frame, istoplevel)
                         end
                         stmti = src.code[pc]
-                        if isexpr(stmti, :call) && is_quotenode_egal(stmti.args[1], Core.kwfunc)
+                        if isexpr(stmti, :call) && is_quotenode_egal(stmti.args[1], #= deliberately not kwhandler =# Core.kwfunc)
                             pc = step_expr!(recurse, frame, istoplevel)
                         end
                     end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -25,15 +25,16 @@ function extract_inner_call!(stmt::Expr, idx, once::Bool=false)
     return nothing
 end
 
-function replace_ssa(@nospecialize(stmt), ssalookup)
-    isa(stmt, Expr) || return stmt
+function replace_ssa(stmt::Expr, ssalookup)
     return Expr(stmt.head, Any[
         if isa(a, SSAValue)
             SSAValue(ssalookup[a.id])
         elseif isa(a, NewSSAValue)
             SSAValue(a.id)
-        else
+        elseif isa(a, Expr)
             replace_ssa(a, ssalookup)
+        else
+            a
         end
         for a in stmt.args
     ]...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -348,6 +348,7 @@ Base.show(io::IO, var::Variable) = (print(io, var.name, " = "); show(io,var.valu
 Base.isequal(var1::Variable, var2::Variable) =
     var1.value == var2.value && var1.name === var2.name && var1.isparam == var2.isparam &&
     var1.is_captured_closure == var2.is_captured_closure
+Base.:(==)(var1::Variable, var2::Variable) = isequal(var1, var2)
 
 # A type that is unique to this package for which there are no valid operations
 struct Unassigned end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,6 +194,13 @@ function unpack_splatcall(stmt)
     end
     return false, nothing
 end
+function unpack_splatcall(stmt, src::CodeInfo)
+    issplatcall, callee = unpack_splatcall(stmt)
+    if isa(callee, SSAValue)
+        callee = src.code[callee.id]
+    end
+    return issplatcall, callee
+end
 
 function is_bodyfunc(@nospecialize(arg))
     if isa(arg, QuoteNode)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -224,6 +224,12 @@ end
 
 is_generated(meth::Method) = isdefined(meth, :generator)
 
+if Base.VERSION < v"1.10.0-DEV.873"  # julia#48766
+    get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi)
+else
+    get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi, Base.get_world_counter())
+end
+
 """
     is_doc_expr(ex)
 

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -198,7 +198,7 @@ struct Squarer end
     if VERSION < v"1.9.0-DEV.846" # https://github.com/JuliaLang/julia/pull/45069
         LOC = " in $(@__MODULE__) at $(@__FILE__)"
     else
-        LOC = "\n     @ $(@__MODULE__) $(contractuser(@__FILE__))"
+        LOC = " @ $(@__MODULE__) $(contractuser(@__FILE__))"
     end
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 1)
     @test repr(bp) == "breakpoint(loop_radius2(n)$LOC:$(3-Δ), line 3)"


### PR DESCRIPTION
With the introduction of Core.kwcall, we need to adjust our
pattern-matching for the statements that prepare to dispatch on
kw-handling functions.

There are still a few broken tests on 1.9+, but this fixes the majority.