### PR TITLE
Use `invoke_in_world` for `setglobal!` (fix #662)

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -355,11 +355,11 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         end
     elseif f === setglobal!
         if nargs == 3
-            return Some{Any}(setglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(setglobal!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
         else
-            return Some{Any}(setglobal!(getargs(args, frame)...))
+            return Some{Any}(Base.invoke_in_world(frame.world, getargs(args, frame)...))
         end
     elseif @static isdefined(Core, :setglobalonce!) && f === setglobalonce!
         if nargs == 3

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -142,6 +142,19 @@ JuliaInterpreter.finish_and_return!(frame, true)
 
 @test @interpret Base.Math.DoubleFloat64(-0.5707963267948967, 4.9789962508669555e-17).hi ≈ -0.5707963267948967
 
+# assignment (issue #662)
+ex = quote
+    assignedvar = 33
+    return assignedvar + 1
+end
+frame = Frame(Main, ex)
+ret = try
+    JuliaInterpreter.finish_and_return!(frame, true)
+catch
+    catch_backtrace()
+end
+@test ret == 34
+
 # ccall with cfunction
 fcfun(x::Int, y::Int) = 1
 ex = quote   # in lowered code, cf is a Symbol


### PR DESCRIPTION
This ensures that `setglobal!` respects an `Expr(:latestworld)` in the
lowered code for expressions that set global variables.

The extra test isn't strictly necessary, but by decoupling it from a
much more complex issue, `@cfunction`, it helps simplify debugging.

This gets `test/interpreter.jl` much farther along, until an `@llvmcall` failure.