### PR TITLE
make dynamic-ccall detection more correct

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -2,7 +2,7 @@ const compiled_calls = Dict{Any,Any}()
 
 # Pre-frame-construction lookup
 function lookup_stmt(stmts::Vector{Any}, @nospecialize arg)
-    # this convert a statement into something else, without the slightly interest in correctness:
+    # this converts a statement into something else, without the slightest interest in correctness:
     if isa(arg, SSAValue)
         arg = stmts[arg.id]
     end


### PR DESCRIPTION
Relies on https://github.com/JuliaLang/julia/pull/59165 for exact
accuracy, otherwise we're relying on hoping that `eval` on a random
expression is safe and correct (both hopes are quite false).
