### PR TITLE
Try harder to find llvmcalls

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -74,6 +74,7 @@ function finish_stack!(@nospecialize(recurse), frame::Frame, rootistoplevel::Boo
             end
         end
         pc += 1
+        @assert is_leaf(frame)
         frame.pc = pc
         shouldbreak(frame, pc) && return BreakpointRef(frame.framecode, pc)
     end
@@ -410,6 +411,7 @@ function unwind_exception(frame::Frame, @nospecialize(exc))
     while frame !== nothing
         if !isempty(frame.framedata.exception_frames)
             # Exception caught
+            @assert is_leaf(frame)
             frame.pc = frame.framedata.exception_frames[end]
             frame.framedata.last_exception[] = exc
             return frame

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -48,8 +48,9 @@ end
 end
 
 function return_from(frame::Frame)
-    recycle(frame)
+    oldframe = frame
     frame = caller(frame)
+    recycle(oldframe)
     frame === nothing || (frame.callee = nothing)
     return frame
 end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -166,8 +166,8 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
         # Currenly, our strategy to deal with llvmcall can't handle parametric functions
         # (the "mini interpreter" runs in module scope, not method scope)
         if (!isempty(lenv) && (hasarg(isidentical(:llvmcall), code.code) ||
-                               hasarg(isidentical(Base.llvmcall), code.code) ||
-                               hasarg(a->is_global_ref(a, Base, :llvmcall), code.code))) ||
+                               hasarg(isidentical(Core.Intrinsics.llvmcall), code.code) ||
+                               hasarg(a->is_global_ref_egal(a, :llvmcall, Core.Intrinsics.llvmcall), code.code))) ||
                                hasarg(isidentical(:iolock_begin), code.code)
             return Compiled()
         end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -560,6 +560,7 @@ function step_expr!(@nospecialize(recurse), frame::Frame, @nospecialize(node), i
                 rhs = eval_rhs(recurse, frame, node)
             end
         elseif isa(node, GotoNode)
+            @assert is_leaf(frame)
             return (frame.pc = node.label)
         elseif isa(node, GotoIfNot)
             arg = @lookup(frame, node.cond)
@@ -567,6 +568,7 @@ function step_expr!(@nospecialize(recurse), frame::Frame, @nospecialize(node), i
                 throw(TypeError(nameof(frame), "if", Bool, arg))
             end
             if !arg
+                @assert is_leaf(frame)
                 return (frame.pc = node.dest)
             end
         elseif isa(node, ReturnNode)
@@ -596,6 +598,7 @@ function step_expr!(@nospecialize(recurse), frame::Frame, @nospecialize(node), i
         lhs = SSAValue(pc)
         do_assignment!(frame, lhs, rhs)
     end
+    @assert is_leaf(frame)
     return (frame.pc = pc + 1)
 end
 
@@ -653,6 +656,7 @@ function handle_err(@nospecialize(recurse), frame::Frame, @nospecialize(err))
     end
     data.last_exception[] = err
     pc = @static VERSION >= v"1.11-" ? pop!(data.exception_frames) : data.exception_frames[end] # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
+    @assert is_leaf(frame)
     frame.pc = pc
     return pc
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -131,7 +131,7 @@ function optimize!(code::CodeInfo, scope)
                 # Check for :llvmcall
                 arg1 = stmt.args[1]
                 larg1 = lookup_stmt(code.code, arg1)
-                if (arg1 === :llvmcall || larg1 === Base.llvmcall || is_global_ref(larg1, Base, :llvmcall)) && isempty(sparams) && scope isa Method
+                if (arg1 === :llvmcall || larg1 === Base.llvmcall || is_global_ref_egal(larg1, :llvmcall, Core.Intrinsics.llvmcall)) && isempty(sparams) && scope isa Method
                     # Call via `invokelatest` to avoid compiling it until we need it
                     @invokelatest build_compiled_llvmcall!(stmt, code, idx, evalmod)
                     methodtables[idx] = Compiled()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,6 +140,14 @@ Tests whether `g` is equal to `GlobalRef(mod, name)`.
 """
 is_global_ref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name == name
 
+function is_global_ref_egal(@nospecialize(g), name::Symbol, @nospecialize(ref))
+    # Identifying GlobalRefs regardless of how the caller scopes them
+    isa(g, GlobalRef) || return false
+    g.name === name || return false
+    gref = getglobal(g.mod, g.name)
+    return gref === ref
+end
+
 is_quotenode(@nospecialize(q), @nospecialize(val)) = isa(q, QuoteNode) && q.value == val
 is_quotenode_egal(@nospecialize(q), @nospecialize(val)) = isa(q, QuoteNode) && q.value === val
 


### PR DESCRIPTION
One can use `llvmcall` without scoping it as `Base.llvmcall`. Thus we need a reliable way to find it independently of the GlobalRef module.

This was very difficult to debug, and I only figured out what was actually happening on my third attempt, after having fixed most of the other bugs in the package. The failure to identify an `llvmcall` led to a kind of error that we weren't handling correctly and which ended up changing the `pc` in a parent frame when it should have been changed in a leaf-frame. Thus we were getting absolutely crazy execution orders. The second commit adds several asserts that would have made catching it a bit easier.

Please do not squash when merging, since there is a chance we'll regret some of the `@assert`s.