### PR TITLE
fix #642

### DIFF
--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -98,7 +98,9 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
     bp.f isa Method && return meth === bp.f
     f = extract_function_from_method(meth)
     if !(bp.f === f || @static isdefined(Core, :kwcall) ?
-            f === Core.kwcall && bp.f isa meth.sig.parameters[3] :
+            f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3] 
+                !Base.has_free_typevars(ftype) && bp.f isa ftype
+            end :
             Core.kwfunc(bp.f) === f
         )
         return false

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -593,4 +593,10 @@ end
     fkw2(;x=1) = x
     g2() = fkw2(; x=1)
     @test @interpret g2() === 1
+
+    fkw3(::T; x=1) where {T} = x
+    breakpoint(fkw3)
+    g3() = fkw3(7; x=1)
+    frame, bp = @interpret g3()
+    @test isa(frame, Frame) && isa(bp, JuliaInterpreter.BreakpointRef)
 end


### PR DESCRIPTION
The fix in #641 accidentally introduced a bug for keyword functions with static parameters
