### PR TITLE
Re-enable const folding with world-age invalidation

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -371,15 +371,13 @@ end
 maybe_step_through_kwprep!(frame::Frame, istoplevel::Bool=false) =
     maybe_step_through_kwprep!(RecursiveInterpreter(), frame, istoplevel)
 
-@static if isbindingresolved_deprecated
-    function is_empty_namedtuple(stmt)
-        isexpr(stmt, :call) && length(stmt.args) == 1 || return false
-        arg1 = stmt.args[1]
-        isa(arg1, GlobalRef) || return false
-        return arg1.name === :NamedTuple
-    end
-else
-    is_empty_namedtuple(stmt) = isexpr(stmt, :call) && is_quoted_type(stmt.args[1], :NamedTuple) && length(stmt.args) == 1
+# `optimize!` may fold the `NamedTuple` `const` `GlobalRef` into a `QuoteNode` of the type, so
+# accept both the folded (`QuoteNode`) and unfolded (`GlobalRef`) forms of an empty-`NamedTuple`
+# construction.
+function is_empty_namedtuple(stmt)
+    isexpr(stmt, :call) && length(stmt.args) == 1 || return false
+    arg1 = stmt.args[1]
+    return is_quoted_type(arg1, :NamedTuple) || (isa(arg1, GlobalRef) && arg1.name === :NamedTuple)
 end
 
 """

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -200,6 +200,11 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
     else
         framecode = get(framedict, method, nothing)
     end
+    # A cached `FrameCode` that folded a `const` global is only valid in worlds where the binding
+    # still holds the folded value; if not, drop it so a fresh one is built and re-cached below.
+    if framecode !== nothing && !framecode_valid_world(framecode, world)
+        framecode = nothing
+    end
     if framecode === nothing
         if is_generated(method) && !enter_generated
             # If we're stepping into a staged function, we need to use
@@ -236,15 +241,29 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
     return framecode, lenv
 end
 
-function get_framecode(method)
+function get_framecode(method; world::UInt=default_world())
     framecode = get(framedict, method, nothing)
+    if framecode !== nothing && !framecode_valid_world(framecode, world)
+        framecode = nothing
+    end
     if framecode === nothing
         @assert !is_generated(method)
         code = get_source(method)
-        framecode = FrameCode(method, code; generator=false)
+        framecode = FrameCode(method, code; generator=false, world)
         framedict[method] = framecode
     end
     return framecode
+end
+
+# A `FrameCode` whose `optimize!` folded `const` globals (recorded in `world_deps`) is only valid
+# in worlds where every folded binding still covers `world`. Each `Core.BindingPartition` is an
+# in-place invalidation token: a redefinition drops its `max_world` below the redefinition world.
+# Returns `true` for the overwhelmingly common case of no folded bindings.
+function framecode_valid_world(framecode::FrameCode, world::UInt)
+    for p in framecode.world_deps
+        (p.min_world <= world <= p.max_world) || return false
+    end
+    return true
 end
 
 """

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -8,7 +8,9 @@ function lookup_stmt(stmts::Vector{Any}, @nospecialize(arg), world::UInt)
     end
     if isa(arg, QuoteNode)
         return arg.value
-    elseif isexpr(arg, :call, 3) && is_global_ref(arg.args[1], Base, :getproperty)
+    elseif isexpr(arg, :call, 3) && (is_global_ref(arg.args[1], Base, :getproperty) ||
+                                     is_quotenode_egal(arg.args[1], Base.getproperty))
+        # `getproperty` may have been folded from a `GlobalRef` to a `QuoteNode` by `optimize!`.
         # Starting with Julia 1.12, llvmcall looks like this:
         # julia> src.code[1:3]
         # 3-element Vector{Any}:
@@ -45,32 +47,57 @@ function smallest_ref(stmts, arg, idmin)
     return idmin
 end
 
