### PR TITLE
Rename check_builtins.yml job from "CI" to "check_builtins"

### DIFF
--- a/.github/workflows/check_builtins.yml
+++ b/.github/workflows/check_builtins.yml
@@ -1,4 +1,4 @@
-name: CI
+name: check_builtins
 on:
   pull_request:
   push:


### PR DESCRIPTION
It is rather confusing that https://github.com/JuliaDebug/JuliaInterpreter.jl/actions/workflows/check_builtins.yml lists two "CI" workflows which do really different things.