### PR TITLE
check_builtins only via the action on CI

### DIFF
--- a/test/check_builtins.jl
+++ b/test/check_builtins.jl
@@ -1,7 +1,8 @@
 using Test, DeepDiffs
 
-@static if !Base.GIT_VERSION_INFO.tagged_commit && # only run on nightly
-    !Sys.iswindows() # TODO: Understand why this fails, probably some line endings
+@static if get(ENV, "GITHUB_ACTION", nothing) === nothing &&  # on CI we have a separate action to run this test
+        !Base.GIT_VERSION_INFO.tagged_commit && # only run on nightly
+        !Sys.iswindows() # TODO: Understand why this fails, probably some line endings
     @testset "Check builtin.jl consistency" begin
         builtins_path = joinpath(@__DIR__, "..", "src", "builtins.jl")
         old_builtins = read(builtins_path, String)


### PR DESCRIPTION
Currently `1.12-nightly` is failing `check_builtins` due to the absence
of `Core._import`. While `check_builtins` doesn't do anything unless
`!Base.GIT_VERSION_INFO.tagged_commit`, both `nightly` and `1.12-rc1`
satisfy this condition.

Since we have a separate action to run this test on CI only on nightly,
we can skip running it from `runtests.jl` if `ENV["GITHUB_ACTION"]` is
set.