-function lookup_global_ref(a::GlobalRef, world::UInt)
-    isbindingresolved_deprecated && return a   # TODO: reenable this optimization once we can invalidate Frames
-    if Base.isbindingresolved(a.mod, a.name) &&
-        (invoke_in_world(world, isdefinedglobal, a.mod, a.name)) &&
-        (invoke_in_world(world, isconst, a.mod, a.name))
-        return QuoteNode(invoke_in_world(world, getglobal, a.mod, a.name))
+@static if isbindingresolved_deprecated
+    # Julia 1.12+: a `const` may be redefined, which advances the world age, so a folded value is
+    # only valid while its binding partition still covers the frame's world. Record that partition
+    # in `world_deps` as an invalidation token (redefinition drops its `max_world` below the
+    # redefinition world); `framecode_valid_world` then rejects the cached `FrameCode` for any world
+    # a folded value would be stale in, triggering a rebuild.
+    function lookup_global_ref(a::GlobalRef, world::UInt, world_deps)
+        if invoke_in_world(world, isdefinedglobal, a.mod, a.name) &&
+           invoke_in_world(world, isconst, a.mod, a.name)
+            partition = Base.lookup_binding_partition(world, a)
+            # Only fold *explicit* `const`s, not implicit (`using`-imported) bindings: an implicit
+            # name may be locally shadowed — e.g. `sin(::Int) = …` in a module that uses `Base.sin`,
+            # where the `:method` defines a new local `sin` — so folding the imported value would
+            # bind the method to the wrong function. (Pre-1.12 this role was served by the now-inert
+            # `isbindingresolved`.) Genuine local/explicit `const`s are the optimization's real target.
+            if !Base.is_some_implicit(Base.binding_kind(partition))
+                push!(world_deps, partition)
+                return QuoteNode(invoke_in_world(world, getglobal, a.mod, a.name))
+            end
+        end
+        return a
     end
-    return a
+else
+    # Pre-1.12: `const` bindings cannot be redefined, so a folded value never goes stale and no
+    # invalidation tracking is needed (`world_deps` is left untouched).
+    function lookup_global_ref(a::GlobalRef, world::UInt, world_deps)
+        if Base.isbindingresolved(a.mod, a.name) &&
+            (invoke_in_world(world, isdefinedglobal, a.mod, a.name)) &&
+            (invoke_in_world(world, isconst, a.mod, a.name))
+            return QuoteNode(invoke_in_world(world, getglobal, a.mod, a.name))
+        end
+        return a
+    end
 end
 
-function lookup_global_refs!(ex::Expr, world::UInt)
+function lookup_global_refs!(ex::Expr, world::UInt, world_deps)
     if isexpr(ex, (:isdefined, :thunk, :toplevel, :method, :global, :const, :globaldecl))
         return nothing
     end
     for (i, a) in enumerate(ex.args)
         ex.head === :(=) && i == 1 && continue # Don't look up globalrefs on the LHS of an assignment (issue #98)
         if isa(a, GlobalRef)
-            ex.args[i] = lookup_global_ref(a, world)
+            ex.args[i] = lookup_global_ref(a, world, world_deps)
         elseif isa(a, Expr)
-            lookup_global_refs!(a, world)
+            lookup_global_refs!(a, world, world_deps)
         end
     end
     return nothing
 end
 
-function lookup_getproperties(code::Vector{Any}, @nospecialize(a), world::UInt)
+function lookup_getproperties(code::Vector{Any}, @nospecialize(a), world::UInt, world_deps)
     isexpr(a, :call) || return a
     length(a.args) == 3 || return a
     arg1 = lookup_stmt(code, a.args[1], world)
@@ -79,7 +106,7 @@ function lookup_getproperties(code::Vector{Any}, @nospecialize(a), world::UInt)
     arg2 isa Module || return a
     arg3 = lookup_stmt(code, a.args[3], world)
     arg3 isa Symbol || return a
-    return lookup_global_ref(GlobalRef(arg2, arg3), world)
+    return lookup_global_ref(GlobalRef(arg2, arg3), world, world_deps)
 end
 
 # HACK This isn't optimization really, but necessary to bypass llvmcall and foreigncall
@@ -106,20 +133,30 @@ function optimize!(code::CodeInfo, scope, world::UInt)
     sparams = scope isa Method ? sparam_syms(scope) : Symbol[]
     replace_coretypes!(code)
 
+    # Binding partitions for the `const` globals folded below; recorded so a cached `FrameCode`
+    # can be invalidated once any folded value goes stale (see `FrameCode.world_deps`).
+    world_deps = BindingPartition[]
     # TODO: because of builtins.jl, for CodeInfos like
     #   %1 = Core.apply_type
     #   %2 = (%1)(args...)
     # it would be best to *not* resolve the GlobalRef at %1
     ## Replace GlobalRefs with QuoteNodes
