### PR TITLE
Fix `ExprSplitter` for 4-arg `Expr(:module, ...)` w/ docstring

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -561,7 +561,8 @@ function Base.iterate(iter::ExprSplitter, state=nothing)
         if isa(body, Expr) && body.head === :module
             # Just document the module itself and push the module def onto the stack
             excopy = Expr(ex.head, ex.args[1], ex.args[2], ex.args[3])
-            push!(excopy.args, body.args[2])
+            module_name = body.args[end - 1]
+            push!(excopy.args, module_name)
             append!(excopy.args, ex.args[5:end])   # there should only be at most a 5th, but just for robustness
             ex = excopy
             push_modex!(iter, mod, body)

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -687,4 +687,21 @@ module ModuleFormsTest end
             @test @invokelatest(@invokelatest(ModuleFormsTest.FourArgModule).f()) == 42
         end
     end
+    if VERSION ≥ v"1.14-DEV.1836"
+        # 4-arg :module form (with syntax version) should also work with docstrings
+        ex = Base.parse_input_line("""
+            "docstring"
+            module OuterModDocstring4
+                "docstring for InnerModDocstring4"
+                module InnerModDocstring4
+                end
+            end
+            """; mod=Main)
+        # The parser should have given us the 4-arg :module form
+        mod_ex = ex.args[2].args[4]
+        @test mod_ex.head === :module && length(mod_ex.args) == 4
+        modexs = collect(ExprSplitter(JIVisible, ex))
+        @test isdefinedglobal(JIVisible, :OuterModDocstring4)
+        @test isdefinedglobal(JIVisible.OuterModDocstring4, :InnerModDocstring4)
+    end
 end


### PR DESCRIPTION
This was missed (by me) in https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/711.

Test written by Claude.