### PR TITLE
remove the new `finish_nested_frame!` interface

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -44,7 +44,6 @@ JuliaInterpreter.step_expr!
 JuliaInterpreter.finish!
 JuliaInterpreter.finish_and_return!
 JuliaInterpreter.finish_stack!
-JuliaInterpreter.finish_nested_frame!
 JuliaInterpreter.get_return
 JuliaInterpreter.next_until!
 JuliaInterpreter.maybe_next_until!

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -105,15 +105,8 @@ function evaluate_limited!(interp::Interpreter, frame::Frame, nstmts::Int, istop
                 else
                     limited_interp.nstmts = nstmts
                     newframe = Frame(moduleof(frame), stmt)
-                    if isa(interp, NonRecursiveInterpreter)
-                        finish!(interp, newframe, true)
-                    else
-                        newframe.caller = frame
-                        frame.callee = newframe
-                        ret = finish_and_return!(limited_interp, newframe, true)
-                        isa(ret, Aborted) && return ret, limited_interp.nstmts
-                        frame.callee = nothing
-                    end
+                    ret = finish_and_return!(limited_interp, newframe, true)
+                    isa(ret, Aborted) && return ret, limited_interp.nstmts
                     JuliaInterpreter.recycle(newframe)
                     # Because thunks may define new methods, return to toplevel
                     frame.pc = pc + 1


### PR DESCRIPTION
The additional logic implemented for `RecursiveInterpreter` seems to be no longer necessary. I think we can simply call `finish!` instead, since there is no strong reason to add `caller->callee` relation to the nested `CodeInfo` frame within `:thunk` expression.

Confirmed LoweredCodeUtils/Revise/Debugger still pass their test suites with this change.