-    for (i, stmt) in enumerate(code.code)
-        if isa(stmt, GlobalRef)
-            code.code[i] = lookup_global_ref(stmt, world)
-        elseif isa(stmt, Expr)
-            if stmt.head === :call && stmt.args[1] === :cglobal  # cglobal requires literals
-                continue
-            else
-                lookup_global_refs!(stmt, world)
-                code.code[i] = lookup_getproperties(code.code, stmt, world)
+    # On Julia 1.12+ fold only in method scope: a method frame executes in a single fixed
+    # world, so a value folded at `world` is exact. A module-scoped (toplevel) thunk advances
+    # the world at `:latestworld` markers — a `const` redefined and then read within the same
+    # thunk would serve a stale folded value — and such thunks execute once, so folding has
+    # nothing to gain there.
+    if scope isa Method || !isbindingresolved_deprecated
+        for (i, stmt) in enumerate(code.code)
+            if isa(stmt, GlobalRef)
+                code.code[i] = lookup_global_ref(stmt, world, world_deps)
+            elseif isa(stmt, Expr)
+                if stmt.head === :call && stmt.args[1] === :cglobal  # cglobal requires literals
+                    continue
+                else
+                    lookup_global_refs!(stmt, world, world_deps)
+                    code.code[i] = lookup_getproperties(code.code, stmt, world, world_deps)
+                end
             end
         end
     end
@@ -151,7 +188,7 @@ function optimize!(code::CodeInfo, scope, world::UInt)
         end
     end
 
-    return code, methodtables
+    return code, methodtables, world_deps
 end
 
 function parametric_type_to_expr(@nospecialize(t::Type))

--- a/src/types.jl
+++ b/src/types.jl
@@ -119,6 +119,15 @@ function do_coverage(m::Module)
     return false
 end
 
+# Element type of `FrameCode.world_deps`: the binding partitions captured when `optimize!` folds a
+# `const` global (see `lookup_global_ref`). `Core.BindingPartition` only exists on Julia 1.12+;
+# pre-1.12 nothing is ever folded with invalidation tracking, so `world_deps` is always empty there.
+@static if isbindingresolved_deprecated
+    const BindingPartition = Core.BindingPartition
+else
+    const BindingPartition = Union{}
+end
+
 """
 `FrameCode` holds static information about a method or toplevel code.
 One `FrameCode` can be shared by many calling `Frame`s.
@@ -144,6 +153,11 @@ struct FrameCode
     # true if `src.code` holds *unlowered* surface statements of a `:toplevel`/`:module`
     # expression that must be interpreted statement-by-statement (see `step_toplevel!`)
     is_toplevel_surface::Bool
+    # `Core.BindingPartition`s for the `const` globals that `optimize!` folded into `src` (empty
+    # unless any were folded). Each is an in-place invalidation token: redefining the binding drops
+    # its `max_world`, so `framecode_valid_world` can reject this cached `FrameCode` for worlds in
+    # which a folded value would be stale. Only populated on Julia 1.12+ (see `lookup_global_ref`).
+    world_deps::Vector{BindingPartition}
 end
 
 """
@@ -169,7 +183,10 @@ function is_breakpoint_expr(ex::Expr)
 end
 
 @static if isbindingresolved_deprecated
-    is_breakpoint_marker(stmt) = is_global_ref(stmt, JuliaInterpreter, :__BREAK_POINT_MARKER__)
+    # `optimize!` folds the `const` marker `GlobalRef` into its value, so match the value; the
+    # `is_global_ref` form is kept for any path where folding did not collapse the marker.
+    is_breakpoint_marker(stmt) = stmt === __BREAK_POINT_MARKER__ ||
+                                 is_global_ref(stmt, JuliaInterpreter, :__BREAK_POINT_MARKER__)
 else
     is_breakpoint_marker(stmt) = stmt === __BREAK_POINT_MARKER__
 end
@@ -198,10 +215,11 @@ default_world() = Base.get_world_counter()
 function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::UInt=default_world(),
                    is_toplevel_surface::Bool=false)
     if optimize
-        src, methodtables = optimize!(copy(src), scope, world)
+        src, methodtables, world_deps = optimize!(copy(src), scope, world)
     else
         src = replace_coretypes!(copy(src))
         methodtables = Vector{Union{Compiled,DispatchableMethod}}(undef, length(src.code))
+        world_deps = BindingPartition[]
     end
     breakpoints = Vector{BreakpointState}(undef, length(src.code))
     for (i, pc_expr) in enumerate(src.code)
@@ -228,7 +246,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
     end
     end # @static if
 
