### PR TITLE
changes to adapt to compressed line table format

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -172,7 +172,7 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
         if (!isempty(lenv) && (hasarg(isidentical(:llvmcall), code.code) ||
                                hasarg(isidentical(Base.llvmcall), code.code) ||
                                hasarg(a->is_global_ref(a, Base, :llvmcall), code.code))) ||
-                hasarg(isidentical(:iolock_begin), code.code)
+                               hasarg(isidentical(:iolock_begin), code.code)
             return Compiled()
         end
         framecode = FrameCode(method, code; generator=generator)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -36,8 +36,7 @@ struct Aborted    # for signaling that some statement or test blocks were interr
 end
 
 function Aborted(frame::Frame, pc)
-    src = frame.framecode.src
-    lineidx = src.codelocs[pc]
+    lineidx = JuliaInterpreter.codelocs(frame, pc)
     lineinfo = JuliaInterpreter.linetable(frame, lineidx; macro_caller=true)
     return Aborted(lineinfo)
 end


### PR DESCRIPTION
This contains some of the updates needed to keep working with the optimized debuginfo format (https://github.com/JuliaLang/julia/pull/52415). This is a draft, since someone needs integrate this to maintain support for old versions, where the old code is mostly marked here with my initials (jwn) and my initials should be removed entirely and instead the implementation in those places fixed.