### PR TITLE
allow getindex in lookup_or_eval :call

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -112,6 +112,9 @@ function lookup_or_eval(@nospecialize(recurse), frame::Frame, @nospecialize(node
                 return typeassert(ex.args[2], ex.args[3])
             elseif f === Base.getproperty && length(ex.args) == 3
                 return Base.getproperty(ex.args[2], ex.args[3])
+            elseif f === Base.getindex && length(ex.args) >= 3
+                popfirst!(ex.args)
+                return Base.getindex(ex.args...)
             elseif f === Core.Compiler.Val && length(ex.args) == 2
                 return Core.Compiler.Val(ex.args[2])
             elseif f === Val && length(ex.args) == 2


### PR DESCRIPTION
This is needed for CxxWrap.jl to avoid `unknown call f introduced by ccall lowering getindex`, see #613.

Probably for code like this:
```julia
    push!(call_exp.args, :(@inbounds ccall(__cxxwrap_pointers[$funcidx][1], $c_return_type, ($(c_arg_types...),), $(argsymbols...)))) # Direct pointer call
```

This does fix my reproducer from #613.
But I don't really know how a proper test for this would look like.

cc: @barche