### PR TITLE
use child `@testset` to get nicer test summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ deps/build.log
 docs/build/
 test/results.md
 Manifest.toml
+Manifest-*.toml
 !/test/code_coverage/coverage_example.jl.cov

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using JuliaInterpreter
 using Test
 using Logging
 
-
 @test isempty(detect_ambiguities(JuliaInterpreter, Base, Core))
 
 if !isdefined(@__MODULE__, :read_and_parse)
@@ -12,14 +11,14 @@ end
 Core.eval(JuliaInterpreter, :(debug_mode() = true))
 
 @testset "Main tests" begin
-    include("check_builtins.jl")
-    include("core.jl")
-    include("interpret.jl")
-    include("toplevel.jl")
-    include("limits.jl")
-    include("eval_code.jl")
-    include("breakpoints.jl")
-    @static VERSION >= v"1.8.0-DEV.370" && include("code_coverage/code_coverage.jl")
+    @testset "check_bulitins.jl" begin include("check_builtins.jl") end
+    @testset "core.jl" begin include("core.jl") end
+    @testset "interpret.jl" begin include("interpret.jl") end
+    @testset "toplevel.jl" begin include("toplevel.jl") end
+    @testset "limits.jl" begin include("limits.jl") end
+    @testset "eval_code.jl" begin include("eval_code.jl") end
+    @testset "breakpoints.jl" begin include("breakpoints.jl") end
+    @static VERSION >= v"1.8.0-DEV.370" && @testset "code_coverage/code_coverage.jl" begin include("code_coverage/code_coverage.jl") end
     remove()
-    include("debug.jl")
+    @testset "debug.jl" begin include("debug.jl") end
 end


### PR DESCRIPTION
Without this, the tests would stop prematurely, which means if there's even one unresolved regression, we'd miss out on detecting any additional regressions.
