### PR TITLE
Change `==` test for `deepcopy(::QuoteNode)`

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -559,7 +559,8 @@ end
 
 # https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/154
 q = QuoteNode([1])
-@test @interpret deepcopy(q) == q
+qcopy = @interpret deepcopy(q)
+@test isa(qcopy, QuoteNode) && qcopy.value == q.value
 
 # Check #args for builtins (#217)
 f217() = <:(Float64, Float32, Float16)


### PR DESCRIPTION
Nightly became more strict about equality among `QuoteNode`s (https://github.com/JuliaLang/julia/pull/58661). This expands the comparison to circumvent Base's new behavior.