### PR TITLE
RFC: upper-bound julia version in [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodeTracking = "0.5.9, 1"
-julia = "1.6"
+julia = "1.6 - 1.11"
 
 [extras]
 CassetteOverlay = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"


### PR DESCRIPTION
In practice, JuliaInterpreter is frequently broken by internal changes in Julia. As suggested on [discourse](https://discourse.julialang.org/t/would-slowing-julias-release-cadence-improve-ecosystem-quality/103114/74?u=tim.holy), perhaps we should consider upper-bounding the Julia version.

This is RFC because I'm not certain this really fixes problems. What this presumably means is that if you have an old Project/Manifest lying around, you upgrade your Julia version, and then activate the project, you'll immediately get a compatibility issue. If you then update the project, often you'll get new versions of everything. So it seems that we're still in a mode where we ensure that new releases of packages work with new versions of Julia, but not fixing the complaint (in that discourse thread) that old package versions don't always work with new Julia releases.

Fundamentally, though, practical experience makes me skeptical that the current version of JuliaInterpreter can be trusted to work on, say, Julia 1.14. That alone seems to argue that bounding makes sense, even if it just changes the kind of error. A possible downside is that you're trading an error that you think is likely to one that is guaranteed.