### PR TITLE
Interpret toplevel/module AST directly

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -21,6 +21,7 @@ JuliaInterpreter.method_table
 ```@docs
 Frame(mod::Module, ex::Expr)
 ExprSplitter
+JuliaInterpreter.find_or_create_module
 JuliaInterpreter.enter_call
 JuliaInterpreter.enter_call_expr
 JuliaInterpreter.prepare_frame

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -61,14 +61,19 @@ function finish_stack!(interp::Interpreter, frame::Frame, rootistoplevel::Bool=f
     frame0 = frame
     frame = leaf(frame)
     while true
-        istoplevel = rootistoplevel && frame.caller === nothing
+        istoplevel = rootistoplevel && is_toplevel_frame(frame)
         ret = finish_and_return!(interp, frame, istoplevel)
         isa(ret, BreakpointRef) && return ret
         frame === frame0 && return ret
         frame = return_from(frame)
         frame === nothing && return ret
         pc = frame.pc
-        if isassign(frame, pc)
+        if frame.framecode.is_toplevel_surface
+            # Driver frames record each statement's value (see `step_toplevel!`). The statement's
+            # side effects, including any global assignment, were performed by the child frame,
+            # so a surface `:(=)` must not be re-executed here.
+            frame.framedata.ssavalues[pc] = ret
+        elseif isassign(frame, pc)
             lhs = SSAValue(pc)
             do_assignment!(frame, lhs, ret)
         else
@@ -405,7 +410,7 @@ function maybe_reset_frame!(interp::Interpreter, frame::Frame, @nospecialize(pc)
         if is_wrapper
             return maybe_reset_frame!(interp, frame, finish!(interp, frame), rootistoplevel)
         end
-        pc = maybe_next_call!(interp, frame, rootistoplevel && frame.caller===nothing)
+        pc = maybe_next_call!(interp, frame, rootistoplevel && is_toplevel_frame(frame))
         return maybe_reset_frame!(interp, frame, pc, rootistoplevel)
     end
     return frame, pc
@@ -481,11 +486,11 @@ function debug_command(interp::Interpreter, frame::Frame, cmd::Symbol, rootistop
         if pc === nothing || isa(pc, BreakpointRef)
             return maybe_reset_frame!(interp, frame, pc, rootistoplevel)
         end
-        maybe_step_through_kwprep!(interp, frame, rootistoplevel && frame.caller === nothing)
+        maybe_step_through_kwprep!(interp, frame, rootistoplevel && is_toplevel_frame(frame))
         return frame, frame.pc
     end
 
-    istoplevel = rootistoplevel && frame.caller === nothing
+    istoplevel = rootistoplevel && is_toplevel_frame(frame)
     cmd0 = cmd
     is_si = false
     if cmd === :si

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -55,6 +55,60 @@ function return_from(frame::Frame)
     return frame
 end
 
+function link_caller_callee!(caller::Frame, callee::Frame)
+    caller.callee = callee
+    callee.caller = caller
+    return callee
+end
+
+"""
+    mod, body = find_or_create_module(parentmod::Module, ex::Expr)
+
+Given a `:module` expression `ex`, return the module it refers to (creating an empty one in
+`parentmod` if it does not yet exist) together with the `:block` of body statements. Handles
+both the 3-arg and 4-arg (syntax-versioned) `:module` forms.
+"""
+function find_or_create_module(parentmod::Module, ex::Expr)
+    @assert ex.head === :module
+    if length(ex.args) == 3
+        (std_imports, newname, modbody) = ex.args[1:3]
+        syntax_version = nothing
+    elseif length(ex.args) == 4
+        (syntax_version, std_imports, newname, modbody) = ex.args[1:4]
+    else
+        error("unexpected :module form with $(length(ex.args)) args")
+    end
+    newname = newname::Symbol
+    if invokelatest(isdefinedglobal, parentmod, newname)
+        mod = invokelatest(getglobal, parentmod, newname)
+        mod isa Module || throw(ErrorException("invalid redefinition of constant $(newname)"))
+    else
+        newnamestr = String(newname)
+        id = Base.identify_package(parentmod, newnamestr)
+        # If we're in a test environment and Julia's internal stdlibs are not a declared dependency
+        # of the package, we might fail to find it. Try really hard to find it.
+        if id === nothing && parentmod === Base.__toplevel__
+            for loaded_id in keys(Base.loaded_modules)
+                if loaded_id.name == newnamestr
+                    id = loaded_id
+                    break
+                end
+            end
+        end
+        if id !== nothing && haskey(Base.loaded_modules, id)
+            mod = Base.root_module(id)::Module
+        else
+            loc = firstline(ex)
+            module_ex = Expr(:module, std_imports, newname, Expr(:block, loc))
+            if syntax_version !== nothing
+                pushfirst!(module_ex.args, syntax_version)
+            end
+            mod = Core.eval(parentmod, module_ex)::Module
+        end
+    end
+    return mod, modbody::Expr
+end
+
 function clear_caches()
     empty!(junk_framedata)
     empty!(framedict)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -389,7 +389,12 @@ end
 
 function maybe_assign!(frame::Frame, @nospecialize(stmt), @nospecialize(val))
     pc = frame.pc
-    if isexpr(stmt, :(=))
+    if frame.framecode.is_toplevel_surface
+        # Driver frames record each statement's value (see `step_toplevel!`). The statement's
+        # side effects, including any global assignment, were performed by the child frame, so
+        # a surface `:(=)` must not be re-executed here.
+        frame.framedata.ssavalues[pc] = val
+    elseif isexpr(stmt, :(=))
         lhs = stmt.args[1]
         do_assignment!(frame, lhs, val)
     elseif isassign(frame, pc)
@@ -481,6 +486,88 @@ end
 # in `step_expr!`
 const _location = Dict{Tuple{Method,Int},Int}()
 
+# Run a child frame to completion with the task's world age raised to the latest committed
+# world. Per Julia's world-age rules, a binding/method defined by a previous toplevel statement
+# is only visible once the running task's world age advances to the global counter — which can
+# only happen at a toplevel boundary. `invoke_in_world` provides exactly that boundary, so the
+# child (and the `Core.eval`s it performs for definitions) sees all earlier toplevel definitions.
+function finish_latestworld!(interp::Interpreter, frame::Frame)
+    return invoke_in_world(Base.get_world_counter(), finish!, interp, frame, true)
+end
+
+# Interpret a single surface statement `node` of a toplevel/module driver frame (see
+# `is_toplevel_surface`). `:module`/`:toplevel`/`:using`/... are handled directly; every other
+# statement is lowered and run as a child frame so that method/struct/const definitions, scoping
+# blocks (issue #427), and macro expansions are handled by the ordinary lowered-code machinery.
+function step_toplevel!(interp::Interpreter, frame::Frame, @nospecialize(node))
+    pc = frame.pc
+    data = frame.framedata
+    mod = moduleof(frame)
+    frame.world = Base.get_world_counter()
+    local rhs
+    try
+        if isa(node, LineNumberNode) || isa(node, Nothing)
+            # nothing to do; just advance
+        elseif isa(node, Core.ReturnNode)
+            return nothing
+        elseif isa(node, Expr) && node.head === :module
+            newmod, modbody = find_or_create_module(mod, node)
+            newframe = toplevel_frame(newmod, modbody.args; world=frame.world)
+            link_caller_callee!(frame, newframe)
+            ret = finish_latestworld!(interp, newframe)
+            isa(ret, BreakpointRef) && return ret
+            return_from(newframe)
+            rhs = newmod
+        elseif isa(node, Expr) && node.head === :toplevel
+            newframe = toplevel_frame(mod, node.args; world=frame.world)
+            link_caller_callee!(frame, newframe)
+            ret = finish_latestworld!(interp, newframe)
+            isa(ret, BreakpointRef) && return ret
+            rhs = get_return(newframe)
+            return_from(newframe)
+        elseif isa(node, Expr) && (node.head === :using || node.head === :import ||
+                                   node.head === :export || node.head === :public)
+            invoke_in_world(Base.get_world_counter(), Core.eval, mod, node)
+        else
+            rhs = interpret_toplevel_stmt!(interp, frame, node)
+            isa(rhs, BreakpointRef) && return rhs
+        end
+        data.ssavalues[pc] = @isdefined(rhs) ? rhs : nothing
+    catch err
+        return handle_err(interp, frame, err)
+    end
+    return (frame.pc = pc + 1)
+end
+
+# Lower an ordinary toplevel statement and interpret it as a child frame.
+function interpret_toplevel_stmt!(interp::Interpreter, frame::Frame, @nospecialize(stmt))
+    mod = moduleof(frame)
+    lwr = isa(stmt, Expr) ? Meta.lower(mod, stmt) : stmt
+    if isexpr(lwr, :thunk, 1)
+        newframe = Frame(mod, (lwr.args[1])::CodeInfo; world=frame.world)
+        link_caller_callee!(frame, newframe)
+        ret = finish_latestworld!(interp, newframe)
+        isa(ret, BreakpointRef) && return ret
+        rhs = get_return(newframe)
+        return_from(newframe)
+        return rhs
+    elseif isexpr(lwr, :error)
+        throw(ArgumentError("lowering returned an error, $lwr"))
+    elseif isexpr(lwr, (:toplevel, :module))
+        # macro expansion surfaced a nested toplevel/module; interpret it directly
+        newframe = Frame(mod, lwr::Expr; world=frame.world)
+        link_caller_callee!(frame, newframe)
+        ret = finish_latestworld!(interp, newframe)
+        isa(ret, BreakpointRef) && return ret
+        rhs = get_return(newframe)
+        return_from(newframe)
+        return rhs
+    else
+        # not lowerable to a thunk (e.g. a bare `:global` declaration or a literal value)
+        return invoke_in_world(Base.get_world_counter(), Core.eval, mod, isa(lwr, Expr) ? lwr : stmt)
+    end
+end
+
 function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), istoplevel::Bool)
     pc, code, data = frame.pc, frame.framecode, frame.framedata
     # if !is_leaf(frame)
@@ -492,6 +579,9 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
     # bindings, methods, and types defined by earlier statements in the same frame.
     # Method frames, by contrast, execute in the fixed world captured at frame creation.
     istoplevel && (frame.world = Base.get_world_counter())
+    if frame.framecode.is_toplevel_surface
+        return step_toplevel!(interp, frame, node)
+    end
     coverage_visit_line!(frame)
     local rhs
     # For debugging:
@@ -536,10 +626,19 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
                 # TODO: This needs to handle the exception stack properly
                 # (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/591)
             elseif istoplevel
+                # This branch handles `:module`/`:toplevel` reached from a *lowered* `:thunk`.
+                # `step_toplevel!` handles the same heads reached from *unlowered* surface
+                # statements; keep the two in sync.
                 if node.head === :method && length(node.args) > 1
                     rhs = @invokelatest evaluate_methoddef(interp, frame, node)
                 elseif node.head === :module
-                    error("this should have been handled by split_expressions")
+                    newmod, modbody = find_or_create_module(moduleof(frame), node)
+                    newframe = toplevel_frame(newmod, modbody.args; world=frame.world)
+                    link_caller_callee!(frame, newframe)
+                    ret = finish_latestworld!(interp, newframe)
+                    isa(ret, BreakpointRef) && return ret
+                    return_from(newframe)
+                    rhs = newmod
                 elseif node.head === :using || node.head === :import || node.head === :export
                     Core.eval(moduleof(frame), node)
                 elseif node.head === :const || node.head === :globaldecl
@@ -556,20 +655,12 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
                 elseif node.head === :global
                     Core.eval(moduleof(frame), node)
                 elseif node.head === :toplevel
-                    mod = moduleof(frame)
-                    iter = ExprSplitter(mod, node)
-                    rhs = Core.eval(mod, Expr(:toplevel,
-                        :(for (mod, ex) in $iter
-                              if ex.head === :toplevel
-                                  Core.eval(mod, ex)
-                                  continue
-                              end
-                              newframe = ($Frame)(mod, ex)
-                              while true
-                                  ($through_methoddef_or_done!)($interp, newframe) === nothing && break
-                              end
-                              $return_from(newframe)
-                          end)))
+                    newframe = toplevel_frame(moduleof(frame), node.args; world=frame.world)
+                    link_caller_callee!(frame, newframe)
+                    ret = finish_latestworld!(interp, newframe)
+                    isa(ret, BreakpointRef) && return ret
+                    rhs = get_return(newframe)
+                    return_from(newframe)
                 elseif node.head === :error
                     error("unexpected error statement ", node)
                 elseif node.head === :incomplete

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -12,8 +12,6 @@ function _precompile_()
         end
         const threshold = 0.1
     end
-    for (mod, ex) in ExprSplitter(var"#Internal", expr)
-        frame = Frame(mod, ex)
-        debug_command(frame, :c, true)
-    end
+    frame = Frame(var"#Internal", Expr(:toplevel, expr.args...))
+    debug_command(frame, :c, true)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -141,6 +141,9 @@ struct FrameCode
     generator::Bool   # true if this is for the expression-generator of a @generated function
     report_coverage::Bool
     unique_files::Set{Symbol}
+    # true if `src.code` holds *unlowered* surface statements of a `:toplevel`/`:module`
+    # expression that must be interpreted statement-by-statement (see `step_toplevel!`)
+    is_toplevel_surface::Bool
 end
 
 """
@@ -192,7 +195,8 @@ end
 # stepping even if new code is defined mid-session; toplevel frames refresh it per statement.
 default_world() = Base.get_world_counter()
 
-function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::UInt=default_world())
+function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::UInt=default_world(),
+                   is_toplevel_surface::Bool=false)
     if optimize
         src, methodtables = optimize!(copy(src), scope, world)
     else
@@ -224,7 +228,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
     end
     end # @static if
 
-    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files)
+    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface)
     if scope isa Method
         for bp in _breakpoints
             # Manual union splitting
@@ -344,19 +348,62 @@ function Frame(mod::Module, src::CodeInfo; world::UInt=default_world(), kwargs..
     framecode = FrameCode(mod, src; world, kwargs...)
     return Frame(framecode, prepare_framedata(framecode, []), 1, nothing, world)
 end
+# Build a synthetic `CodeInfo` whose `code` holds the *unlowered* surface statements of a
+# `:toplevel`/`:module` body. Such a frame is stepped statement-by-statement by `step_toplevel!`,
+# which lowers ordinary statements to child frames and handles `:module`/`:using`/... directly.
+function toplevel_codeinfo(mod::Module, stmts::Vector{Any})
+    ci = (Meta.lower(mod, :(1 + 1)).args[1])::CodeInfo   # a throwaway skeleton; we overwrite its body
+    code = copy(stmts)
+    lastreal = findlast(s -> !isa(s, LineNumberNode), code)
+    push!(code, Core.ReturnNode(lastreal === nothing ? nothing : Core.SSAValue(lastreal)))
+    n = length(code)
+    ci.code = code
+    ci.ssavaluetypes = n
+    ci.ssaflags = zeros(eltype(ci.ssaflags), n)
+    ci.slotnames = Symbol[Symbol("#self#")]
+    ci.slotflags = UInt8[0x00]
+    # `step_toplevel!` reads line info from the surface `LineNumberNode`s in `code` directly and
+    # never consults the `CodeInfo`'s line tables, so the skeleton's debuginfo is left untouched on
+    # 1.12+ (where `codelocs` was folded into `debuginfo`); on older versions `codelocs` must match
+    # the new code length.
+    @static if !(VERSION ≥ v"1.12.0-DEV.173")
+        ci.codelocs = fill(Int32(1), n)
+    end
+    return ci
+end
+
+function toplevel_frame(mod::Module, stmts::Vector{Any}; world::UInt=default_world())
+    ci = toplevel_codeinfo(mod, stmts)
+    framecode = FrameCode(mod, ci; optimize=false, is_toplevel_surface=true, world)
+    return Frame(framecode, prepare_framedata(framecode, []), 1, nothing, world)
+end
+
 """
     frame = Frame(mod::Module, ex::Expr)
 
 Construct a `Frame` to evaluate `ex` in module `mod`.
 
+`ex` may be an ordinary expression (lowered to a `:thunk`) or a `:toplevel`/`:module`
+expression, in which case the resulting frame interprets the surface statements directly.
+
 This constructor can error, for example if lowering `ex` results in an `:error` or `:incomplete`
 expression, or if it otherwise fails to return a `:thunk`.
 """
-function Frame(mod::Module, ex::Expr)
+function Frame(mod::Module, ex::Expr; world::UInt=default_world())
+    if isexpr(ex, :toplevel)
+        return toplevel_frame(mod, ex.args; world)
+    elseif isexpr(ex, :module)
+        newmod, modbody = find_or_create_module(mod, ex)
+        return toplevel_frame(newmod, modbody.args; world)
+    end
     lwr = Meta.lower(mod, ex)
-    isexpr(lwr, :thunk) && return Frame(mod, lwr.args[1])
+    isexpr(lwr, :thunk, 1) && return Frame(mod, (lwr.args[1])::CodeInfo; world)
     if isexpr(lwr, :error) || isexpr(lwr, :incomplete)
         throw(ArgumentError("lowering returned an error, $lwr"))
+    end
+    # `macroexpand` inside lowering can surface a `:toplevel`/`:module` (lowering leaves these intact)
+    if isexpr(lwr, (:toplevel, :module))
+        return Frame(mod, lwr::Expr; world)
     end
     throw(ArgumentError("lowering did not return a `:thunk` expression, got $lwr"))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,6 +14,11 @@ function moduleof(@nospecialize(x))
     return isa(s, Module) ? s : s.module
 end
 
+# A frame executes top-level statements iff its scope is a Module. This cannot be inferred
+# from stack position: `:toplevel`/`:module` interpretation links module-scoped child frames
+# into the stack (see `step_toplevel!`), so a frame with a caller may still be toplevel.
+is_toplevel_frame(frame::Frame) = scopeof(frame) isa Module
+
 function Base.nameof(frame::Frame)
     s = frame.framecode.scope
     isa(s, Method) ? s.name : nameof(s)
@@ -370,6 +375,22 @@ function firstline(ex::Expr)
     return nothing
 end
 
+# A toplevel-surface framecode carries its line info in the `LineNumberNode`s of the surface
+# statements themselves; the synthetic `CodeInfo`'s line table is an unrelated skeleton (see
+# `toplevel_codeinfo`). Return the most recent `LineNumberNode` at or before `pc`, or `nothing`.
+function toplevel_surface_lnn(framecode::FrameCode, pc::Int)
+    code = framecode.src.code
+    for i in min(pc, length(code)):-1:1
+        stmt = code[i]
+        isa(stmt, LineNumberNode) && return stmt
+        if isa(stmt, Expr)
+            lnn = firstline(stmt)
+            lnn !== nothing && return lnn
+        end
+    end
+    return nothing
+end
+
 """
     loc = whereis(frame, pc::Int=frame.pc; macro_caller=false)
 
@@ -381,6 +402,11 @@ definition, but with`macro_caller=true` you can obtain the location within the
 method that issued the macro.
 """
 function CodeTracking.whereis(framecode::FrameCode, pc::Int; kwargs...)
+    if framecode.is_toplevel_surface
+        lnn = toplevel_surface_lnn(framecode, pc)
+        (lnn === nothing || lnn.file === nothing) && return nothing
+        return (getfile(lnn), getline(lnn))
+    end
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
     m = framecode.scope
@@ -401,6 +427,9 @@ is the location at the time the method was most recently defined.
 See [`CodeTracking.whereis`](@ref) for dynamic line information.
 """
 function linenumber(framecode::FrameCode, pc)
+    if framecode.is_toplevel_surface
+        return getline(toplevel_surface_lnn(framecode, pc))
+    end
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
     return getline(linetable(framecode, codeloc))
@@ -408,6 +437,11 @@ end
 linenumber(frame::Frame, pc=frame.pc) = linenumber(frame.framecode, pc)
 
 function getfile(framecode::FrameCode, pc)
+    if framecode.is_toplevel_surface
+        lnn = toplevel_surface_lnn(framecode, pc)
+        (lnn === nothing || lnn.file === nothing) && return nothing
+        return getfile(lnn)
+    end
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
     return getfile(linetable(framecode, codeloc))

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -601,3 +601,58 @@ end
     frame, bp = @interpret g3()
     @test isa(frame, Frame) && isa(bp, JuliaInterpreter.BreakpointRef)
 end
+
+module BPResumeToplevel
+callee(x) = 2x
+end
+
+@testset "breakpoint resume in direct toplevel frames" begin
+    # Module-scoped frames created by direct `:toplevel` interpretation have a caller, so the
+    # resume machinery must identify them as toplevel by scope, not by stack position: the
+    # interrupted thunk still contains `:latestworld`/`:method` statements to execute.
+    # Distinct values per scenario keep each run's assertions independent of the previous run.
+    resume_stmts(x, y) = Any[
+        :(a = callee($x)),
+        :(begin b = callee($y); k() = $x + $y; c = k() end),   # `:method` after the call, same thunk
+        :(d = k() + 1),
+    ]
+    getglob(name) = invokelatest(getproperty, BPResumeToplevel, name)
+    breakpoint(BPResumeToplevel.callee)
+    try
+        # Resume with `:c` (`finish_stack!`)
+        frame = Frame(BPResumeToplevel, Expr(:toplevel, resume_stmts(3, 4)...))
+        ret = JuliaInterpreter.debug_command(frame, :c, true)
+        nhits = 0
+        while ret !== nothing && nhits < 10
+            leafframe, bp = ret
+            @test bp isa JuliaInterpreter.BreakpointRef
+            nhits += 1
+            ret = JuliaInterpreter.debug_command(leafframe, :c, true)
+        end
+        @test nhits == 2
+        @test getglob(:a) == 6
+        @test getglob(:b) == 8
+        @test getglob(:c) == 7
+        @test getglob(:d) == 8
+
+        # Resume with `:finish` and `:n` (`maybe_reset_frame!`): `:finish` returns from the
+        # callee into the interrupted thunk, then `:n` steps the toplevel frames to completion.
+        frame = Frame(BPResumeToplevel, Expr(:toplevel, resume_stmts(5, 6)...))
+        leafframe, bp = JuliaInterpreter.debug_command(frame, :c, true)      # first hit
+        leafframe, bp = JuliaInterpreter.debug_command(leafframe, :c, true)  # second hit, mid-thunk
+        ret = JuliaInterpreter.debug_command(leafframe, :finish, true)
+        nsteps = 0
+        while ret !== nothing && (nsteps += 1) < 50
+            fr, pc = ret
+            @test !isa(pc, JuliaInterpreter.BreakpointRef)
+            ret = JuliaInterpreter.debug_command(fr, :n, true)
+        end
+        @test nsteps < 50
+        @test getglob(:a) == 10
+        @test getglob(:b) == 12
+        @test getglob(:c) == 11
+        @test getglob(:d) == 12
+    finally
+        remove()
+    end
+end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -705,3 +705,58 @@ module ModuleFormsTest end
         @test isdefinedglobal(JIVisible.OuterModDocstring4, :InnerModDocstring4)
     end
 end
+
+module DirectMulti end
+module DirectNest end
+module DirectLocal end
+module DirectKwdef end
+
+@testset "Direct toplevel interpretation" begin
+    # A whole multi-definition "file" interpreted as a single `Frame` (no `ExprSplitter`):
+    # struct, multiple dispatch, parametric method, `const`, and a module-level binding that
+    # calls a function defined earlier in the same frame.
+    src = """
+        struct Pt; x::Int; y::Int; end
+        area(p::Pt) = p.x * p.y
+        typ(::T) where {T} = T
+        const K = 7
+        v = area(Pt(3, 4))
+        """
+    frame = Frame(DirectMulti, Base.parse_input_line(src))
+    @test frame isa Frame
+    @test JuliaInterpreter.finish_and_return!(frame, true) == 12
+    @test @invokelatest(isdefinedglobal(DirectMulti, :Pt))
+    @test @invokelatest(DirectMulti.v) == 12
+    @test @invokelatest(DirectMulti.area(DirectMulti.Pt(2, 5))) == 10
+    @test @invokelatest(DirectMulti.typ(1.0)) === Float64
+    @test @invokelatest(DirectMulti.K) == 7
+
+    # Nested modules interpreted as a single `Frame`.
+    srcn = """
+        module Inner
+            inner_f() = 10
+            module Deep
+                deep_v = 99
+            end
+        end
+        outer = Inner.inner_f() + Inner.Deep.deep_v
+        """
+    JuliaInterpreter.finish_and_return!(Frame(DirectNest, Base.parse_input_line(srcn)), true)
+    @test @invokelatest(isdefinedglobal(DirectNest, :Inner))
+    @test @invokelatest(isdefinedglobal(DirectNest.Inner, :Deep))
+    @test @invokelatest(DirectNest.outer) == 109
+
+    # Issue #427: a `local` in a toplevel block must not leak to module scope.
+    JuliaInterpreter.finish_and_return!(Frame(DirectLocal, Expr(:toplevel, :(local foo = 10; bar = sin(foo)))), true)
+    @test !@invokelatest(isdefinedglobal(DirectLocal, :foo))
+    @test @invokelatest(DirectLocal.bar) == sin(10)
+
+    # A macrocall expanding to multiple definitions (constructors + keyword defaults).
+    srck = """
+        Base.@kwdef struct KW; a::Int = 1; b::Int = 2; end
+        p = KW(); q = KW(a = 10)
+        """
+    JuliaInterpreter.finish_and_return!(Frame(DirectKwdef, Base.parse_input_line(srck)), true)
+    @test @invokelatest(DirectKwdef.p) == @invokelatest(DirectKwdef.KW(1, 2))
+    @test @invokelatest(DirectKwdef.q) == @invokelatest(DirectKwdef.KW(10, 2))
+end


### PR DESCRIPTION
For toplevel code, formerly we relied on `ExprSplitter`, which arranged a return to actual toplevel as a device to solve world-age problems. This allowed the world age to advance by Julia's ordinary mechanisms. However, splitting is tricky and has some edge cases, and fortunately it is no longer necessary: instead, now we can increment the `Frame`'s world age at the right points to allow later statements to see earlier ones, without needing to return to the REPL's top-level.

Each child frame runs via `finish_latestworld!`, which uses `invoke_in_world(get_world_counter(), ...)` to raise the task's world age to the latest committed world. This is the real top-level world boundary: without it the ambient task world stays frozen at the outer `finish_and_return!` call and a binding/method defined by an earlier statement is "too new" for later ones.

`ExprSplitter` itself is untouched and still fully functional (Revise depends on it); only the interpreter's internal trampoline was removed.

This is the second PR out of an anticipated four to give JuliaInterpreter proper handling of world age.