### PR TITLE
Support external method tables in method evaluation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,7 @@ Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "PyCall", "SHA", "SparseArrays", "Tensors", "Test"]
+test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "PyCall", "SHA", "SparseArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.9.44"
+version = "0.9.45"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -359,7 +359,7 @@ function extract_method_table(frame::Frame, node::Expr; eval = true)
     end
     mod, name = isa(arg, Symbol) ? (moduleof(frame), arg) : (arg.mod, arg.name)
     @invokelatest(isdefinedglobal(mod, name)) || return nothing
-    value = Core.eval(mod, name)
+    value = getglobal(mod, name)
     isa(value, MethodTable) && return value
     return nothing
 end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -359,7 +359,7 @@ function extract_method_table(frame::Frame, node::Expr; eval = true)
     end
     mod, name = isa(arg, Symbol) ? (moduleof(frame), arg) : (arg.mod, arg.name)
     @invokelatest(isdefinedglobal(mod, name)) || return nothing
-    value = getglobal(mod, name)
+    value = @invokelatest getglobal(mod, name)
     isa(value, MethodTable) && return value
     return nothing
 end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -350,7 +350,11 @@ end
 function extract_method_table(frame::Frame, node::Expr)
     arg = node.args[1]
     isa(arg, Core.MethodTable) && return arg
-    isa(arg, Symbol) || isa(arg, GlobalRef) || return nothing
+    if !isa(arg, Symbol) && !isa(arg, GlobalRef)
+        value = Core.eval(moduleof(frame), arg)
+        isa(value, Core.MethodTable) && return value
+        return nothing
+    end
     mod, name = isa(arg, Symbol) ? (moduleof(frame), arg) : (arg.mod, arg.name)
     @invokelatest(isdefined(mod, name)) || return nothing
     value = Core.eval(mod, name)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -338,7 +338,7 @@ function evaluate_methoddef(frame::Frame, node::Expr)
     return method
 end
 
-function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::Core.MethodTable)
+function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::MethodTable)
     # Overlaying an empty function such as `function f end` is not legal, and `f` must
     # already be defined so we don't need to do as much work as in `evaluate_methoddef`.
     sig = @lookup(frame, node.args[2])::SimpleVector
@@ -347,19 +347,20 @@ function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::Core.MethodT
     return method
 end
 
-function extract_method_table(frame::Frame, node::Expr)
+function extract_method_table(frame::Frame, node::Expr; eval = true)
     isexpr(node, :method, 3) || return nothing
     arg = node.args[1]
-    isa(arg, Core.MethodTable) && return arg
+    isa(arg, MethodTable) && return arg
     if !isa(arg, Symbol) && !isa(arg, GlobalRef)
+        eval || return nothing
         value = Core.eval(moduleof(frame), arg)
-        isa(value, Core.MethodTable) && return value
+        isa(value, MethodTable) && return value
         return nothing
     end
     mod, name = isa(arg, Symbol) ? (moduleof(frame), arg) : (arg.mod, arg.name)
     @invokelatest(isdefined(mod, name)) || return nothing
     value = Core.eval(mod, name)
-    isa(value, Core.MethodTable) && return value
+    isa(value, MethodTable) && return value
     return nothing
 end
 

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -348,6 +348,7 @@ function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::Core.MethodT
 end
 
 function extract_method_table(frame::Frame, node::Expr)
+    isexpr(node, :method, 3) || return nothing
     arg = node.args[1]
     isa(arg, Core.MethodTable) && return arg
     if !isa(arg, Symbol) && !isa(arg, GlobalRef)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -353,7 +353,7 @@ function extract_method_table(frame::Frame, node::Expr; eval = true)
     isa(arg, MethodTable) && return arg
     if !isa(arg, Symbol) && !isa(arg, GlobalRef)
         eval || return nothing
-        value = Core.eval(moduleof(frame), arg)
+        value = try Core.eval(moduleof(frame), arg) catch _ nothing end
         isa(value, MethodTable) && return value
         return nothing
     end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -339,6 +339,8 @@ function evaluate_methoddef(frame::Frame, node::Expr)
 end
 
 function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::Core.MethodTable)
+    # Overlaying an empty function such as `function f end` is not legal, and `f` must
+    # already be defined so we don't need to do as much work as in `evaluate_methoddef`.
     sig = @lookup(frame, node.args[2])::SimpleVector
     body = @lookup(frame, node.args[3])::Union{CodeInfo, Expr}
     ccall(:jl_method_def, Cvoid, (Any, Any, Any, Any), sig, mt, body, moduleof(frame)::Module)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -358,7 +358,7 @@ function extract_method_table(frame::Frame, node::Expr; eval = true)
         return nothing
     end
     mod, name = isa(arg, Symbol) ? (moduleof(frame), arg) : (arg.mod, arg.name)
