### PR TITLE
Add Core.declare_const and Core.declare_global

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -5,6 +5,8 @@ using InteractiveUtils
 # Builtins not present in 1.10 (the lowest supported version)
 const RECENTLY_ADDED = Core.Builtin[
     Core.current_scope,
+    Core.declare_const,
+    Core.declare_global,
     isdefinedglobal,
     Core.memorynew,
     Core.memoryref_isassigned,

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -134,6 +134,10 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
         else
             return Some{Any}(Core.current_scope(getargs(interp, args, frame)...))
         end
+    elseif @static isdefinedglobal(Core, :declare_const) && f === Core.declare_const
+        return Some{Any}(Core.declare_const(getargs(interp, args, frame)...))
+    elseif @static isdefinedglobal(Core, :declare_global) && f === Core.declare_global
+        return Some{Any}(Core.declare_global(getargs(interp, args, frame)...))
     elseif f === Core.donotdelete
         return Some{Any}(Core.donotdelete(getargs(interp, args, frame)...))
     elseif f === Core.finalizer


### PR DESCRIPTION
This change adds the two new builtins that should eventually land, `Core.declare_global` (JuliaLang/julia#58279) and `Core.declare_const` (JuliaLang/julia#58187).  No other changes should be necessary, but the code that handles the lowered forms of `:global`, `:globaldecl`, and `:const` can eventually be deleted when support for the last version of Julia with those Expr heads is dropped.