### PR TITLE
remove old compats

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -119,7 +119,7 @@ maybe_next_until!(@nospecialize(predicate), frame::Frame, istoplevel::Bool=false
     pc = next_call!(frame, istoplevel=false)
 
 Execute the current statement. Continue stepping through `frame` until the next
-`:return` or `:call` expression.
+`ReturnNode` or `:call` expression.
 """
 next_call!(@nospecialize(recurse), frame::Frame, istoplevel::Bool=false) =
     next_until!(frame -> is_call_or_return(pc_expr(frame)), recurse, frame, istoplevel)
@@ -129,8 +129,8 @@ next_call!(frame::Frame, istoplevel::Bool=false) = next_call!(finish_and_return!
     pc = maybe_next_call!(recurse, frame, istoplevel=false)
     pc = maybe_next_call!(frame, istoplevel=false)
 
-Return the current program counter of `frame` if it is a `:return` or `:call` expression.
-Otherwise, step through the statements of `frame` until the next `:return` or `:call` expression.
+Return the current program counter of `frame` if it is a `ReturnNode` or `:call` expression.
+Otherwise, step through the statements of `frame` until the next `ReturnNode` or `:call` expression.
 """
 maybe_next_call!(@nospecialize(recurse), frame::Frame, istoplevel::Bool=false) =
     maybe_next_until!(frame -> is_call_or_return(pc_expr(frame)), recurse, frame, istoplevel)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1,6 +1,6 @@
 using Base.Meta
 import Base: +, -, convert, isless, get_world_counter
-using Core: CodeInfo, SimpleVector, LineInfoNode, GotoNode,
+using Core: CodeInfo, SimpleVector, LineInfoNode, GotoNode, GotoIfNot, ReturnNode,
             GeneratedFunctionStub, MethodInstance, NewvarNode, TypeName
 
 using UUIDs

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,25 +132,7 @@ end
 
 isidentical(x) = Base.Fix2(===, x)   # recommended over isequal(::Symbol) since it cannot be invalidated
 
-# is_goto_node(@nospecialize(node)) = isa(node, GotoNode) || isexpr(node, :gotoifnot)
-
-if isdefined(Core, :GotoIfNot)
-    is_GotoIfNot(@nospecialize(node)) = isa(node, Core.GotoIfNot)
-    is_gotoifnot(@nospecialize(node)) = is_GotoIfNot(node)
-else
-    is_GotoIfNot(@nospecialize(node)) = false
-    is_gotoifnot(@nospecialize(node)) = isexpr(node, :gotoifnot)
-end
-
-if isdefined(Core, :ReturnNode)
-    is_ReturnNode(@nospecialize(node)) = isa(node, Core.ReturnNode)
-    is_return(@nospecialize(node)) = is_ReturnNode(node)
-    get_return_node(@nospecialize(node)) = (node::Core.ReturnNode).val
-else
-    is_ReturnNode(@nospecialize(node)) = false
-    is_return(@nospecialize(node)) = isexpr(node, :return)
-    get_return_node(@nospecialize(node)) = node.args[1]
-end
+is_return(@nospecialize(node)) = node isa ReturnNode
 
 is_loc_meta(@nospecialize(expr), @nospecialize(kind)) = isexpr(expr, :meta) && length(expr.args) >= 1 && expr.args[1] === kind
 
@@ -184,7 +166,7 @@ function is_call(@nospecialize(node))
         (isexpr(node, :(=)) && (isexpr(node.args[2], :call)))
 end
 
-is_call_or_return(@nospecialize(node)) = is_call(node) || is_return(node)
+is_call_or_return(@nospecialize(node)) = is_call(node) || node isa ReturnNode
 
 is_dummy(bpref::BreakpointRef) = bpref.stmtidx == 0 && bpref.err === nothing
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -25,8 +25,8 @@ using Test
     end
 
     thunk = Meta.lower(Main, :(return 1+2))
-    stmt = thunk.args[1].code[end]   # the return
-    @test JuliaInterpreter.get_return_node(stmt) isa Core.SSAValue
+    stmt = thunk.args[1].code[end]::Core.ReturnNode   # the return
+    @test stmt.val isa Core.SSAValue
 
     @test string(JuliaInterpreter.parametric_type_to_expr(Base.Iterators.Stateful{String})) ∈
         ("Base.Iterators.Stateful{String, VS}", "(Base.Iterators).Stateful{String, VS}", "Base.Iterators.Stateful{String, VS, N}")

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -38,7 +38,7 @@ end
     @test Aborted(frame, i).at.line == 6
     # Check conditional
     frame = Frame(modexs[4]...)
-    i = findfirst(stmt->JuliaInterpreter.is_gotoifnot(stmt), frame.framecode.src.code) + 1
+    i = findfirst(stmt->isa(stmt, Core.GotoIfNot), frame.framecode.src.code) + 1
     @test Aborted(frame, i).at.line == 9
     # Check macro
     frame = Frame(modexs[5]...)


### PR DESCRIPTION
The version compat is >=1.6, so we can expect `ReturnNode` and `GotoIfNot` are defined in `Core` always.
This should be good to go as far as 1.6 CI passes.