### PR TITLE
deprecate `@lookup` macro in favor of `lookup` function

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -90,7 +90,7 @@ function generate_fcall_nargs(fname, minarg, maxarg; requires_world::Bool=false)
         wrapper *= "$nargs\n            "
         argcall = ""
         for i = 1:nargs
-            argcall *= "@lookup(frame, args[$(i+1)])"
+            argcall *= "lookup(frame, args[$(i+1)])"
             if i < nargs
                 argcall *= ", "
             end
@@ -144,7 +144,7 @@ function getargs(args, frame)
     nargs = length(args)-1  # skip f
     callargs = resize!(frame.framedata.callargs, nargs)
     for i = 1:nargs
-        callargs[i] = @lookup(frame, args[i+1])
+        callargs[i] = lookup(frame, args[i+1])
     end
     return callargs
 end
@@ -175,7 +175,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     if isa(fex, QuoteNode)
         f = fex.value
     else
-        f = @lookup(frame, fex)
+        f = lookup(frame, fex)
     end
 
     if f isa Core.OpaqueClosure
@@ -208,7 +208,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
             print(io,
 """
     $head f === tuple
-        return Some{Any}(ntupleany(i->@lookup(frame, args[i+1]), length(args)-1))
+        return Some{Any}(ntupleany(i::Int->lookup(frame, args[i+1]), length(args)-1))
 """)
             continue
         elseif f === Core._apply_iterate
@@ -293,13 +293,13 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         if nargs == 1
             call_expr = copy(call_expr)
             args2 = args[2]
-            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : lookup(frame, args2)
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         elseif nargs == 2
             call_expr = copy(call_expr)
             args2 = args[2]