-    @invokelatest(isdefined(mod, name)) || return nothing
+    @invokelatest(isdefinedglobal(mod, name)) || return nothing
     value = Core.eval(mod, name)
     isa(value, MethodTable) && return value
     return nothing

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -334,20 +334,17 @@ function evaluate_methoddef(frame::Frame, node::Expr)
     length(node.args) == 1 && return f
     sig = @lookup(frame, node.args[2])::SimpleVector
     body = @lookup(frame, node.args[3])::Union{CodeInfo, Expr}
-    RT = method_def_return_type()
-    return ccall(:jl_method_def, Any, (Any, Ptr{Cvoid}, Any, Any), sig, C_NULL, body, moduleof(frame)::Module)::RT
+    method = ccall(:jl_method_def, Any, (Any, Ptr{Cvoid}, Any, Any), sig, C_NULL, body, moduleof(frame)::Module)::Method
+    return method
 end
-
-# see https://github.com/JuliaLang/julia/pull/58076
-method_def_return_type() = @static VERSION ≥ v"1.13.0-DEV.388" ? Method : Nothing
 
 function evaluate_overlayed_methoddef(frame::Frame, node::Expr, mt::Core.MethodTable)
     # Overlaying an empty function such as `function f end` is not legal, and `f` must
     # already be defined so we don't need to do as much work as in `evaluate_methoddef`.
     sig = @lookup(frame, node.args[2])::SimpleVector
     body = @lookup(frame, node.args[3])::Union{CodeInfo, Expr}
-    RT = method_def_return_type()
-    return ccall(:jl_method_def, Any, (Any, Any, Any, Any), sig, mt, body, moduleof(frame)::Module)::RT
+    method = ccall(:jl_method_def, Any, (Any, Any, Any, Any), sig, mt, body, moduleof(frame)::Module)::Method
+    return method
 end
 
 function extract_method_table(frame::Frame, node::Expr)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1,7 +1,7 @@
 using Base.Meta
 import Base: +, -, convert, isless, get_world_counter, mapany, ntupleany, invokelatest
 using Core: CodeInfo, SimpleVector, LineInfoNode, GotoNode, GotoIfNot, ReturnNode,
-            GeneratedFunctionStub, MethodInstance, NewvarNode, TypeName
+            GeneratedFunctionStub, MethodInstance, MethodTable, NewvarNode, TypeName
 
 using UUIDs
 using Random

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,7 +34,8 @@ and doesn't throw when there is no matching method.
 function whichtt(@nospecialize(tt), mt::Union{Nothing, MethodTable} = nothing)
     # TODO: provide explicit control over world age? In case we ever need to call "old" methods.
     # branch on https://github.com/JuliaLang/julia/pull/44515
-    # for now, actual code execution doesn't ever need to consider overlayed method table
+    # for now, code execution doesn't have the capability to use an overlayed method table,
+    # which is meant to be addressed in https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/682.
     match, _ = Core.Compiler._findsup(tt, mt, get_world_counter())
     match === nothing && return nothing
     return match.method

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,16 +26,16 @@ function to_function(@nospecialize(x))
 end
 
 """
-    method = whichtt(tt)
+    method = whichtt(tt, mt = nothing)
 
 Like `which` except it operates on the complete tuple-type `tt`,
 and doesn't throw when there is no matching method.
 """
-function whichtt(@nospecialize(tt))
+function whichtt(@nospecialize(tt), mt::Union{Nothing, MethodTable} = nothing)
     # TODO: provide explicit control over world age? In case we ever need to call "old" methods.
     # branch on https://github.com/JuliaLang/julia/pull/44515
     # for now, actual code execution doesn't ever need to consider overlayed method table
-    match, _ = Core.Compiler._findsup(tt, nothing, get_world_counter())
+    match, _ = Core.Compiler._findsup(tt, mt, get_world_counter())
     match === nothing && return nothing
     return match.method
 end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -415,7 +415,7 @@ end
 
     function g_gf()
         eval(:(z = 2))
-        return z
+        return @invokelatest(@__MODULE__().z)
     end
     @test @interpret g_gf() == 2
 
@@ -461,13 +461,13 @@ file, line = JuliaInterpreter.whereis(fr)
 @test line == (@__LINE__() - 4)
 
 # Test path to files in stdlib
-fr = JuliaInterpreter.enter_call(Test.eval, 1)
+fr = JuliaInterpreter.enter_call(rand)
 file, line = JuliaInterpreter.whereis(fr)
 @test isfile(file)
 @static if VERSION < v"1.12.0-DEV.173"
 @test isfile(JuliaInterpreter.getfile(fr.framecode.src.linetable[1]))
 end
