### PR TITLE
bump the minimum supported Julia version to 1.10 (LTS)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: '1.6' # old LTS
+          - version: '1' # current stable
             os: ubuntu-latest
             arch: x64
-          - version: '1.10' # current stable
+          - version: '1.10' # lowerest version supported
             os: ubuntu-latest
             arch: x64
-          - version: '~1.11.0-0' # next release
+          - version: '1.12-nightly' # next release
             os: ubuntu-latest
             arch: x64
           - version: 'nightly' # dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           - version: '1' # current stable
             os: ubuntu-latest
             arch: x64
-          - version: '1.10' # lowerest version supported
+          - version: '1.10' # lowest version supported
             os: ubuntu-latest
             arch: x64
           - version: '1.12-nightly' # next release

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.9.37"
+version = "0.10.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -10,7 +10,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodeTracking = "0.5.9, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 CassetteOverlay = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.10.0"
+version = "0.9.38"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -2,16 +2,26 @@
 # Should be run on the latest Julia nightly
 using InteractiveUtils
 
-# All builtins present in 1.6
-const ALWAYS_PRESENT = Core.Builtin[
-    (<:), (===), Core._abstracttype, Core._apply_iterate, Core._apply_pure,
-    Core._call_in_world, Core._call_latest, Core._equiv_typedef, Core._expr,
-    Core._primitivetype, Core._setsuper!, Core._structtype, Core._typebody!,
-    Core._typevar, Core.apply_type, Core.ifelse, Core.sizeof, Core.svec,
-    applicable, fieldtype, getfield, invoke, isa, isdefined, nfields,
-    setfield!, throw, tuple, typeassert, typeof
+# All builtins present in 1.10
+const RECENTLY_ADDED = Core.Builtin[
+    Core.current_scope,
+    Core.memoryref_isassigned,
+    Core.memoryrefget,
+    Core.memoryrefmodify!,
+    Core.memoryrefnew,
+    Core.memoryrefoffset,
+    Core.memoryrefreplace!,
+    Core.memoryrefset!,
+    Core.memoryrefsetonce!,
+    Core.memoryrefswap!,
+    Core.throw_methoderror,
+    modifyglobal!,
+    replaceglobal!,
+    setfieldonce!,
+    setglobalonce!,
+    swapglobal!,
 ]
-# Builtins present from 1.6, not builtins (potentially still normal functions) anymore
+# Builtins present from 1.10, not builtins (potentially still normal functions) anymore
 const RECENTLY_REMOVED = GlobalRef.(Ref(Core), [
     :arrayref, :arrayset, :arrayset, :const_arrayref, :memoryref, :set_binding_type!
 ])
@@ -235,7 +245,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 
         id = findfirst(isequal(f), Core.Compiler.T_FFUNC_KEY)
         fcall = generate_fcall(f, Core.Compiler.T_FFUNC_VAL, id)
-        if !(f in ALWAYS_PRESENT)
+        if f in RECENTLY_ADDED
             print(io,
 """
     $head @static isdefined($(ft.name.module), $(repr(nameof(f)))) && f === $fname

--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -2,7 +2,7 @@
 # Should be run on the latest Julia nightly
 using InteractiveUtils
 
-# All builtins present in 1.10
+# Builtins not present in 1.10 (the lowest supported version)
 const RECENTLY_ADDED = Core.Builtin[
     Core.current_scope,
     Core.memoryref_isassigned,

--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -132,7 +132,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         f = @lookup(frame, fex)
     end
 
-    if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
+    if f isa Core.OpaqueClosure
         if expand
             if !Core.Compiler.uncompressed_ir(f.source).inferred
                 return Expr(:call, f, args[2:end]...)
@@ -324,16 +324,14 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 """
     if isa(f, Core.IntrinsicFunction)
         cargs = getargs(args, frame)
-        @static if isdefined(Core.Intrinsics, :have_fma)
-            if f === Core.Intrinsics.have_fma && length(cargs) == 1
-                cargs1 = cargs[1]
-                if cargs1 == Float64
-                    return Some{Any}(FMA_FLOAT64[])
-                elseif cargs1 == Float32
-                    return Some{Any}(FMA_FLOAT32[])
-                elseif cargs1 == Float16
-                    return Some{Any}(FMA_FLOAT16[])
-                end
+        if f === Core.Intrinsics.have_fma && length(cargs) == 1
+            cargs1 = cargs[1]
+            if cargs1 == Float64
+                return Some{Any}(FMA_FLOAT64[])
+            elseif cargs1 == Float32
+                return Some{Any}(FMA_FLOAT32[])
+            elseif cargs1 == Float16
+                return Some{Any}(FMA_FLOAT16[])
             end
         end
         if f === Core.Intrinsics.muladd_float && length(cargs) == 3

--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -134,7 +134,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 
     if f isa Core.OpaqueClosure
         if expand
-            if !Core.Compiler.uncompressed_ir(f.source).inferred
+            if !Base.uncompressed_ir(f.source).inferred
                 return Expr(:call, f, args[2:end]...)
             else
                 @debug "not interpreting opaque closure \$f since it contains inferred code"

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -97,12 +97,9 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
     meth isa Method || return false
     bp.f isa Method && return meth === bp.f
     f = extract_function_from_method(meth)
-    if !(bp.f === f || @static isdefined(Core, :kwcall) ?
-            f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3] 
+    if !(bp.f === f || (f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3]
                 !Base.has_free_typevars(ftype) && bp.f isa ftype
-            end :
-            Core.kwfunc(bp.f) === f
-        )
+            end))
         return false
     end
     bp.sig === nothing && return true

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -86,7 +86,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core._apply_pure(getargs(args, frame)...))
     elseif f === Core._call_in_world
         return Some{Any}(Core._call_in_world(getargs(args, frame)...))
