### PR TITLE
Update builtins, allow stepping into invokelatest

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -266,6 +266,9 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         id = findfirst(isequal(f), Core.Compiler.T_FFUNC_KEY)
         fcall = generate_fcall(f, Core.Compiler.T_FFUNC_VAL, id)
         if f in RECENTLY_ADDED
+            if f === Core.invokelatest
+                fcall = replace(CALL_LATEST, "_call_latest" => "invokelatest")
+            end
             print(io,
 """
     $head @static isdefined($(ft.name.module), $(repr(nameof(f)))) && f === $fname


### PR DESCRIPTION
JuliaInterpreter had special handling for `Core._call_latest` to allow
stepping into callees invoked in the latest world. In Julia 1.12,
`Core._call_latest` is now an alias for `Core.invokelatest`, but because
`generate_builtins` requires exact name matching, we had written the
implementation for `invokelatest` without the special handling applied
to `_call_latest`.

This should enable the `test/debug.jl` test for `f_inv_latest` to pass
on Julia 1.12.