### PR TITLE
Breakpoint setting for inverted linetable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-CodeTracking = "0.5.9, 1"
+CodeTracking = "1.3.9"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
This is largely a rewrite of `statementnumbers` for the new linetable representation. There are also adjustments to the tests. This largely completes the effort started in #606.

This allows `test/breakpoints.jl` to pass, with two warnings about invalid binding access (world-age).

Fixes #636
