### PR TITLE
JuliaSyntax says `public` as an identifier is deprecated

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -352,7 +352,7 @@ In a fresh session,
 
 ```
 julia> expr = quote
-           public(x::Integer) = true
+           public_fn(x::Integer) = true
            module Private
            private(y::String) = false
            end
@@ -365,7 +365,7 @@ julia> for (mod, ex) in ExprSplitter(Main, expr)
 mod = Main
 ex = quote
     #= REPL[7]:2 =#
-    public(x::Integer) = begin
+    public_fn(x::Integer) = begin
             #= REPL[7]:2 =#
             true
         end
@@ -415,7 +415,7 @@ julia> for (mod, ex) in ExprSplitter(Main, expr)
 julia> threshold
 0.1
 
-julia> public(3)
+julia> public_fn(3)
 true
 ```
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,12 +1,12 @@
 module var"#Internal"
-public(x::String) = false
+public_fn(x::String) = false
 end
 
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @interpret sum(rand(10))
     expr = quote
-        public(x::Integer) = true
+        public_fn(x::Integer) = true
         module Private
             private(y::String) = false
         end


### PR DESCRIPTION
This makes JuliaSyntax happier when parsing the code of JuliaInterpreter. Note this doesn't affect normal usage of the package.

Found when testing out https://github.com/ericphanson/ExplicitImports.jl, which relies on source code parsing via JuliaSyntax.

## master
```julia
julia> JuliaSyntax.parseall(JuliaSyntax.SyntaxNode, read("src/precompile.jl", String); version=v"1.11")
ERROR: ParseError:
# Warning @ line 2:1
module var"#Internal"
public(x::String) = false
└────┘ ── using public as an identifier is deprecated
Stacktrace:
 [1] _parse(rule::Symbol, need_eof::Bool, ::Type{…}, text::String, index::Int64; version::VersionNumber, ignore_trivia::Bool, filename::Nothing, first_line::Int64, ignore_errors::Bool, ignore_warnings::Bool, kws::@Kwargs{})
   @ JuliaSyntax ~/.julia/packages/JuliaSyntax/eqCSU/src/parser_api.jl:93
 [2] _parse (repeats 2 times)
   @ ~/.julia/packages/JuliaSyntax/eqCSU/src/parser_api.jl:77 [inlined]
 [3] #parseall#96
   @ ~/.julia/packages/JuliaSyntax/eqCSU/src/parser_api.jl:143 [inlined]
 [4] top-level scope
   @ REPL[9]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

## PR
```julia
julia> JuliaSyntax.parseall(JuliaSyntax.SyntaxNode, read("src/precompile.jl", String); version=v"1.11")
line:col│ tree                                   │ file_name
   1:1  │[toplevel]
   1:1  │  [module]
   1:8  │    [var]
   1:12 │      #Internal
   1:22 │    [block]
   2:1  │      [=]
   2:1  │        [call]
   2:1  │          public_fn
   2:11 │          [::-i]
   2:11 │            x
   2:14 │            String
   2:24 │        false
   5:1  │  [function]
   5:10 │    [call]
   5:10 │      _precompile_
   5:24 │    [block]
   6:5  │      [||]
   6:5  │        [call-i]
   6:5  │          [call]
   6:5  │            ccall
   6:11 │            [quote-:]
   6:12 │              jl_generating_output
   6:34 │            Cint
   6:40 │            [tuple-p]
   6:44 │          ==
   6:47 │          1
   6:52 │        [return]
   6:59 │          nothing
   7:5  │      [macrocall]
   7:6  │        @interpret
   7:16 │        [call]
   7:16 │          sum
   7:20 │          [call]
   7:20 │            rand
   7:25 │            10
   8:5  │      [=]
   8:5  │        expr
   8:12 │        [quote]
   8:12 │          [block]
   9:9  │            [=]
   9:9  │              [call]
   9:9  │                public_fn
   9:19 │                [::-i]
   9:19 │                  x
   9:22 │                  Integer
   9:33 │              true
  10:9  │            [module]
  10:16 │              Private
  10:23 │              [block]
  11:13 │                [=]
  11:13 │                  [call]
  11:13 │                    private
  11:21 │                    [::-i]
  11:21 │                      y
  11:24 │                      String
  11:34 │                  false
  13:9  │            [const]
  13:14 │              [=]
  13:15 │                threshold
  13:27 │                0.1
  15:5  │      [for]
  15:8  │        [=]
  15:9  │          [tuple-p]
  15:10 │            mod
  15:15 │            ex
  15:22 │          [call]
  15:22 │            ExprSplitter
  15:35 │            [var]
  15:39 │              #Internal
  15:51 │            expr
  15:56 │        [block]
  16:9  │          [=]
  16:9  │            frame
  16:17 │            [call]
  16:17 │              Frame
  16:23 │              mod
  16:28 │              ex
  17:9  │          [call]
  17:9  │            debug_command
  17:23 │            frame
  17:30 │            [quote-:]
  17:31 │              c
  17:34 │            true
```