### PR TITLE
implement a system for interpreting overlay methods

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -13,6 +13,7 @@ JuliaInterpreter.Interpreter
 JuliaInterpreter.RecursiveInterpreter
 JuliaInterpreter.NonRecursiveInterpreter
 JuliaInterpreter.Compiled
+JuliaInterpreter.method_table
 ```
 
 ## Frame creation

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -260,7 +260,9 @@ function evaluate_call!(interp::Interpreter, frame::Frame, call_expr::Expr, ente
         lenv === nothing && return framecode  # this was a Builtin
         fargs = fargs_pruned
     else
-        framecode, lenv = get_call_framecode(fargs, frame.framecode, frame.pc; enter_generated=enter_generated)
+        method_table = JuliaInterpreter.method_table(interp)
+        framecode, lenv = get_call_framecode(fargs, frame.framecode, frame.pc;
+                                             enter_generated, method_table)
         if lenv === nothing
             if isa(framecode, Compiled)
                 return native_call(fargs, frame)

--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -7,7 +7,9 @@ Return the framecode and environment for a call specified by `fargs = [f, args..
 `parentframecode` is the caller, and `idx` is the program-counter index.
 If possible, `framecode` will be looked up from the local method tables of `parentframe`.
 """
-function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int; enter_generated::Bool=false)
+function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int;
+                            enter_generated::Bool=false,
+                            method_table::Union{Nothing,MethodTable}=nothing)
     nargs = length(fargs)  # includes f as the first "argument"
     # Determine whether we can look up the appropriate framecode in the local method table
     if isassigned(parentframe.methodtables, idx)  # if this is the first call, this may not yet be set
@@ -60,7 +62,7 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
     end
     # We haven't yet encountered this argtype combination and need to look it up by dispatch
     fargs[1] = f = to_function(fargs[1])
-    ret = prepare_call(f, fargs; enter_generated=enter_generated)
+    ret = prepare_call(f, fargs; enter_generated, method_table)
     ret === nothing && return invokelatest(f, fargs[2:end]...), nothing
     is_compiled = isa(ret[1], Compiled)
     local framecode

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,6 +39,14 @@ redefined as a completely different type in v0.11 or later.
 const Compiled = NonRecursiveInterpreter # for backward compatibility
 Base.similar(::Compiled, sz) = Compiled()  # to support similar(stack, 0)
 
+"""
+    method_table(interpreter::Interpreter) -> mt::Union{Nothing,MethodTable}
+
+Configures the method table used for method lookups performed by the interpreter.
+Uses the global method table by default.
+"""
+method_table(::Interpreter) = nothing
+
 # Our own replacements for Core types. We need to do this to ensure we can tell the difference
 # between "data" (Core types) and "code" (our types) if we step into Core.Compiler
 struct SSAValue


### PR DESCRIPTION
Implemented, being inspired by JuliaDebug/JuliaInterpreter.jl#680, thinking it might be useful in the near future for JET's use case.

The overlay interpretertation is enabled by overloading `JuliaInterpreter.method_table(recurse)`, but maybe the entire `recurse`-overload mechanism itself needs to be aligned with the `AbstractInterpreter` design and properly organized.

Since this interface will also be needed for JET,
I'll probably work on it soon.