### PR TITLE
Add a second link to the docs from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 ]add JuliaInterpreter
 ```
 
+## Usage
+
+See the [documentation][docs-stable-url].
+
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://JuliaDebug.github.io/JuliaInterpreter.jl/stable
 


### PR DESCRIPTION
The badges seem less visible to some people than text links (I may have been in that camp once myself?), so let's have both.

Closes #587