-            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
-            call_expr.args[3] = @lookup(frame, args[3])
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : lookup(frame, args2)
+            call_expr.args[3] = lookup(frame, args[3])
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         end
 """)

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -99,7 +99,7 @@ JuliaInterpreter.interpreted_methods
 
 ```@docs
 JuliaInterpreter.eval_code
-JuliaInterpreter.@lookup
+JuliaInterpreter.lookup
 JuliaInterpreter.is_wrapper_call
 JuliaInterpreter.is_doc_expr
 JuliaInterpreter.is_global_ref

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -4,7 +4,7 @@ function getargs(args, frame)
     nargs = length(args)-1  # skip f
     callargs = resize!(frame.framedata.callargs, nargs)
     for i = 1:nargs
-        callargs[i] = @lookup(frame, args[i+1])
+        callargs[i] = lookup(frame, args[i+1])
     end
     return callargs
 end
@@ -35,7 +35,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     if isa(fex, QuoteNode)
         f = fex.value
     else
-        f = @lookup(frame, fex)
+        f = lookup(frame, fex)
     end
 
     if f isa Core.OpaqueClosure
@@ -55,13 +55,13 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
     # each gets call-site optimized.
     if f === <:
         if nargs == 2
-            return Some{Any}(<:(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(<:(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(<:(getargs(args, frame)...))
         end
     elseif f === ===
         if nargs == 2
-            return Some{Any}(===(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(===(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(===(getargs(args, frame)...))
         end
@@ -100,7 +100,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core._structtype(getargs(args, frame)...))
     elseif f === Core._svec_ref
         if nargs == 2
-            return Some{Any}(Core._svec_ref(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core._svec_ref(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(Core._svec_ref(getargs(args, frame)...))
         end
@@ -108,7 +108,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core._typebody!(getargs(args, frame)...))
     elseif f === Core._typevar
         if nargs == 3
-            return Some{Any}(Core._typevar(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core._typevar(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(Core._typevar(getargs(args, frame)...))
         end
@@ -116,7 +116,7 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core.apply_type(getargs(args, frame)...))
     elseif f === Core.compilerbarrier
         if nargs == 2
-            return Some{Any}(Core.compilerbarrier(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.compilerbarrier(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(Core.compilerbarrier(getargs(args, frame)...))
         end
@@ -134,23 +134,23 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core.donotdelete(getargs(args, frame)...))
     elseif f === Core.finalizer
         if nargs == 2
-            return Some{Any}(Core.finalizer(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.finalizer(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.finalizer(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.finalizer(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.finalizer(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.finalizer(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(Core.finalizer(getargs(args, frame)...))
         end
     elseif f === Core.get_binding_type
         if nargs == 2
-            return Some{Any}(Base.invoke_in_world(frame.world, Core.get_binding_type, @lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Base.invoke_in_world(frame.world, Core.get_binding_type, lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, Core.get_binding_type, getargs(args, frame)...))
         end
     elseif f === Core.ifelse
         if nargs == 3
-            return Some{Any}(Core.ifelse(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.ifelse(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(Core.ifelse(getargs(args, frame)...))
         end
@@ -158,75 +158,75 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(Core.invoke_in_world(getargs(args, frame)...))
     elseif @static isdefinedglobal(Core, :memorynew) && f === Core.memorynew
         if nargs == 2
-            return Some{Any}(Core.memorynew(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.memorynew(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(Core.memorynew(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryref_isassigned) && f === Core.memoryref_isassigned
         if nargs == 3
-            return Some{Any}(Core.memoryref_isassigned(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.memoryref_isassigned(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(Core.memoryref_isassigned(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefget) && f === Core.memoryrefget
         if nargs == 3
-            return Some{Any}(Core.memoryrefget(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.memoryrefget(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(Core.memoryrefget(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefmodify!) && f === Core.memoryrefmodify!
         if nargs == 5
-            return Some{Any}(Core.memoryrefmodify!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.memoryrefmodify!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.memoryrefmodify!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefnew) && f === Core.memoryrefnew
         if nargs == 1
-            return Some{Any}(Core.memoryrefnew(@lookup(frame, args[2])))
+            return Some{Any}(Core.memoryrefnew(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.memoryrefnew(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.memoryrefnew(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.memoryrefnew(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.memoryrefnew(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.memoryrefnew(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.memoryrefnew(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.memoryrefnew(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.memoryrefnew(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.memoryrefnew(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefoffset) && f === Core.memoryrefoffset
         if nargs == 1
-            return Some{Any}(Core.memoryrefoffset(@lookup(frame, args[2])))
+            return Some{Any}(Core.memoryrefoffset(lookup(frame, args[2])))
         else
             return Some{Any}(Core.memoryrefoffset(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefreplace!) && f === Core.memoryrefreplace!
         if nargs == 6
-            return Some{Any}(Core.memoryrefreplace!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
+            return Some{Any}(Core.memoryrefreplace!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6]), lookup(frame, args[7])))
         else
             return Some{Any}(Core.memoryrefreplace!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefset!) && f === Core.memoryrefset!
         if nargs == 4
-            return Some{Any}(Core.memoryrefset!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.memoryrefset!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(Core.memoryrefset!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefsetonce!) && f === Core.memoryrefsetonce!
         if nargs == 5
-            return Some{Any}(Core.memoryrefsetonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.memoryrefsetonce!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.memoryrefsetonce!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :memoryrefswap!) && f === Core.memoryrefswap!
         if nargs == 4
-            return Some{Any}(Core.memoryrefswap!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.memoryrefswap!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(Core.memoryrefswap!(getargs(args, frame)...))
         end
     elseif f === Core.sizeof
         if nargs == 1
-            return Some{Any}(Core.sizeof(@lookup(frame, args[2])))
+            return Some{Any}(Core.sizeof(lookup(frame, args[2])))
         else
             return Some{Any}(Core.sizeof(getargs(args, frame)...))
         end
@@ -238,27 +238,27 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(applicable(getargs(args, frame)...))
     elseif f === fieldtype
         if nargs == 2
-            return Some{Any}(fieldtype(@lookup(frame, args[2]), @lookup(frame, args[3]))::Type)
+            return Some{Any}(fieldtype(lookup(frame, args[2]), lookup(frame, args[3]))::Type)
         elseif nargs == 3
-            return Some{Any}(fieldtype(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]))::Type)
+            return Some{Any}(fieldtype(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]))::Type)
         else
             return Some{Any}(fieldtype(getargs(args, frame)...)::Type)
         end
     elseif f === getfield
         if nargs == 2
-            return Some{Any}(getfield(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(getfield(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(getfield(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(getfield(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(getfield(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(getfield(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(getfield(getargs(args, frame)...))
         end
     elseif f === getglobal
         if nargs == 2
-            return Some{Any}(getglobal(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(getglobal(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(getglobal(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(getglobal(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(getglobal(getargs(args, frame)...))
         end
@@ -284,15 +284,15 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
 
     elseif f === isa
         if nargs == 2
-            return Some{Any}(isa(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(isa(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(isa(getargs(args, frame)...))
         end
     elseif f === isdefined
         if nargs == 2
-            return Some{Any}(isdefined(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(isdefined(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(isdefined(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(isdefined(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(isdefined(getargs(args, frame)...))
         end
@@ -300,115 +300,115 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         return Some{Any}(isdefinedglobal(getargs(args, frame)...))
     elseif f === modifyfield!
         if nargs == 4
-            return Some{Any}(modifyfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(modifyfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(modifyfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(modifyfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(modifyfield!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :modifyglobal!) && f === modifyglobal!
         if nargs == 4
-            return Some{Any}(Base.invoke_in_world(frame.world, modifyglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, modifyglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Base.invoke_in_world(frame.world, modifyglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Base.invoke_in_world(frame.world, modifyglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, modifyglobal!, getargs(args, frame)...))
         end
     elseif f === nfields
         if nargs == 1
-            return Some{Any}(nfields(@lookup(frame, args[2])))
+            return Some{Any}(nfields(lookup(frame, args[2])))
         else
             return Some{Any}(nfields(getargs(args, frame)...))
         end
     elseif f === replacefield!
         if nargs == 4
-            return Some{Any}(replacefield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(replacefield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(replacefield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(replacefield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         elseif nargs == 6
-            return Some{Any}(replacefield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
+            return Some{Any}(replacefield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6]), lookup(frame, args[7])))
         else
             return Some{Any}(replacefield!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :replaceglobal!) && f === replaceglobal!
         if nargs == 4
-            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         elseif nargs == 6
-            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
+            return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6]), lookup(frame, args[7])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, replaceglobal!, getargs(args, frame)...))
         end
     elseif f === setfield!
         if nargs == 3
-            return Some{Any}(setfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(setfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(setfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(setfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(setfield!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :setfieldonce!) && f === setfieldonce!
         if nargs == 3
-            return Some{Any}(setfieldonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(setfieldonce!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(setfieldonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(setfieldonce!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(setfieldonce!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(setfieldonce!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(setfieldonce!(getargs(args, frame)...))
         end
     elseif f === setglobal!
         if nargs == 3
-            return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, setglobal!, getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :setglobalonce!) && f === setglobalonce!
         if nargs == 3
-            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, setglobalonce!, getargs(args, frame)...))
         end
     elseif f === swapfield!
         if nargs == 3
-            return Some{Any}(swapfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(swapfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(swapfield!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(swapfield!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(swapfield!(getargs(args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :swapglobal!) && f === swapglobal!
         if nargs == 3
-            return Some{Any}(Base.invoke_in_world(frame.world, swapglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Base.invoke_in_world(frame.world, swapglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Base.invoke_in_world(frame.world, swapglobal!, @lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Base.invoke_in_world(frame.world, swapglobal!, lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         else
             return Some{Any}(Base.invoke_in_world(frame.world, swapglobal!, getargs(args, frame)...))
         end
     elseif f === throw
         if nargs == 1
-            return Some{Any}(throw(@lookup(frame, args[2])))
+            return Some{Any}(throw(lookup(frame, args[2])))
         else
             return Some{Any}(throw(getargs(args, frame)...))
         end
     elseif f === tuple
-        return Some{Any}(ntupleany(i->@lookup(frame, args[i+1]), length(args)-1))
+        return Some{Any}(ntupleany(i::Int->lookup(frame, args[i+1]), length(args)-1))
     elseif f === typeassert
         if nargs == 2
-            return Some{Any}(typeassert(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(typeassert(lookup(frame, args[2]), lookup(frame, args[3])))
         else
             return Some{Any}(typeassert(getargs(args, frame)...))
         end
     elseif f === typeof
         if nargs == 1
-            return Some{Any}(typeof(@lookup(frame, args[2])))
+            return Some{Any}(typeof(lookup(frame, args[2])))
         else
             return Some{Any}(typeof(getargs(args, frame)...))
         end
@@ -417,94 +417,94 @@ function maybe_evaluate_builtin(frame, call_expr, expand::Bool)
         if nargs == 1
             call_expr = copy(call_expr)
             args2 = args[2]
-            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : lookup(frame, args2)
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         elseif nargs == 2
             call_expr = copy(call_expr)
             args2 = args[2]
-            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : @lookup(frame, args2)
-            call_expr.args[3] = @lookup(frame, args[3])
+            call_expr.args[2] = isa(args2, QuoteNode) ? args2 : lookup(frame, args2)
+            call_expr.args[3] = lookup(frame, args[3])
             return Some{Any}(Core.eval(moduleof(frame), call_expr))
         end
     elseif @static (isdefinedglobal(Core, :arrayref) && Core.arrayref isa Core.Builtin) && f === Core.arrayref
         if nargs == 1
-            return Some{Any}(Core.arrayref(@lookup(frame, args[2])))
+            return Some{Any}(Core.arrayref(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.arrayref(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.arrayref(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.arrayref(getargs(args, frame)...))
         end
     elseif @static (isdefinedglobal(Core, :arrayset) && Core.arrayset isa Core.Builtin) && f === Core.arrayset
         if nargs == 1
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         elseif nargs == 6
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6]), lookup(frame, args[7])))
         else
             return Some{Any}(Core.arrayset(getargs(args, frame)...))
         end
     elseif @static (isdefinedglobal(Core, :arrayset) && Core.arrayset isa Core.Builtin) && f === Core.arrayset
         if nargs == 1
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         elseif nargs == 6
-            return Some{Any}(Core.arrayset(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6]), @lookup(frame, args[7])))
+            return Some{Any}(Core.arrayset(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6]), lookup(frame, args[7])))
         else
             return Some{Any}(Core.arrayset(getargs(args, frame)...))
         end
     elseif @static (isdefinedglobal(Core, :const_arrayref) && Core.const_arrayref isa Core.Builtin) && f === Core.const_arrayref
         if nargs == 1
-            return Some{Any}(Core.const_arrayref(@lookup(frame, args[2])))
+            return Some{Any}(Core.const_arrayref(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.const_arrayref(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.const_arrayref(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.const_arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.const_arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.const_arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.const_arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.const_arrayref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.const_arrayref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.const_arrayref(getargs(args, frame)...))
         end
     elseif @static (isdefinedglobal(Core, :memoryref) && Core.memoryref isa Core.Builtin) && f === Core.memoryref
         if nargs == 1
-            return Some{Any}(Core.memoryref(@lookup(frame, args[2])))
+            return Some{Any}(Core.memoryref(lookup(frame, args[2])))
         elseif nargs == 2
-            return Some{Any}(Core.memoryref(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.memoryref(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.memoryref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.memoryref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         elseif nargs == 4
-            return Some{Any}(Core.memoryref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5])))
+            return Some{Any}(Core.memoryref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5])))
         elseif nargs == 5
-            return Some{Any}(Core.memoryref(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4]), @lookup(frame, args[5]), @lookup(frame, args[6])))
+            return Some{Any}(Core.memoryref(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4]), lookup(frame, args[5]), lookup(frame, args[6])))
         else
             return Some{Any}(Core.memoryref(getargs(args, frame)...))
         end
     elseif @static (isdefinedglobal(Core, :set_binding_type!) && Core.set_binding_type! isa Core.Builtin) && f === Core.set_binding_type!
         if nargs == 2
-            return Some{Any}(Core.set_binding_type!(@lookup(frame, args[2]), @lookup(frame, args[3])))
+            return Some{Any}(Core.set_binding_type!(lookup(frame, args[2]), lookup(frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(Core.set_binding_type!(@lookup(frame, args[2]), @lookup(frame, args[3]), @lookup(frame, args[4])))
+            return Some{Any}(Core.set_binding_type!(lookup(frame, args[2]), lookup(frame, args[3]), lookup(frame, args[4])))
         else
             return Some{Any}(Core.set_binding_type!(getargs(args, frame)...))
         end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -186,7 +186,7 @@ function build_compiled_llvmcall!(stmt::Expr, code::CodeInfo, idx::Int, evalmod:
             pc === nothing && error("this should never happen")
         end
     end
-    llvmir, RetType, ArgType = @lookup(frame, stmt.args[2]), @lookup(frame, stmt.args[3]), @lookup(frame, stmt.args[4])::DataType
+    llvmir, RetType, ArgType = lookup(frame, stmt.args[2]), lookup(frame, stmt.args[3]), lookup(frame, stmt.args[4])::DataType
     args = stmt.args[5:end]
     argnames = Any[Symbol(:arg, i) for i = 1:length(args)]
     cc_key = (llvmir, RetType, ArgType, evalmod)  # compiled call key

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -1,5 +1,5 @@
 using CodeTracking, JuliaInterpreter, Test
-using JuliaInterpreter: enter_call, enter_call_expr, get_return, @lookup
+using JuliaInterpreter: enter_call, enter_call_expr, get_return
 using Base.Meta: isexpr
 include("utils.jl")
 
@@ -275,7 +275,7 @@ end
         frame = fr = JuliaInterpreter.enter_call(f_va_outer, 1)
         # depending on whether this is in or out of a @testset, the first statement may differ
         stmt1 = fr.framecode.src.code[1]
-        if isexpr(stmt1, :call) && @lookup(frame, stmt1.args[1]) === getfield
+        if isexpr(stmt1, :call) && JuliaInterpreter.lookup(frame, stmt1.args[1]) === getfield
             fr, pc = debug_command(fr, :se)
         end
         fr, pc = debug_command(fr, :s)
@@ -462,7 +462,7 @@ end
         frame = JuliaInterpreter.enter_call(f, 2, 3) # at sin
         frame, pc = debug_command(frame, :n)
         # Check that we are at the kw call to g
-        @test Core.kwfunc(g) == JuliaInterpreter.@lookup frame JuliaInterpreter.pc_expr(frame).args[1]
+        @test Core.kwfunc(g) == JuliaInterpreter.lookup(frame, JuliaInterpreter.pc_expr(frame).args[1])
         # Step into the inner g
         frame, pc = debug_command(frame, :s)
         # Finish the frame and make sure we step out of the wrapper
@@ -477,7 +477,7 @@ end
         frame = JuliaInterpreter.enter_call(h_1, 2, 1)
         frame, pc = debug_command(frame, :s)
         # Should have skipped the kwprep in h_2 and be at call to kwfunc h_3
-        @test Core.kwfunc(h_3) == JuliaInterpreter.@lookup frame JuliaInterpreter.pc_expr(frame).args[1]
+        @test Core.kwfunc(h_3) == JuliaInterpreter.lookup(frame, JuliaInterpreter.pc_expr(frame).args[1])
     end
 
     @testset "si should not step through wrappers or kwprep" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 using JuliaInterpreter
-using JuliaInterpreter: Frame, @lookup
+using JuliaInterpreter: Frame
 using JuliaInterpreter: finish_and_return!, evaluate_call!, step_expr!, shouldbreak,
                         do_assignment!, SSAValue, isassign, pc_expr, handle_err, get_return,
                         moduleof


### PR DESCRIPTION
The `@lookup frame node` macro effectively inlines code in the caller’s context to choose lookup subroutines based on the type of `node`, but there’s no performance benefit to doing this.
A regular function call should deliver equivalent performance, and using a function improves maintainability. Below are the benchmark results:
> master (49220f956c88715b265ca6feed448d9f21a66f95)
```
julia> run(SUITE["recursive self 1_000"])
BenchmarkTools.Trial: 1254 samples with 1 evaluation per sample.
 Range (min … max):  3.634 ms …  13.210 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.845 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.979 ms ± 514.632 μs  ┊ GC (mean ± σ):  2.15% ± 6.18%

    ▄▇▆█▆▂▁
  ▃▇███████▇▇▇▅▄▅▄▄▄▃▃▂▂▂▂▁▁▁▁▂▂▁▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▃▂▂▃▂▂▂▂▂▁▂▂ ▃
  3.63 ms         Histogram: frequency by time        5.54 ms <

 Memory estimate: 1.33 MiB, allocs estimate: 44348.

julia> run(SUITE["tight loop 10_000"])
BenchmarkTools.Trial: 29 samples with 1 evaluation per sample.
 Range (min … max):  170.913 ms … 188.887 ms  ┊ GC (min … max): 0.00% … 0.46%
 Time  (median):     176.319 ms               ┊ GC (median):    0.70%
 Time  (mean ± σ):   176.275 ms ±   3.806 ms  ┊ GC (mean ± σ):  0.61% ± 0.42%

  ▁▁▁▁ ▁ █ █▁▁▁   █ █  █▁▁█▁▁ ▁▁ ▁     ▁                      ▁
  ████▁█▁█▁████▁▁▁█▁█▁▁██████▁██▁█▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  171 ms           Histogram: frequency by time          189 ms <

 Memory estimate: 24.09 MiB, allocs estimate: 1386513.

julia> run(SUITE["throw long 1_000"])
BenchmarkTools.Trial: 157 samples with 1 evaluation per sample.
 Range (min … max):  29.388 ms … 151.134 ms  ┊ GC (min … max): 0.00% … 13.02%
 Time  (median):     30.651 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   31.861 ms ±   9.778 ms  ┊ GC (mean ± σ):  0.94% ±  2.53%

     ▂▅▇█ ▁
  ▃██████▆█▆▆▃▁▃▁▃▁▃▁▁▃▃▁▁▃▁▃▁▃▁▁▁▁▁▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▃ ▃
  29.4 ms         Histogram: frequency by time         42.2 ms <

 Memory estimate: 3.75 MiB, allocs estimate: 85380.
```

> this PR
```
julia> run(SUITE["recursive self 1_000"])
BenchmarkTools.Trial: 1277 samples with 1 evaluation per sample.
 Range (min … max):  3.662 ms …   7.569 ms  ┊ GC (min … max): 0.00% … 49.27%
 Time  (median):     3.809 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.908 ms ± 341.900 μs  ┊ GC (mean ± σ):  1.76% ±  5.62%

    ▃▅█▄▂▂
  ▄▇██████▇▄▄▃▃▃▃▃▃▃▃▃▃▂▂▂▁▂▂▂▂▁▂▁▁▁▁▁▁▁▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  3.66 ms         Histogram: frequency by time        5.27 ms <

 Memory estimate: 1.33 MiB, allocs estimate: 44348.

julia> run(SUITE["tight loop 10_000"])
BenchmarkTools.Trial: 29 samples with 1 evaluation per sample.
 Range (min … max):  170.863 ms … 178.231 ms  ┊ GC (min … max): 0.57% … 2.61%
 Time  (median):     173.559 ms               ┊ GC (median):    0.56%
 Time  (mean ± σ):   173.568 ms ±   1.643 ms  ┊ GC (mean ± σ):  0.55% ± 0.57%

  ▁█   ▁   █ ▁ ▁▁   ▁▁▁█▁▁▁█ ██▁   ▁   ▁  ▁   ▁               ▁
  ██▁▁▁█▁▁▁█▁█▁██▁▁▁████████▁███▁▁▁█▁▁▁█▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  171 ms           Histogram: frequency by time          178 ms <

 Memory estimate: 24.09 MiB, allocs estimate: 1386514.

julia> run(SUITE["throw long 1_000"])
BenchmarkTools.Trial: 175 samples with 1 evaluation per sample.
 Range (min … max):  27.760 ms … 37.426 ms  ┊ GC (min … max): 0.00% … 20.80%
 Time  (median):     28.402 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   28.698 ms ±  1.185 ms  ┊ GC (mean ± σ):  0.65% ±  2.76%

     ▄█▄▁  ▄
  ▃▅█████▇▇█▄▄▂▃▂▂▃▁▂▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▂▂▁▁▁▁▁▂▁▁▁▁▁▁▁▂ ▂
  27.8 ms         Histogram: frequency by time        34.3 ms <

 Memory estimate: 3.75 MiB, allocs estimate: 85380.
```