-    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface)
+    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface, world_deps)
     if scope isa Method
         for bp in _breakpoints
             # Manual union splitting

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1060,3 +1060,43 @@ JuliaInterpreter.method_table(::OverlayInterpreter) = ex_method_table
     end
     @test cos(42.0) == @interpret interp=OverlayInterpreter() call_func_overlay(42.0)
 end
+
+module ConstFoldTest
+const KK = 7
+twice_KK() = 2 * KK
+end
+
+@testset "const folding world-age invalidation" begin
+    # `optimize!` folds `const` globals into the lowered code; interpretation must still give
+    # the correct value (folding is active on all supported Julia versions).
+    @test @interpret(ConstFoldTest.twice_KK()) == 14
+
+    @static if JuliaInterpreter.isbindingresolved_deprecated
+        # Julia 1.12+ allows redefining a `const`, which advances the world age. Confirm `KK` was
+        # actually folded into the code first — otherwise the redefinition check below would be
+        # vacuous, since a non-folding interpreter would see the new value via a runtime lookup.
+        m = only(methods(ConstFoldTest.twice_KK))
+        w = Base.get_world_counter()
+        fc, _ = JuliaInterpreter.prepare_framecode(m, Tuple{typeof(ConstFoldTest.twice_KK)}; world=w)
+        @test any(s -> s isa QuoteNode && s.value === 7, fc.src.code)
+        @test JuliaInterpreter.framecode_valid_world(fc, w)
+
+        # Module-scoped (toplevel) thunks must not fold: the world advances at `:latestworld`
+        # markers mid-thunk, so a `const` redefined and then read within a single thunk would
+        # serve a stale folded value. Native semantics: `b` sees the new value.
+        Core.eval(ConstFoldTest, :(const B = 1))
+        frame = Frame(ConstFoldTest, :(begin const B = 2; b = B end))
+        JuliaInterpreter.finish_and_return!(frame, true)
+        @test invokelatest(getproperty, ConstFoldTest, :b) == 2
+
+        # Redefining the const invalidates the folded `FrameCode`: it is detected as stale, a fresh
+        # one is built that folds the new value, and the interpreter observes 140 rather than 14.
+        Core.eval(ConstFoldTest, :(const KK = 70))
+        w2 = Base.get_world_counter()
+        @test !JuliaInterpreter.framecode_valid_world(fc, w2)
+        fc2, _ = JuliaInterpreter.prepare_framecode(m, Tuple{typeof(ConstFoldTest.twice_KK)}; world=w2)
+        @test fc2 !== fc                                                # cache miss -> rebuilt
+        @test any(s -> s isa QuoteNode && s.value === 70, fc2.src.code) # new value folded in
+        @test @interpret(ConstFoldTest.twice_KK()) == 140
+    end
+end


### PR DESCRIPTION
`optimize!` folds references to `const` globals into the lowered code, but this was disabled on Julia 1.12+ (where a `const` may be redefined) because a cached `FrameCode` could then serve a stale folded value. Now that frames are gaining the ability to be invalidated, re-enable it.

Each folded binding's `Core.BindingPartition` is recorded in a new `FrameCode.world_deps` field. The partition is an in-place invalidation token: redefining the binding drops its `max_world` below the redefinition world. `framecode_valid_world` checks the frame's world against every recorded partition; `prepare_framecode`/`get_framecode` drop and rebuild a cached `FrameCode` that no longer holds for the requested world.

On 1.12+, folding is restricted in two ways:

- Only method scopes are folded, never module-scoped (toplevel) thunks. Module-scoped thunks only run once, so the performance isn't an issue; moreover, they need ways for definitions to update with world-age, making const-folding a liability rather than a benefit.

- Only *explicit* `const`s are folded, never implicit (`using`-imported) bindings: an implicit name may be locally shadowed -- for example `sin(::Int) = ...` in a module that uses `Base.sin`, where the `:method` introduces a new local `sin` -- so folding the imported value would bind the method to the wrong function. Pre-1.12 this role was served by the now-inert `isbindingresolved`.

It's worth clarifying this leaves one correctness gap: it's possible to set up situations where a toplevel frame that redefines a binding reaches the *old* binding within method frames. It requires a complex sequence that is unlikely to occur in practice (start debugging in a toplevel frame that calls a method, redefines a binding accessed by the method, and then calls the method again). Because I think debugging toplevel frames is rare (I might be the most likely person to do it, because of my work on Revise), I think this omission is defensible. But it will be closed in a follow-up PR, so let's avoid making a release until that lands.