### PR TITLE
avoid `args` getting boxed in `maybe_evaluate_builtin`

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -210,7 +210,9 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
             print(io,
 """
     $head f === tuple
-        return Some{Any}(ntupleany(i::Int->lookup(interp, frame, args[i+1]), length(args)-1))
+        let args=args
+            return Some{Any}(ntupleany(i::Int->lookup(interp, frame, args[i+1]), length(args)-1))
+        end
 """)
             continue
         elseif f === Core._apply_iterate

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -403,7 +403,9 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
             return Some{Any}(throw(getargs(interp, args, frame)...))
         end
     elseif f === tuple
-        return Some{Any}(ntupleany(i::Int->lookup(interp, frame, args[i+1]), length(args)-1))
+        let args=args
+            return Some{Any}(ntupleany(i::Int->lookup(interp, frame, args[i+1]), length(args)-1))
+        end
     elseif f === typeassert
         if nargs == 2
             return Some{Any}(typeassert(lookup(interp, frame, args[2]), lookup(interp, frame, args[3])))


### PR DESCRIPTION
😮‍💨 🥊 

```julia 
julia> function mysum(x)
           s = 0
           for v in x
               s += v
           end
           return s
       end;

# master
julia> @time @interpret mysum(fill(1, 100000))
  1.198966 seconds (27.70 M allocations: 527.277 MiB, 0.41% gc time)
100000

# PR
julia> @time @interpret mysum(fill(1, 100000))
  0.958389 seconds (20.80 M allocations: 417.413 MiB, 0.45% gc time)
100000
```