### PR TITLE
Resolve `getproperty`-chain library in `cglobal`/`ccall` tuple syntax

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -75,8 +75,12 @@ function lookup_expr(interp::Interpreter, frame::Frame, e::Expr)
             # work around for a linearization bug in Julia (https://github.com/JuliaLang/julia/pull/52497)
             return Core.svec(Any[lookup(interp, frame, e.args[i]) for i in 2:length(e.args)]...)
         elseif f === Core.tuple
-            # handling for ccall literal syntax
-            return Core.tuple(Any[lookup(interp, frame, e.args[i]) for i in 2:length(e.args)]...)
+            # Handling for `ccall`/`cglobal` literal syntax, e.g. the `(:sin, lib)`
+            # first argument of `cglobal((:sin, lib), Ptr{Cvoid})`. The library may be
+            # spelled as a `getproperty` chain (e.g. `Base.Math.libm` on Julia ≥ 1.11),
+            # so resolve each element with `lookup_nested`, which understands
+            # `getproperty`/`getindex`/`apply_type`. (Issue #455)
+            return Core.tuple(Any[lookup_nested(interp, frame, e.args[i]) for i in 2:length(e.args)]...)
         end
     end
     error("invalid lookup expr ", e)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -229,11 +229,11 @@ val = @interpret(BigInt())
 # expression rather than a literal symbol. Interleaved with `GotoIfNot` branches, this is
 # the structure of `PyCall.pystring_query`, the original trigger; reproduce it
 # self-containedly against openlibm (a permissively-licensed library bundled with
-# Julia) so the check no longer depends on PyCall or a Python install. The library
-# is named with a string literal rather than `Base.Math.libm`: on Julia ≥ 1.11 the
-# latter lowers to a nested `getproperty` chain, which the interpreter cannot
-# resolve when it looks up the inline `cglobal` tuple argument.
-function cglobal_query(x)
+# Julia) so the check no longer depends on PyCall or a Python install. Spell the
+# library both as a string literal and as `Base.Math.libm`: on Julia ≥ 1.11 the
+# latter lowers to a nested `getproperty` chain inside the `cglobal` tuple, which the
+# interpreter must resolve when looking up that argument.
+function cglobal_query_str(x)
     p1 = cglobal((:sin, "libopenlibm"), Ptr{Cvoid})
     if p1 == C_NULL
         return AbstractString
@@ -244,7 +244,19 @@ function cglobal_query(x)
     end
     return Union{}
 end
-@test @interpret(cglobal_query(0)) === cglobal_query(0) === Union{}
+function cglobal_query_chain(x)
+    p1 = cglobal((:sin, Base.Math.libm), Ptr{Cvoid})
+    if p1 == C_NULL
+        return AbstractString
+    end
+    p2 = cglobal((:cos, Base.Math.libm), Ptr{Cvoid})
+    if p2 == C_NULL
+        return Integer
+    end
+    return Union{}
+end
+@test @interpret(cglobal_query_str(0)) === cglobal_query_str(0) === Union{}
+@test @interpret(cglobal_query_chain(0)) === cglobal_query_chain(0) === Union{}
 # Issue #354: an `llvmcall` argument computed from a function argument cannot be
 # interpreted directly. `build_compiled_llvmcall!` runs a mini-interpreter (with
 # no arguments) over the statements feeding the call's type parameters; here the


### PR DESCRIPTION
The first argument of `cglobal((:sym, lib), T)` (or the analogous `ccall` form) lowers to `Core.tuple(:sym, lib)`, which the interpreter resolves via `lookup_expr`'s `Core.tuple` branch. That branch looked up each element with `lookup`, which cannot evaluate a nested `getproperty` expression. On Julia >= 1.11, `Base.Math.libm` lowers to such a chain, so a library named that way
raised "invalid lookup expr Base.getproperty(...)".

Resolve the elements with `lookup_nested` instead, which already understands `getproperty`/`getindex`/`apply_type` for ccall lowering. Extend the issue #455 test to spell the library both as a string literal and as `Base.Math.libm`.