### PR TITLE
doctests: use julia lts version in github workflow

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: 'lts'
           show-versioninfo: true         # print versioninfo in the action log
       - uses: actions/checkout@v4
       - uses: julia-actions/julia-buildpkg@latest


### PR DESCRIPTION
There are a bunch of failures in the doctests for #651 which I assume come from the transition to 1.11.
So this changes the github doctests to use the lts version 1.10.