### PR TITLE
Correct logic for ccall symbol lookup

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -814,9 +814,9 @@ function Base.display_error(io::IO, er, frame::Frame)
     println(io)
 end
 
-function static_eval(ex)
+function static_eval(evalmod, ex)
     try
-        eval(ex)
+        Core.eval(evalmod, ex)
     catch
         nothing
     end


### PR DESCRIPTION
The existing logic could not distinguish between ccall(foo) and ccall(:foo) and was giving wrong errors as a result.