### PR TITLE
fix interpretation of opaque closures on nightly

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -132,16 +132,6 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         f = @lookup(frame, fex)
     end
 
-    if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
-        if expand
-            if !Core.Compiler.uncompressed_ir(f.source).inferred
-                return Expr(:call, f, args[2:end]...)
-            else
-                @debug "not interpreting opaque closure \$f since it contains inferred code"
-            end
-        end
-        return Some{Any}(f(args...))
-    end
     if !(isa(f, Core.Builtin) || isa(f, Core.IntrinsicFunction))
         return call_expr
     end

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -38,16 +38,6 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         f = @lookup(frame, fex)
     end
 
-    if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
-        if expand
-            if !Core.Compiler.uncompressed_ir(f.source).inferred
-                return Expr(:call, f, args[2:end]...)
-            else
-                @debug "not interpreting opaque closure $f since it contains inferred code"
-            end
-        end
-        return Some{Any}(f(args...))
-    end
     if !(isa(f, Core.Builtin) || isa(f, Core.IntrinsicFunction))
         return call_expr
     end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -244,7 +244,10 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
         method = f.source
         # don't try to interpret optimized ir
-        if Core.Compiler.uncompressed_ir(method).inferred
+        is_inferred_ir = any(Core.Compiler.uncompressed_ir(f.source).code) do stmt
+            stmt isa Core.PiNode || stmt isa Core.PhiNode || stmt isa Core.PhiCNode || stmt isa Core.UpsilonNode
+        end
+        if is_inferred_ir
             @debug "not interpreting opaque closure $f since it contains inferred code"
             return nothing
         end


### PR DESCRIPTION
This is the best way I could think of to determine whether an OC
contains inferred code after JuliaLang/julia#53219. Also deletes a
fastpath we had for OCs containing inferred code in
`maybe_evaluate_builtin` as it doesn't really seem necessary and we
would otherwise scan the IR twice for OCs we do want to interpret.
