### PR TITLE
Don't error if we don't have line information

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -457,23 +457,25 @@ function coverage_visit_line!(frame::Frame)
     code.report_coverage || return
     src = code.src
     @static if VERSION ≥ v"1.12.0-DEV.173"
-    lineinfo = linetable(src, pc)
-    file, line = lineinfo.file, lineinfo.line
-    if line != frame.last_codeloc
-        file isa Symbol || (file = Symbol(file)::Symbol)
-        @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
-        frame.last_codeloc = line
-    end
+        lineinfo = linetable(src, pc)
+        if lineinfo !== nothing
+            file, line = lineinfo.file, lineinfo.line
+            if line != frame.last_codeloc
+                file isa Symbol || (file = Symbol(file)::Symbol)
+                @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
+                frame.last_codeloc = line
+            end
+        end
     else # VERSION < v"1.12.0-DEV.173"
-    codeloc = src.codelocs[pc]
-    if codeloc != frame.last_codeloc && codeloc != 0
-        linetable = src.linetable::Vector{Any}
-        lineinfo = linetable[codeloc]::Core.LineInfoNode
-        file, line = lineinfo.file, lineinfo.line
-        file isa Symbol || (file = Symbol(file)::Symbol)
-        @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
-        frame.last_codeloc = codeloc
-    end
+        codeloc = src.codelocs[pc]
+        if codeloc != frame.last_codeloc && codeloc != 0
+            linetable = src.linetable::Vector{Any}
+            lineinfo = linetable[codeloc]::Core.LineInfoNode
+            file, line = lineinfo.file, lineinfo.line
+            file isa Symbol || (file = Symbol(file)::Symbol)
+            @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
+            frame.last_codeloc = codeloc
+        end
     end # @static if
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -353,9 +353,10 @@ function lineoffset(framecode::FrameCode)
     return offset
 end
 
-function getline(ln::Union{LineTypes,Expr})
+function getline(ln::Union{LineTypes,Expr,Nothing})
     _getline(ln::LineTypes) = Int(ln.line)
     _getline(ln::Expr)      = ln.args[1]::Int # assuming ln.head === :line
+    _getline(::Nothing)     = nothing
     return _getline(ln)
 end
 function getfile(ln::Union{LineTypes,Expr})


### PR DESCRIPTION
`whereis` is already allowed to return `nothing`. It's possible for codeloc to be != 0, but for Core.Compiler to still be unable to produce a location. In that case, also return `nothing`.