### PR TITLE
Handle `:latestworld` expr

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -550,6 +550,8 @@ function step_expr!(@nospecialize(recurse), frame::Frame, @nospecialize(node), i
                     error("unexpected error statement ", node)
                 elseif node.head === :incomplete
                     error("incomplete statement ", node)
+                elseif node.head === :latestworld
+                    frame.world = Base.get_world_counter()
                 else
                     rhs = eval_rhs(recurse, frame, node)
                 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -256,7 +256,8 @@ mutable struct Frame
     # TODO: This is incompletely implemented
     world::UInt
 end
-function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing, world=Base.tls_world_age())
+function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing,
+               world=isdefined(Base, :tls_world_age) ? Base.tls_world_age() : Base.get_world_counter())
     if length(junk_frames) > 0
         frame = pop!(junk_frames)
         frame.framecode = framecode

--- a/src/types.jl
+++ b/src/types.jl
@@ -253,8 +253,10 @@ mutable struct Frame
     caller::Union{Frame,Nothing}
     callee::Union{Frame,Nothing}
     last_codeloc::Int
+    # TODO: This is incompletely implemented
+    world::UInt
 end
-function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing)
+function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing, world=Base.tls_world_age())
     if length(junk_frames) > 0
         frame = pop!(junk_frames)
         frame.framecode = framecode
@@ -264,9 +266,10 @@ function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing)
         frame.caller = caller
         frame.callee = nothing
         frame.last_codeloc = 0
+        frame.world = world
         return frame
     else
-        return Frame(framecode, framedata, pc, 1, caller, nothing, 0)
+        return Frame(framecode, framedata, pc, 1, caller, nothing, 0, world)
     end
 end
 """


### PR DESCRIPTION
These were added in https://github.com/JuliaLang/julia/pull/56523. This simply adds tracking for the world age to the interpreter, but does not use it for anything. JuliaInterpreter's current model of world age does not match Base anyway. We should fix that eventually, but it's probably easier to do that once https://github.com/JuliaLang/julia/pull/56509 and binding partitions are merged.