### PR TITLE
Lookup bindings in the latest world

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -2,7 +2,7 @@ isassign(frame::Frame) = isassign(frame, frame.pc)
 isassign(frame::Frame, pc::Int) = (pc in frame.framecode.used)
 
 lookup_var(frame::Frame, val::SSAValue) = frame.framedata.ssavalues[val.id]
-lookup_var(frame::Frame, ref::GlobalRef) = getfield(ref.mod, ref.name)
+lookup_var(frame::Frame, ref::GlobalRef) = invokelatest(getfield, ref.mod, ref.name)
 function lookup_var(frame::Frame, slot::SlotNumber)
     val = frame.framedata.locals[slot.id]
     val !== nothing && return val.value
@@ -311,8 +311,8 @@ function evaluate_methoddef(frame::Frame, node::Expr)
     if f isa Symbol || f isa GlobalRef
         mod = f isa Symbol ? moduleof(frame) : f.mod
         name = f isa Symbol ? f : f.name
-        if Base.isbindingresolved(mod, name) && isdefined(mod, name)  # `isdefined` accesses the binding, making it impossible to create a new one
-            f = getfield(mod, name)
+        if Base.isbindingresolved(mod, name) && invokelatest(isdefined, mod, name)  # `isdefined` accesses the binding, making it impossible to create a new one
+            f = invokelatest(getfield, mod, name)
         else
             f = Core.eval(mod, Expr(:function, name))  # create a new function
         end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -24,8 +24,8 @@ function smallest_ref(stmts, arg, idmin)
 end
 
 function lookup_global_ref(a::GlobalRef)
-    if Base.isbindingresolved(a.mod, a.name) && isdefined(a.mod, a.name) && isconst(a.mod, a.name)
-        return QuoteNode(getfield(a.mod, a.name))
+    if Base.isbindingresolved(a.mod, a.name) && invokelatest(isdefined, a.mod, a.name) && invokelatest(isconst, a.mod, a.name)
+        return QuoteNode(invokelatest(getfield, a.mod, a.name))
     end
     return a
 end


### PR DESCRIPTION
Post-partitioning the executing world age matters for bindings lookup. JuliaInterpreter currently does not model world age correctly. That's a bigger issue. However, for now, just look up bindings in the latest world age, which mostly restores the unpartitioned behavior.