### PR TITLE
Vendor issue #354 test; drop HTTP dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
@@ -31,4 +30,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "HTTP", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "PyCall", "SHA", "SparseArrays", "Test"]
+test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "PyCall", "SHA", "SparseArrays", "Test"]

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -229,10 +229,20 @@ using PyCall
 let np = pyimport("numpy")
     @test @interpret(PyCall.pystring_query(np.zeros)) === Union{}
 end
-# Issue #354
-using HTTP
-headers = Dict("User-Agent" => "Debugger.jl")
-@test @interpret(HTTP.request("GET", "https://httpbingo.julialang.org", headers)) isa HTTP.Messages.Response
+# Issue #354: an `llvmcall` argument computed from a function argument cannot be
+# interpreted directly. `build_compiled_llvmcall!` runs a mini-interpreter (with
+# no arguments) over the statements feeding the call's type parameters; here the
+# inline `Tuple{Int64}` type argument lowers ahead of the argument-dependent
+# `x + 1`, so that sweep reaches `x + 1` and has no argument to evaluate it with.
+# Such methods are instead routed to compiled execution via `compiled_methods`.
+# `Base.load_state_acquire` (an atomic load via `llvmcall`) was the original
+# trigger; it was removed from Base in 1.12, so this reproduces the same
+# structural case portably, without pointers.
+function llvmcall_354(x::Int64)
+    Base.llvmcall("ret i64 %0", Int64, Tuple{Int64}, x + 1)
+end
+push!(JuliaInterpreter.compiled_methods, which(llvmcall_354, Tuple{Int64}))
+@test @interpret(llvmcall_354(10)) === Int64(11)
 
 # "correct" line numbers
 defline = @__LINE__() + 1


### PR DESCRIPTION
The HTTP test made a live network request and asserted against `HTTP.Messages.Response`, a path that no longer resolves in HTTP 2.x. Its real purpose was issue #354: an `llvmcall` argument derived from a function argument cannot be interpreted directly and must be routed to compiled execution. `Base.load_state_acquire` was the original trigger but was removed from Base in 1.12. Reproduce the construct self-containedly so the check no longer depends on the network or on an external package, and works on all supported Julia versions.