-    elseif @static isdefined(Core, :_call_in_world_total) && f === Core._call_in_world_total
+    elseif f === Core._call_in_world_total
         return Some{Any}(Core._call_in_world_total(getargs(args, frame)...))
     elseif f === Core._call_latest
         args = getargs(args, frame)
@@ -99,7 +99,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             push!(new_expr.args, QuoteNode(x))
         end
         return maybe_recurse_expanded_builtin(frame, new_expr)
-    elseif @static isdefined(Core, :_compute_sparams) && f === Core._compute_sparams
+    elseif f === Core._compute_sparams
         return Some{Any}(Core._compute_sparams(getargs(args, frame)...))
     elseif f === Core._equiv_typedef
         return Some{Any}(Core._equiv_typedef(getargs(args, frame)...))
@@ -111,7 +111,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core._setsuper!(getargs(args, frame)...))
     elseif f === Core._structtype
         return Some{Any}(Core._structtype(getargs(args, frame)...))
-    elseif @static isdefined(Core, :_svec_ref) && f === Core._svec_ref
+    elseif f === Core._svec_ref
         return Some{Any}(Core._svec_ref(getargs(args, frame)...))
     elseif f === Core._typebody!
         return Some{Any}(Core._typebody!(getargs(args, frame)...))
@@ -123,7 +123,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         end
     elseif f === Core.apply_type
         return Some{Any}(Core.apply_type(getargs(args, frame)...))
-    elseif @static isdefined(Core, :compilerbarrier) && f === Core.compilerbarrier
+    elseif f === Core.compilerbarrier
         if nargs == 2
             return Some{Any}(Core.compilerbarrier(@lookup(frame, args[2]), @lookup(frame, args[3])))
         else
