### PR TITLE
Fix world age issues in test/toplevel

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -18,9 +18,9 @@ function lookup_stmt(stmts::Vector{Any}, @nospecialize arg)
         if isa(q, QuoteNode) && isa(q.value, Symbol)
             mod = lookup_stmt(stmts, arg.args[2])
             if isa(mod, GlobalRef)
-                mod = @invokelatest getproperty(mod.mod, mod.name)
+                mod = @invokelatest getglobal(mod.mod, mod.name)
             end
-            isa(mod, Module) && return @invokelatest getproperty(mod, q.value)
+            isa(mod, Module) && return @invokelatest getglobal(mod, q.value)
         end
     end
     return arg

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -18,9 +18,9 @@ function lookup_stmt(stmts::Vector{Any}, @nospecialize arg)
         if isa(q, QuoteNode) && isa(q.value, Symbol)
             mod = lookup_stmt(stmts, arg.args[2])
             if isa(mod, GlobalRef)
-                mod = getproperty(mod.mod, mod.name)
+                mod = @invokelatest getproperty(mod.mod, mod.name)
             end
-            isa(mod, Module) && return getproperty(mod, q.value)
+            isa(mod, Module) && return @invokelatest getproperty(mod, q.value)
         end
     end
     return arg

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -82,15 +82,15 @@ end
         end
         @eval using TmpPkg1
         # Every package is technically parented in Main but the name may not be visible in Main
-        @test isdefined(@__MODULE__, :TmpPkg1)
-        @test !isdefined(@__MODULE__, :TmpPkg2)
+        @test @eval isdefined(@__MODULE__, :TmpPkg1)
+        @test @eval !isdefined(@__MODULE__, :TmpPkg2)
         collect(ExprSplitter(@__MODULE__, quote
                 module TmpPkg2
                 f() = 2
                 end
             end))
-        @test isdefined(@__MODULE__, :TmpPkg1)
-        @test !isdefined(@__MODULE__, :TmpPkg2)
+        @test @eval isdefined(@__MODULE__, :TmpPkg1)
+        @test @eval !isdefined(@__MODULE__, :TmpPkg2)
     end
 
     # Revise issue #718
@@ -119,7 +119,7 @@ module Toplevel end
     for (mod, ex) in modexs
         frame = Frame(mod, ex)
         while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
+            invokelatest(JuliaInterpreter.through_methoddef_or_done!, frame) === nothing && break
         end
     end
 


### PR DESCRIPTION
With these changes we can get much of the way through the toplevel tests. This is good, because Revise is critically dependent on toplevel handling. (Despite Revise tests passing on Julia 1.12, it often fails on complex code bases.)

There are remaining world-age issues in the Non-frames test (and maybe others). My sense is that probably the only realistic way to get everything working well is to provide full support for world age in JuliaInterpreter.