### PR TITLE
Vendor issue #455 test; drop PyCall dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,10 +24,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "PyCall", "SHA", "SparseArrays", "Test"]
+test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "SHA", "SparseArrays", "Test"]

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -224,11 +224,27 @@ val = @interpret(BigInt())
 @test isa(val, BigInt) && val == 0
 @test isa(@interpret(Base.GMP.version()), VersionNumber)
 
-# Issue #455
-using PyCall
-let np = pyimport("numpy")
-    @test @interpret(PyCall.pystring_query(np.zeros)) === Union{}
+# Issue #455: a `cglobal` whose first argument is an inline `(symbol, library)`
+# tuple lowers to `cglobal(Core.tuple(sym, lib), T)`, so the first argument is an
+# SSAValue rather than a literal. Interleaved with `GotoIfNot` branches, this is
+# the structure of `PyCall.pystring_query`, the original trigger; reproduce it
+# self-containedly against openlibm (a permissively-licensed library bundled with
+# Julia) so the check no longer depends on PyCall or a Python install. The library
+# is named with a string literal rather than `Base.Math.libm`: on Julia ≥ 1.11 the
+# latter lowers to a nested `getproperty` chain, which the interpreter cannot
+# resolve when it looks up the inline `cglobal` tuple argument.
+function cglobal_query(x)
+    p1 = cglobal((:sin, "libopenlibm"), Ptr{Cvoid})
+    if p1 == C_NULL
+        return AbstractString
+    end
+    p2 = cglobal((:cos, "libopenlibm"), Ptr{Cvoid})
+    if p2 == C_NULL
+        return Integer
+    end
+    return Union{}
 end
+@test @interpret(cglobal_query(0)) === cglobal_query(0) === Union{}
 # Issue #354: an `llvmcall` argument computed from a function argument cannot be
 # interpreted directly. `build_compiled_llvmcall!` runs a mini-interpreter (with
 # no arguments) over the statements feeding the call's type parameters; here the

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -226,7 +226,7 @@ val = @interpret(BigInt())
 
 # Issue #455: a `cglobal` whose first argument is an inline `(symbol, library)`
 # tuple lowers to `cglobal(Core.tuple(sym, lib), T)`, so the first argument is an
-# SSAValue rather than a literal. Interleaved with `GotoIfNot` branches, this is
+# expression rather than a literal symbol. Interleaved with `GotoIfNot` branches, this is
 # the structure of `PyCall.pystring_query`, the original trigger; reproduce it
 # self-containedly against openlibm (a permissively-licensed library bundled with
 # Julia) so the check no longer depends on PyCall or a Python install. The library

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -258,7 +258,9 @@ function llvmcall_354(x::Int64)
     Base.llvmcall("ret i64 %0", Int64, Tuple{Int64}, x + 1)
 end
 push!(JuliaInterpreter.compiled_methods, which(llvmcall_354, Tuple{Int64}))
-@test @interpret(llvmcall_354(10)) === Int64(11)
+# `Int64(10)`, not `10`: a bare literal is `Int32` on 32-bit platforms and would
+# not match the `Int64` signature.
+@test @interpret(llvmcall_354(Int64(10))) === Int64(11)
 
 # "correct" line numbers
 defline = @__LINE__() + 1


### PR DESCRIPTION
PyCall's build runs conda to install numpy, which fails intermittently on Windows CI before any test executes. Its only test (issue #455) checked that a `cglobal` with an inline `(symbol, library)` tuple first argument — an SSAValue after lowering, interleaved with `GotoIfNot` branches — interprets correctly. Reproduce that structural case self-containedly against openlibm (`Base.Math.libm`, a permissively-licensed library bundled with Julia), so the check no longer depends on PyCall or a Python install.