@@ -139,9 +139,9 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(Core.current_scope(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :donotdelete) && f === Core.donotdelete
+    elseif f === Core.donotdelete
         return Some{Any}(Core.donotdelete(getargs(args, frame)...))
-    elseif @static isdefined(Core, :finalizer) && f === Core.finalizer
+    elseif f === Core.finalizer
         if nargs == 2
             return Some{Any}(Core.finalizer(@lookup(frame, args[2]), @lookup(frame, args[3])))
         elseif nargs == 3
@@ -151,7 +151,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(Core.finalizer(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :get_binding_type) && f === Core.get_binding_type
+    elseif f === Core.get_binding_type
         return Some{Any}(Core.get_binding_type(getargs(args, frame)...))
     elseif f === Core.ifelse
         if nargs == 3
@@ -251,7 +251,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(getfield(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :getglobal) && f === getglobal
+    elseif f === getglobal
         return Some{Any}(getglobal(getargs(args, frame)...))
     elseif f === invoke
         if !expand
@@ -275,7 +275,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(isdefined(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :modifyfield!) && f === modifyfield!
+    elseif f === modifyfield!
         if nargs == 4
             return Some{Any}(modifyfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
         elseif nargs == 5
@@ -291,7 +291,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(nfields(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :replacefield!) && f === replacefield!
+    elseif f === replacefield!
         if nargs == 4
             return Some{Any}(replacefield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
         elseif nargs == 5
@@ -321,11 +321,11 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         else
             return Some{Any}(setfieldonce!(getargs(args, frame)...))
         end
-    elseif @static isdefined(Core, :setglobal!) && f === setglobal!
+    elseif f === setglobal!
         return Some{Any}(setglobal!(getargs(args, frame)...))
     elseif @static isdefined(Core, :setglobalonce!) && f === setglobalonce!
         return Some{Any}(setglobalonce!(getargs(args, frame)...))
-    elseif @static isdefined(Core, :swapfield!) && f === swapfield!
+    elseif f === swapfield!
         if nargs == 3
             return Some{Any}(swapfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
         elseif nargs == 4

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -38,7 +38,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         f = @lookup(frame, fex)
     end
 
-    if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
+    if f isa Core.OpaqueClosure
         if expand
             if !Core.Compiler.uncompressed_ir(f.source).inferred
                 return Expr(:call, f, args[2:end]...)
@@ -152,11 +152,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(Core.finalizer(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :get_binding_type) && f === Core.get_binding_type
-        if nargs == 2
-            return Some{Any}(Core.get_binding_type(@lookup(frame, args[2]), @lookup(frame, args[3])))
-        else
-            return Some{Any}(Core.get_binding_type(getargs(args, frame)...))
-        end
+        return Some{Any}(Core.get_binding_type(getargs(args, frame)...))
     elseif f === Core.ifelse
         if nargs == 3
             return Some{Any}(Core.ifelse(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
@@ -256,13 +252,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(getfield(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :getglobal) && f === getglobal
-        if nargs == 2
-            return Some{Any}(getglobal(@lookup(frame, args[2]), @lookup(frame, args[3])))
-        elseif nargs == 3
-            return Some{Any}(getglobal(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
-        else
-            return Some{Any}(getglobal(getargs(args, frame)...))
-        end
+        return Some{Any}(getglobal(getargs(args, frame)...))
     elseif f === invoke
         if !expand
             argswrapped = getargs(args, frame)
@@ -294,13 +284,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(modifyfield!(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :modifyglobal!) && f === modifyglobal!
-        if nargs == 4
-            return Some{Any}(modifyglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
-        elseif nargs == 5
-            return Some{Any}(modifyglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
-        else
-            return Some{Any}(modifyglobal!(getargs(args, frame)...))
-        end
+        return Some{Any}(modifyglobal!(getargs(args, frame)...))
     elseif f === nfields
         if nargs == 1
             return Some{Any}(nfields(@lookup(frame, args[2])))
@@ -318,15 +302,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(replacefield!(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :replaceglobal!) && f === replaceglobal!
-        if nargs == 4
-            return Some{Any}(replaceglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
-        elseif nargs == 5
-            return Some{Any}(replaceglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
-        elseif nargs == 6
-            return Some{Any}(replaceglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
-        else
-            return Some{Any}(replaceglobal!(getargs(args, frame)...))
-        end
+        return Some{Any}(replaceglobal!(getargs(args, frame)...))
     elseif f === setfield!
         if nargs == 3
             return Some{Any}(setfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
@@ -346,23 +322,9 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(setfieldonce!(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :setglobal!) && f === setglobal!
-        if nargs == 3
-            return Some{Any}(setglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
-        elseif nargs == 4
-            return Some{Any}(setglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
-        else
-            return Some{Any}(setglobal!(getargs(args, frame)...))
-        end
+        return Some{Any}(setglobal!(getargs(args, frame)...))
     elseif @static isdefined(Core, :setglobalonce!) && f === setglobalonce!
-        if nargs == 3
-            return Some{Any}(setglobalonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
-        elseif nargs == 4
-            return Some{Any}(setglobalonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
-        elseif nargs == 5
-            return Some{Any}(setglobalonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
-        else
-            return Some{Any}(setglobalonce!(getargs(args, frame)...))
-        end
+        return Some{Any}(setglobalonce!(getargs(args, frame)...))
     elseif @static isdefined(Core, :swapfield!) && f === swapfield!
         if nargs == 3
             return Some{Any}(swapfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
@@ -372,13 +334,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             return Some{Any}(swapfield!(getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :swapglobal!) && f === swapglobal!
-        if nargs == 3
-            return Some{Any}(swapglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
-        elseif nargs == 4
-            return Some{Any}(swapglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
-        else
-            return Some{Any}(swapglobal!(getargs(args, frame)...))
-        end
+        return Some{Any}(swapglobal!(getargs(args, frame)...))
     elseif f === throw
         if nargs == 1
             return Some{Any}(throw(@lookup(frame, args[2])))
@@ -500,16 +456,14 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     end
     if isa(f, Core.IntrinsicFunction)
         cargs = getargs(args, frame)
-        @static if isdefined(Core.Intrinsics, :have_fma)
-            if f === Core.Intrinsics.have_fma && length(cargs) == 1
-                cargs1 = cargs[1]
-                if cargs1 == Float64
-                    return Some{Any}(FMA_FLOAT64[])
-                elseif cargs1 == Float32
-                    return Some{Any}(FMA_FLOAT32[])
-                elseif cargs1 == Float16
-                    return Some{Any}(FMA_FLOAT16[])
-                end
+        if f === Core.Intrinsics.have_fma && length(cargs) == 1
+            cargs1 = cargs[1]
+            if cargs1 == Float64
+                return Some{Any}(FMA_FLOAT64[])
+            elseif cargs1 == Float32
+                return Some{Any}(FMA_FLOAT32[])
+            elseif cargs1 == Float16
+                return Some{Any}(FMA_FLOAT16[])
             end
         end
         if f === Core.Intrinsics.muladd_float && length(cargs) == 3

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -40,7 +40,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 
     if f isa Core.OpaqueClosure
         if expand
-            if !Core.Compiler.uncompressed_ir(f.source).inferred
+            if !Base.uncompressed_ir(f.source).inferred
                 return Expr(:call, f, args[2:end]...)
             else
                 @debug "not interpreting opaque closure $f since it contains inferred code"

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -226,8 +226,7 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
         if unwrap1 isa DataType
             param1 = Base.unwrap_unionall(unwrap1.parameters[1])
             if param1 isa DataType
-                is_kw = isdefined(Core, :kwcall) ? param1.name.name === Symbol("#kwcall") :
-                                                   endswith(String(param1.name.name), "#kw")
+                is_kw = param1.name.name === Symbol("#kwcall")
             end
         end
     end
@@ -255,13 +254,8 @@ function maybe_step_through_wrapper!(@nospecialize(recurse), frame::Frame)
 end
 maybe_step_through_wrapper!(frame::Frame) = maybe_step_through_wrapper!(finish_and_return!, frame)
 
-if isdefined(Core, :kwcall)
-    const kwhandler = Core.kwcall
-    const kwextrastep = 0
-else
-    const kwhandler = Core.kwfunc
-    const kwextrastep = 1
-end
+const kwhandler = Core.kwcall
+const kwextrastep = 0
 
 """
     frame = maybe_step_through_kwprep!(recurse, frame)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -236,7 +236,7 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     if f isa Core.OpaqueClosure
         method = f.source
         # don't try to interpret optimized ir
-        if Core.Compiler.uncompressed_ir(method).inferred
+        if Base.uncompressed_ir(method).inferred
             @debug "not interpreting opaque closure $f since it contains inferred code"
             return nothing
         end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -88,18 +88,10 @@ end
 
 get_source(meth::Method) = Base.uncompressed_ast(meth)
 
-@static if VERSION < v"1.10.0-DEV.873"  # julia#48766
-    function get_source(g::GeneratedFunctionStub, env, file, line)
-        b = g(env..., g.argnames...)
-        b isa CodeInfo && return b
-        return eval(b)
-    end
-else
-    function get_source(g::GeneratedFunctionStub, env, file, line::Int)
-        b = g(Base.get_world_counter(), LineNumberNode(line, file), env..., g.argnames...)
-        b isa CodeInfo && return b
-        return eval(b)
-    end
+function get_source(g::GeneratedFunctionStub, env, file, line::Int)
+    b = g(Base.get_world_counter(), LineNumberNode(line, file), env..., g.argnames...)
+    b isa CodeInfo && return b
+    return eval(b)
 end
 
 """
@@ -241,7 +233,7 @@ function prepare_call(@nospecialize(f), allargs; enter_generated = false)
     end
     argtypesv = Any[_Typeof(a) for a in allargs]
     argtypes = Tuple{argtypesv...}
-    if @static isdefined(Core, :OpaqueClosure) && f isa Core.OpaqueClosure
+    if f isa Core.OpaqueClosure
         method = f.source
         # don't try to interpret optimized ir
         if Core.Compiler.uncompressed_ir(method).inferred
@@ -308,7 +300,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         islastva = meth.isva && nargs >= meth_nargs
         for i = 1:meth_nargs-islastva
             # for OCs #self# actually refers to the captures instead
-            if @static isdefined(Core, :OpaqueClosure) && i == 1 && (oc = argvals[1]) isa Core.OpaqueClosure
+            if i == 1 && (oc = argvals[1]) isa Core.OpaqueClosure
                 locals[i], last_reference[i] = Some{Any}(oc.captures), 1
             elseif i <= nargs
                 locals[i], last_reference[i] = Some{Any}(argvals[i]), 1

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -271,11 +271,7 @@ function replace_coretypes_list!(list::AbstractVector; rev::Bool=false)
             isa(x, Core.SSAValue) && return SSAValue(x.id)
             isa(x, Core.SlotNumber) && return SlotNumber(x.id)
             @static if VERSION < v"1.11.0-DEV.337"
-                @static if VERSION ≥ v"1.10.0-DEV.631"
-                    isa(x, Core.Compiler.TypedSlot) && return SlotNumber(x.id)
-                else
-                    isa(x, Core.TypedSlot) && return SlotNumber(x.id)
-                end
+            isa(x, Core.Compiler.TypedSlot) && return SlotNumber(x.id)
             end
             return x
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -257,7 +257,7 @@ mutable struct Frame
     world::UInt
 end
 function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing,
-               world=isdefined(Base, :tls_world_age) ? Base.tls_world_age() : Base.get_world_counter())
+               world=@static isdefined(Base, :tls_world_age) ? Base.tls_world_age() : Base.get_world_counter())
     if length(junk_frames) > 0
         frame = pop!(junk_frames)
         frame.framecode = framecode

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,18 +33,11 @@ and doesn't throw when there is no matching method.
 """
 function whichtt(@nospecialize(tt))
     # TODO: provide explicit control over world age? In case we ever need to call "old" methods.
-    @static if VERSION ≥ v"1.8-beta2"
-        # branch on https://github.com/JuliaLang/julia/pull/44515
-        # for now, actual code execution doesn't ever need to consider overlayed method table
-        match, _ = Core.Compiler._findsup(tt, nothing, get_world_counter())
-        match === nothing && return nothing
-        return match.method
-    else
-        m = ccall(:jl_gf_invoke_lookup, Any, (Any, Csize_t), tt, get_world_counter())
-        m === nothing && return nothing
-        isa(m, Method) && return m
-        return m.func::Method
-    end
+    # branch on https://github.com/JuliaLang/julia/pull/44515
+    # for now, actual code execution doesn't ever need to consider overlayed method table
+    match, _ = Core.Compiler._findsup(tt, nothing, get_world_counter())
+    match === nothing && return nothing
+    return match.method
 end
 
 instantiate_type_in_env(arg, spsig::UnionAll, spvals::Vector{Any}) =
@@ -210,11 +203,7 @@ end
 
 is_generated(meth::Method) = isdefined(meth, :generator)
 
-@static if VERSION < v"1.10.0-DEV.873"  # julia#48766
-    get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi)
-else
-    get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi, Base.get_world_counter())
-end
+get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi, Base.get_world_counter())
 
 """
     is_doc_expr(ex)
@@ -239,20 +228,7 @@ end
 
 is_leaf(frame::Frame) = frame.callee === nothing
 
-function is_vararg_type(x)
-    @static if isa(Vararg, Type)
-        if isa(x, Type)
-            (x <: Vararg && !(x <: Union{})) && return true
-            if isa(x, UnionAll)
-                x = Base.unwrap_unionall(x)
-            end
-            return isa(x, DataType) && nameof(x) === :Vararg
-        end
-    else
-        return isa(x, typeof(Vararg))
-    end
-    return false
-end
+is_vararg_type(@nospecialize x) = x isa Core.TypeofVararg
 
 ## Location info
 
@@ -524,26 +500,24 @@ end
 
 function framecode_lines(src::CodeInfo)
     buf = IOBuffer()
-    if isdefined(Base.IRShow, :show_ir_stmt)
-        lines = String[]
-        src = replace_coretypes!(copy(src); rev=true)
-        reverse_lookup_globalref!(src.code)
-        io = IOContext(buf, :displaysize => displaysize(stdout),
-                       :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(src))
-        used = BitSet()
-        cfg = Core.Compiler.compute_basic_blocks(src.code)
-        for stmt in src.code
-            Core.Compiler.scan_ssa_use!(push!, used, stmt)
-        end
-        line_info_preprinter = Base.IRShow.lineinfo_disabled
-        line_info_postprinter = Base.IRShow.default_expr_type_printer
-        bb_idx = 1
-        for idx = 1:length(src.code)
-            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
-            push!(lines, chomp(String(take!(buf))))
-        end
-        return lines
+    lines = String[]
+    src = replace_coretypes!(copy(src); rev=true)
+    reverse_lookup_globalref!(src.code)
+    io = IOContext(buf, :displaysize => displaysize(stdout),
+                    :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(src))
+    used = BitSet()
+    cfg = Core.Compiler.compute_basic_blocks(src.code)
+    for stmt in src.code
+        Core.Compiler.scan_ssa_use!(push!, used, stmt)
     end
+    line_info_preprinter = Base.IRShow.lineinfo_disabled
+    line_info_postprinter = Base.IRShow.default_expr_type_printer
+    bb_idx = 1
+    for idx = 1:length(src.code)
+        bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
+        push!(lines, chomp(String(take!(buf))))
+    end
+    return lines
     show(buf, src)
     code = filter!(split(String(take!(buf)), '\n')) do line
         !(line == "CodeInfo(" || line == ")" || isempty(line) || occursin("within `", line))
@@ -829,12 +803,8 @@ function Base.show_backtrace(io::IO, frame::Frame)
     nd = ndigits(length(stackframes))
     for (i, (last_frame, n)) in enumerate(stackframes)
         frame_counter += 1
-        if isdefined(Base, :print_stackframe)
-            println(io)
-            Base.print_stackframe(io, i, last_frame, n, nd, Base.info_color())
-        else
-            Base.show_trace_entry(IOContext(io, :backtrace => true), last_frame, n, prefix = string(" [", frame_counter, "] "))
-        end
+        println(io)
+        Base.print_stackframe(io, i, last_frame, n, nd, Base.info_color())
     end
 end
 

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -195,11 +195,7 @@ struct Squarer end
     # Breakpoint display
     io = IOBuffer()
     frame = JuliaInterpreter.enter_call(loop_radius2, 2)
-    @static if VERSION < v"1.9.0-DEV.846" # https://github.com/JuliaLang/julia/pull/45069
-        LOC = " in $(@__MODULE__) at $(@__FILE__)"
-    else
-        LOC = " @ $(@__MODULE__) $(contractuser(@__FILE__))"
-    end
+    LOC = " @ $(@__MODULE__) $(contractuser(@__FILE__))"
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 1)
     @test repr(bp) == "breakpoint(loop_radius2(n)$LOC:$(3-Δ), line 3)"
     bp = JuliaInterpreter.BreakpointRef(frame.framecode, 0)  # fictive breakpoint

--- a/test/core.jl
+++ b/test/core.jl
@@ -20,9 +20,7 @@ using Test
     frame = JuliaInterpreter.enter_call(buildexpr)
     lines = JuliaInterpreter.framecode_lines(frame.framecode.src)
     # Test that the :copyast ends up on the same line as the println
-    if isdefined(Base.IRShow, :show_ir_stmt)   # only works on Julia 1.6 and higher
-        @test any(str->occursin(":copyast", str) && occursin("println", str), lines)
-    end
+    @test any(str->occursin(":copyast", str) && occursin("println", str), lines)
 
     thunk = Meta.lower(Main, :(return 1+2))
     stmt = thunk.args[1].code[end]::Core.ReturnNode   # the return

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -836,7 +836,7 @@ end
     end
 
     ci = code_typed(foo, NTuple{2, Int}; optimize=false)[][1]
-    mi = Core.Compiler.method_instances(foo, NTuple{2, Int}, Base.get_world_counter())[]
+    mi = Base.method_instances(foo, NTuple{2, Int}, Base.get_world_counter())[]
 
     frameargs = Any[foo, 1, 2]
     framecode = JuliaInterpreter.FrameCode(mi.def, ci)

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -89,14 +89,8 @@ module EvalLimited end
         nstmts = 10*21 + 27 # 10 * 21 statements per iteration + α
     elseif VERSION >= v"1.11-"
         nstmts = 10*17 + 20 # 10 * 17 statements per iteration + α
-    elseif VERSION >= v"1.10-"
-        nstmts = 10*15 + 20 # 10 * 15 statements per iteration + α
-    elseif isdefined(Core, :get_binding_type)
-        nstmts = 10*14 + 20 # 10 * 14 statements per iteration + α
-    elseif VERSION >= v"1.7-"
-        nstmts = 10*11 + 20 # 10 * 9 statements per iteration + α
     else
-        nstmts = 10*10 + 20 # 10 * 10 statements per iteration + α
+        nstmts = 10*15 + 20 # 10 * 15 statements per iteration + α
     end
     for (mod, ex) in modexs
         frame = Frame(mod, ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ Core.eval(JuliaInterpreter, :(debug_mode() = true))
     @testset "limits.jl" begin include("limits.jl") end
     @testset "eval_code.jl" begin include("eval_code.jl") end
     @testset "breakpoints.jl" begin include("breakpoints.jl") end
-    @static VERSION >= v"1.8.0-DEV.370" && @testset "code_coverage/code_coverage.jl" begin include("code_coverage/code_coverage.jl") end
+    @testset "code_coverage/code_coverage.jl" begin include("code_coverage/code_coverage.jl") end
     remove()
     @testset "debug.jl" begin include("debug.jl") end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -31,14 +31,8 @@ end
 
 ## For running interpreter frames under resource limitations
 
-if isdefined(Base.IRShow, :LineInfoNode)
 struct Aborted    # for signaling that some statement or test blocks were interrupted
     at::Base.IRShow.LineInfoNode
-end
-else
-struct Aborted    # for signaling that some statement or test blocks were interrupted
-    at::Core.LineInfoNode
-end
 end
 
 function Aborted(frame::Frame, pc)


### PR DESCRIPTION
Maintaining this package that closely depends on Julia internals across multiple Julia versions is very cumbersome. Now that the LTS has been updated to 1.10, let's drop compatibility with earlier versions and simplify the code.