-@test occursin(contractuser(Sys.STDLIB), repr(fr))
+@test occursin(joinpath(contractuser(Sys.STDLIB), "Random"), repr(fr))
 
 # Test undef sparam (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/165)
 function foo(x::T) where {T <: AbstractString, S <: AbstractString}

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -625,7 +625,6 @@ end
 
 # parametric llvmcall (issues #112 and #288)
 module VecTest
-    using Tensors
     const Vec{N,T} = NTuple{N,VecElement{T}}
     # The following test mimic SIMD.jl
     const _llvmtypes = Dict{DataType, String}(
@@ -646,7 +645,7 @@ module VecTest
             Core.getfield(Base, :llvmcall)($exp, Vec{$N, $T}, Tuple{Vec{$N, $T}, Vec{$N, $T}}, x, y)
         end
     end
-    f() = 1.0 * one(Tensor{2,3})
+    f(a) = vecadd(a, a)
 end
 let
     # NOTE we need to make sure this code block is compiled, since vecadd is generated function,
@@ -654,8 +653,8 @@ let
     Base.Experimental.@force_compile
     a = (VecElement{Float64}(1.0), VecElement{Float64}(2.0))
     @test @interpret(VecTest.vecadd(a, a)) == VecTest.vecadd(a, a)
+    @test @interpret(VecTest.f(a)) == VecTest.f(a)
 end
-@test @interpret(VecTest.f()) == [1 0 0; 0 1 0; 0 0 1]
 
 # Test exception type for undefined variables
 f_undefvar() = s = s + 1

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -414,11 +414,16 @@ end
     f_gf(x) = false ? some_undef_var_zzzzzzz : x
     @test @interpret f_gf(2) == 2
 
-    function g_gf()
-        eval(:(z = 2))
-        return @invokelatest(@__MODULE__().z)
+    gvar = gensym()
+    @eval function g_gf()
+        @eval $gvar = 2
+        return $gvar
     end
-    @test @interpret g_gf() == 2
+    if VERSION ≥ v"1.12-"
+        @test_throws "`$gvar` not defined" @interpret(g_gf() == 2)
+    else
+        @test @interpret(g_gf() == 2)
+    end
 
     global q_gf = 0
     function h_gf()

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -626,7 +626,7 @@ end
 # parametric llvmcall (issues #112 and #288)
 module VecTest
     using Tensors
-    Vec{N,T} = NTuple{N,VecElement{T}}
+    const Vec{N,T} = NTuple{N,VecElement{T}}
     # The following test mimic SIMD.jl
     const _llvmtypes = Dict{DataType, String}(
         Float64 => "double",

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -618,8 +618,13 @@ end
     JuliaInterpreter.finish!(frame, true)
     @test nmethods_in_overlay() == 1
 
-    ex = :(Base.Experimental.@overlay $(Toplevel.method_table) foo(x; y = 3) = 3 + y)
+    ex = :(Base.Experimental.@overlay $(Toplevel.method_table) external_foo(x; y = 3) = 3 + y)
     frame = Frame(Toplevel, ex)
     JuliaInterpreter.finish!(frame, true)
-    @test nmethods_in_overlay() == 3 # `foo(x)` and `kwcall` methods were added
+    @test nmethods_in_overlay() == 3 # `external_foo(x)` and `kwcall` methods were added
+
+    ex = :(Base.Experimental.@overlay getproperty(@__MODULE__, :method_table) external_foo(x::Int) = 4)
+    frame = Frame(Toplevel, ex)
+    JuliaInterpreter.finish!(frame, true)
+    @test nmethods_in_overlay() == 4
 end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -606,10 +606,13 @@ end
 end
 
 @testset "External method tables" begin
-    Base.eval(Toplevel, quote
+    ex = quote
         external_foo() = 1
         Base.Experimental.@MethodTable method_table
-    end)
+    end
+    frame = Frame(Toplevel, ex)
+    JuliaInterpreter.finish!(frame, true)
+
     nmethods_in_overlay() = length(Base.MethodList(Toplevel.method_table).ms)
     @test nmethods_in_overlay() == 0
 


### PR DESCRIPTION
Currently, method evaluation assumes a syntax of the form
```julia
Expr(:method, :foo, %sig, %body)
```
whereas methods defined in an external method table will have the form
```julia
Expr(:method, mt, %sig, %body)
```

where `mt` references a `Core.MethodTable`, with the function directly extracted from the signature. This form assumes that the function is already defined, so we may rely on having `typeof(foo)` defined and provided as first argument. This slight difference simplifies the evaluation logic as now implemented in `evaluate_overlayed_methoddef`.

We used to evaluate both in the same way, leading to errors such as raised in https://github.com/timholy/Revise.jl/issues/646. While further changes are required to properly revise methods defined in external method tables, this PR at least allows us to interpret any necessary overlay definitions.