### PR TITLE
Make the dispatch cache and compiled wrappers world-age correct

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -200,6 +200,12 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
     else
         framecode = get(framedict, method, nothing)
     end
+    # A cached `FrameCode` that baked a binding's value (e.g. a library name in a compiled `ccall`
+    # wrapper) is only valid in worlds where the binding still holds that value; if not, drop it
+    # so a fresh one is built and re-cached below.
+    if framecode !== nothing && !framecode_valid_world(framecode, world)
+        framecode = nothing
+    end
     if framecode === nothing
         if is_generated(method) && !enter_generated
             # If we're stepping into a staged function, we need to use
@@ -236,15 +242,30 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
     return framecode, lenv
 end
 
-function get_framecode(method)
+function get_framecode(method; world::UInt=default_world())
     framecode = get(framedict, method, nothing)
+    if framecode !== nothing && !framecode_valid_world(framecode, world)
+        framecode = nothing
+    end
     if framecode === nothing
         @assert !is_generated(method)
         code = get_source(method)
-        framecode = FrameCode(method, code; generator=false)
+        framecode = FrameCode(method, code; generator=false, world)
         framedict[method] = framecode
     end
     return framecode
+end
+
+# A `FrameCode` whose `optimize!` baked binding values into compiled wrappers (recorded in
+# `world_deps`) is only valid in worlds where every such binding still covers `world`. Each
+# `Core.BindingPartition` is an in-place invalidation token: a redefinition drops its `max_world`
+# below the redefinition world. Returns `true` for the overwhelmingly common case of no baked
+# bindings.
+function framecode_valid_world(framecode::FrameCode, world::UInt)
+    for p in framecode.world_deps
+        (p.min_world <= world <= p.max_world) || return false
+    end
+    return true
 end
 
 """

--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -19,10 +19,14 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
         local d_methprev
         depth = 1
         while true
-            # TODO: consider using world age bounds to handle cache invalidation
+            # Reuse a cached dispatch only if it was resolved in the current world. A world advance
+            # can change which method applies (e.g. a newly defined, more-specific method), so an
+            # entry stamped at an older world must be re-resolved rather than trusted by argument
+            # type alone. Method lookup reports no usable upper world bound for a live match (it
+            # returns `typemax`), so the resolution world itself is the invalidation key.
             # Determine whether the argument types match the signature
             sig = d_meth.sig.parameters::SimpleVector
-            if length(sig) == nargs
+            if d_meth.world == world && length(sig) == nargs
                 # If this is generated, match only if `enter_generated` also matches
                 fi = d_meth.frameinstance
                 if fi isa FrameInstance
@@ -61,39 +65,70 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
             d_meth = d_meth::DispatchableMethod
         end
     end
-    # We haven't yet encountered this argtype combination and need to look it up by dispatch
+    # We haven't yet encountered this argtype combination (or a world advance invalidated the
+    # cached entry) and need to look it up by dispatch.
     fargs[1] = f = to_function(fargs[1], world)
     ret = prepare_call(f, fargs; enter_generated, world, method_table)
     ret === nothing && return invoke_in_world(world, f, fargs[2:end]...), nothing
     is_compiled = isa(ret[1], Compiled)
-    local framecode
+    local framecode, env
     if is_compiled
-        d_meth = DispatchableMethod(nothing, Compiled(), ret[2])
+        fi = Compiled()
+        argtypes = ret[2]
     else
         framecode, args, env, argtypes = ret
-        # Store the results of the method lookup in the local method table
         fi = FrameInstance(framecode, env, is_generated(scopeof(framecode::FrameCode)::Method) && enter_generated)
-        d_meth = DispatchableMethod(nothing, fi, argtypes)
     end
+    # Store the result of the method lookup in the local method table, stamped with the world in
+    # which it was resolved (see the cache lookup above). If an entry with this exact key — the
+    # signature plus the generator/body flavor — already exists (typically one just rejected as
+    # stale after a world advance), refresh it in place so the chain does not accumulate
+    # superseded entries; otherwise prepend a new entry, dropping the oldest once the chain
+    # exceeds `max_methods`.
     if isassigned(parentframe.methodtables, idx)
-        # Drop the oldest d_meth, if necessary
-        d_methtmp = d_meth.next = parentframe.methodtables[idx]::DispatchableMethod
-        depth = 2
-        while d_methtmp.next !== nothing
-            depth += 1
-            depth >= max_methods && break
-            d_methtmp = d_methtmp.next::DispatchableMethod
-        end
-        if depth >= max_methods
-            d_methtmp.next = nothing
+        existing = find_dispatchable(parentframe.methodtables[idx]::DispatchableMethod, argtypes, fi)
+        if existing !== nothing
+            existing.frameinstance = fi
+            existing.world = world
+        else
+            d_meth = DispatchableMethod(parentframe.methodtables[idx]::DispatchableMethod, fi, argtypes, world)
+            d_methtmp = d_meth.next::DispatchableMethod
+            depth = 2
+            while d_methtmp.next !== nothing
+                depth += 1
+                depth >= max_methods && break
+                d_methtmp = d_methtmp.next::DispatchableMethod
+            end
+            if depth >= max_methods
+                d_methtmp.next = nothing
+            end
+            parentframe.methodtables[idx] = d_meth
         end
     else
-        d_meth.next = nothing
+        parentframe.methodtables[idx] = DispatchableMethod(nothing, fi, argtypes, world)
     end
-    parentframe.methodtables[idx] = d_meth
     if is_compiled
         return Compiled(), nothing
     else
         return framecode, env
+    end
+end
+
+# Return the cached entry that stores the same kind of dispatch as `fi`: the (concrete) signature
+# must be `argtypes` and the entry's generator/body flavor must match, since for a `@generated`
+# method the generator and the specialized body are distinct entries that coexist in the chain
+# (see the `enter_generated` check in the cache-hit loop). Returns `nothing` if there is no such
+# entry. Types are interned, so an identity comparison of signatures suffices and is cheap.
+function find_dispatchable(d::DispatchableMethod, @nospecialize(argtypes), fi::Union{Compiled,FrameInstance})
+    wants_generator = fi isa FrameInstance && fi.enter_generated
+    dd = d
+    while true
+        if dd.sig === argtypes
+            dfi = dd.frameinstance
+            (dfi isa FrameInstance && dfi.enter_generated) == wants_generator && return dd
+        end
+        next = dd.next
+        next === nothing && return nothing
+        dd = next::DispatchableMethod
     end
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,7 +1,39 @@
 const compiled_calls = Dict{Any,Any}()
 
-# Pre-frame-construction lookup
-function lookup_stmt(stmts::Vector{Any}, @nospecialize(arg), world::UInt)
+# Record the binding partition of `gr` in `world_deps` (a `FrameCode.world_deps` vector under
+# construction). Call this whenever a binding's *value* is resolved at framecode-build time and
+# baked into the framecode (e.g. into a compiled `ccall` wrapper): the partition lets
+# `framecode_valid_world` reject the framecode for worlds in which the binding was redefined.
+# Pass `world_deps=nothing` at resolution sites that bake nothing (the value is only inspected,
+# as in llvmcall detection or breakpoint-marker checks). Pre-1.12 a binding cannot be replaced
+# in a way the world age tracks, so there is nothing to record.
+function record_world_dep!(world_deps::Union{Nothing,Vector{BindingPartition}}, world::UInt, gr::GlobalRef)
+    @static if isbindingresolved_deprecated
+        world_deps === nothing && return nothing
+        push!(world_deps, Base.lookup_binding_partition(world, gr))
+    end
+    return nothing
+end
+
+# Record every `GlobalRef` reachable in `arg` (recursing through `Expr`s, but not chasing
+# `SSAValue`s). Used when a whole expression's value is baked at framecode-build time, e.g. a
+# `(name, lib)` tuple evaluated for a compiled `ccall` wrapper or the feeder statements of an
+# `llvmcall`. Over-recording is safe: a spurious entry only forces a rebuild, never staleness.
+function record_globalref_deps!(world_deps::Union{Nothing,Vector{BindingPartition}}, world::UInt, @nospecialize(arg))
+    if isa(arg, GlobalRef)
+        record_world_dep!(world_deps, world, arg)
+    elseif isa(arg, Expr)
+        for a in arg.args
+            record_globalref_deps!(world_deps, world, a)
+        end
+    end
+    return nothing
+end
+
+# Pre-frame-construction lookup. When the result is baked into the framecode, pass `world_deps`
+# so the resolved bindings are recorded (see `record_world_dep!`).
+function lookup_stmt(stmts::Vector{Any}, @nospecialize(arg), world::UInt,
+                     world_deps::Union{Nothing,Vector{BindingPartition}}=nothing)
     # this converts a statement into something else, without the slightest interest in correctness:
     if isa(arg, SSAValue)
         arg = stmts[arg.id]
@@ -17,14 +49,16 @@ function lookup_stmt(stmts::Vector{Any}, @nospecialize(arg), world::UInt)
         #  :(Base.getproperty(%2, :llvmcall))
         q = arg.args[3]
         if isa(q, QuoteNode) && (qval = q.value; qval isa Symbol)
-            mod = lookup_stmt(stmts, arg.args[2], world)
+            mod = lookup_stmt(stmts, arg.args[2], world, world_deps)
             if isa(mod, GlobalRef)
                 if invoke_in_world(world, isdefinedglobal, mod.mod, mod.name)
+                    record_world_dep!(world_deps, world, mod)
                     mod = invoke_in_world(world, getglobal, mod.mod, mod.name)
                 end
             end
             if isa(mod, Module)
                 if invoke_in_world(world, isdefinedglobal, mod, qval)
+                    record_world_dep!(world_deps, world, GlobalRef(mod, qval))
                     return invoke_in_world(world, getglobal, mod, qval)
                 end
             end
@@ -85,20 +119,22 @@ end
 # HACK This isn't optimization really, but necessary to bypass llvmcall and foreigncall
 # TODO This "optimization" should be refactored into a "minimum compilation" necessary to
 # execute `llvmcall` and `foreigncall` and pure optimizations on the lowered code representation.
-# In particular, the optimization that replaces `GlobalRef` with `QuoteNode` is invalid and
-# should be removed: This is because it is not possible to know when and where the binding
-# will be resolved without executing the code.
-# Since the current `build_compiled_[llvmcall|foreigncall]!` relies on this replacement,
-# they also need to be reimplemented.
+# On Julia 1.12+ the GlobalRef -> QuoteNode folding is disabled (`lookup_global_ref` returns the
+# ref unchanged) because a redefinable `const` makes the folded value world-dependent; values
+# that *must* be resolved at build time (library names and llvmcall ingredients baked into the
+# compiled wrappers below) record their bindings in `world_deps` so the framecode can be
+# invalidated when a binding is redefined.
 
 """
-    optimize!(code::CodeInfo, mod::Module)
+    optimize!(code::CodeInfo, scope, world::UInt) -> code, methodtables, world_deps
 
 Perform minor optimizations on the lowered AST in `code` to reduce execution time
 of the interpreter.
-Currently it looks up `GlobalRef`s (for which it needs `mod` to know the scope in
+Currently it looks up `GlobalRef`s (for which it needs `scope` to know the module in
 which this will run) and ensures that no statement includes nested `:call` expressions
 (splitting them out into multiple SSA-form statements if needed).
+`world_deps` collects the binding partitions of globals whose values were baked into
+the code (see `record_world_dep!`); it becomes `FrameCode.world_deps`.
 """
 function optimize!(code::CodeInfo, scope, world::UInt)
     mod = moduleof(scope)
@@ -106,6 +142,10 @@ function optimize!(code::CodeInfo, scope, world::UInt)
     sparams = scope isa Method ? sparam_syms(scope) : Symbol[]
     replace_coretypes!(code)
 
+    # Binding partitions of globals whose values get baked into this framecode (compiled
+    # `ccall`/`llvmcall` wrappers); recorded so a cached `FrameCode` can be invalidated once any
+    # baked value goes stale (see `FrameCode.world_deps`).
+    world_deps = BindingPartition[]
     # TODO: because of builtins.jl, for CodeInfos like
     #   %1 = Core.apply_type
     #   %2 = (%1)(args...)
@@ -140,18 +180,18 @@ function optimize!(code::CodeInfo, scope, world::UInt)
                 larg1 = lookup_stmt(code.code, arg1, world)
                 if (arg1 === :llvmcall || larg1 === Base.llvmcall || is_global_ref_egal(larg1, :llvmcall, Core.Intrinsics.llvmcall)) && isempty(sparams) && scope isa Method
                     # Call via `invokelatest` to avoid compiling it until we need it
-                    @invokelatest build_compiled_llvmcall!(stmt, code, idx, evalmod, world)
+                    @invokelatest build_compiled_llvmcall!(stmt, code, idx, evalmod, world, world_deps)
                     methodtables[idx] = Compiled()
                 end
             elseif stmt.head === :foreigncall && scope isa Method
                 # Call via `invokelatest` to avoid compiling it until we need it
-                @invokelatest build_compiled_foreigncall!(stmt, code, sparams, evalmod, world)
+                @invokelatest build_compiled_foreigncall!(stmt, code, sparams, evalmod, world, world_deps)
                 methodtables[idx] = Compiled()
             end
         end
     end
 
-    return code, methodtables
+    return code, methodtables, world_deps
 end
 
 function parametric_type_to_expr(@nospecialize(t::Type))
@@ -173,13 +213,22 @@ function parametric_type_to_expr(@nospecialize(t::Type))
     return t
 end
 
-function build_compiled_llvmcall!(stmt::Expr, code::CodeInfo, idx::Int, evalmod::Module, world::UInt)
+function build_compiled_llvmcall!(stmt::Expr, code::CodeInfo, idx::Int, evalmod::Module, world::UInt,
+                                  world_deps::Union{Nothing,Vector{BindingPartition}}=nothing)
     # Run a mini-interpreter to extract the types
     framecode = FrameCode(CompiledCalls, code; optimize=false, world)
     frame = Frame(framecode, prepare_framedata(framecode, []), 1, nothing, world)
     idxstart = idx
     for i = 2:4
         idxstart = smallest_ref(code.code, stmt.args[i], idxstart)
+    end
+    # The mini-interpreter resolves any globals among the feeder statements, and their values are
+    # baked into the compiled wrapper below; record them so the framecode can be invalidated.
+    for i = idxstart:idx-1
+        record_globalref_deps!(world_deps, world, code.code[i])
+    end
+    for i = 2:4
+        record_globalref_deps!(world_deps, world, stmt.args[i])
     end
     frame.pc = idxstart
     if idxstart < idx
@@ -211,7 +260,8 @@ function build_compiled_llvmcall!(stmt::Expr, code::CodeInfo, idx::Int, evalmod:
 end
 
 # Handle :llvmcall & :foreigncall (issue #28)
-function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector{Symbol}, evalmod::Module, world::UInt)
+function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector{Symbol}, evalmod::Module, world::UInt,
+                                     world_deps::Union{Nothing,Vector{BindingPartition}}=nothing)
     TVal = evalmod == Core.Compiler ? Core.Compiler.Val : Val
     RetType, ArgType = stmt.args[2], stmt.args[3]::SimpleVector
 
@@ -224,13 +274,19 @@ function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector
         end
     else
         while isa(cfunc, SSAValue)
-            cfunc = lookup_stmt(code.code, cfunc, world)
+            cfunc = lookup_stmt(code.code, cfunc, world, world_deps)
             cfunc isa Symbol && (cfunc = QuoteNode(cfunc))
         end
         # n.b. Base.memhash is deprecated (continued use would cause serious faults) in the same version as the syntax is deprecated
         # so this is only needed as a legacy hack
         if isa(cfunc, Expr) || (cfunc isa GlobalRef && cfunc == GlobalRef(Base, :memhash))
-            cfunc = something(try QuoteNode(Core.eval(evalmod, cfunc)) catch nothing end, cfunc)
+            evaluated = try QuoteNode(Core.eval(evalmod, cfunc)) catch nothing end
+            if evaluated !== nothing
+                # The expression's value (e.g. a `(name, lib)` tuple) is baked into the compiled
+                # wrapper; record the bindings it resolved.
+                record_globalref_deps!(world_deps, world, cfunc)
+                cfunc = evaluated
+            end
         end
         if !(isa(cfunc, Union{String, Tuple}) || (isa(cfunc, QuoteNode) && isa(cfunc.value, Union{String, Tuple, Symbol})))
             dynamic_ccall = true

--- a/src/types.jl
+++ b/src/types.jl
@@ -104,6 +104,7 @@ mutable struct _DispatchableMethod{FrameCode}
     next::Union{Nothing,_DispatchableMethod{FrameCode}}  # linked-list representation
     frameinstance::Union{Compiled,_FrameInstance{FrameCode}} # really a Union{Compiled, FrameInstance} but we have a cyclic dependency
     sig::Type # for speed of matching, this is a *concrete* signature. `sig <: frameinstance.framecode.scope.sig`
+    world::UInt # world age in which `frameinstance` was resolved for `sig`; a later world forces re-resolution
 end
 
 # 0: none

--- a/src/types.jl
+++ b/src/types.jl
@@ -120,6 +120,16 @@ function do_coverage(m::Module)
     return false
 end
 
+# Element type of `FrameCode.world_deps`: the binding partitions of globals whose *values*
+# `optimize!` resolved at framecode-build time (e.g. a library name baked into a compiled `ccall`
+# wrapper; see `record_world_dep!`). `Core.BindingPartition` only exists on Julia 1.12+; pre-1.12
+# a binding cannot be replaced in a way the world age tracks, so `world_deps` is always empty there.
+@static if isbindingresolved_deprecated
+    const BindingPartition = Core.BindingPartition
+else
+    const BindingPartition = Union{}
+end
+
 """
 `FrameCode` holds static information about a method or toplevel code.
 One `FrameCode` can be shared by many calling `Frame`s.
@@ -145,6 +155,12 @@ struct FrameCode
     # true if `src.code` holds *unlowered* surface statements of a `:toplevel`/`:module`
     # expression that must be interpreted statement-by-statement (see `step_toplevel!`)
     is_toplevel_surface::Bool
+    # `Core.BindingPartition`s for globals whose values `optimize!` baked into this framecode's
+    # compiled `ccall`/`llvmcall` wrappers (empty unless any were baked). Each is an in-place
+    # invalidation token: redefining the binding drops its `max_world`, so `framecode_valid_world`
+    # can reject this cached `FrameCode` for worlds in which a baked value would be stale.
+    # Only populated on Julia 1.12+ (see `record_world_dep!`).
+    world_deps::Vector{BindingPartition}
 end
 
 """
@@ -199,10 +215,11 @@ default_world() = Base.get_world_counter()
 function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::UInt=default_world(),
                    is_toplevel_surface::Bool=false)
     if optimize
-        src, methodtables = optimize!(copy(src), scope, world)
+        src, methodtables, world_deps = optimize!(copy(src), scope, world)
     else
         src = replace_coretypes!(copy(src))
         methodtables = Vector{Union{Compiled,DispatchableMethod}}(undef, length(src.code))
+        world_deps = BindingPartition[]
     end
     breakpoints = Vector{BreakpointState}(undef, length(src.code))
     for (i, pc_expr) in enumerate(src.code)
@@ -229,7 +246,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
     end
     end # @static if
 
-    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface)
+    framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface, world_deps)
     if scope isa Method
         for bp in _breakpoints
             # Manual union splitting

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1126,3 +1126,61 @@ end
     end
     @test sort(flavors) == [false, true]
 end
+
+module WrapperDepTest
+    const MYLIB = Base.Math.libm
+    powf_constlib(a, b) = ccall(("powf", MYLIB), Float32, (Float32, Float32), a, b)
+    powf_chainlib(a, b) = ccall(("powf", Base.Math.libm), Float32, (Float32, Float32), a, b)
+    # `Int32`/`i32` keeps the signature exact on both 32- and 64-bit platforms
+    # (`llvmcall` does not convert its arguments).
+    const IR = """
+        %3 = add i32 %0, %1
+        ret i32 %3
+        """
+    llvmadd(x, y) = Base.llvmcall(IR, Int32, Tuple{Int32, Int32}, x, y)
+end
+
+@testset "world-bound compiled ccall/llvmcall wrappers" begin
+    # Library names and llvmcall ingredients are resolved at framecode-build time and baked into
+    # compiled wrappers (see `build_compiled_foreigncall!`/`build_compiled_llvmcall!`).
+    @test @interpret(WrapperDepTest.powf_constlib(2f0, 3f0)) == 8f0
+    @test @interpret(WrapperDepTest.powf_chainlib(2f0, 3f0)) == 8f0
+    @test @interpret(WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 42
+
+    @static if JuliaInterpreter.isbindingresolved_deprecated
+        # On Julia 1.12+ a `const` may be redefined, so every binding resolved at build time is
+        # recorded in `FrameCode.world_deps`; redefining one must invalidate the cached framecode.
+        w = Base.get_world_counter()
+        mlib = only(methods(WrapperDepTest.powf_constlib))
+        fc, _ = JuliaInterpreter.prepare_framecode(mlib, Tuple{typeof(WrapperDepTest.powf_constlib), Float32, Float32}; world=w)
+        @test !isempty(fc.world_deps)   # the `(name, lib)` tuple resolution
+        @test JuliaInterpreter.framecode_valid_world(fc, w)
+        mchain = only(methods(WrapperDepTest.powf_chainlib))
+        fcchain, _ = JuliaInterpreter.prepare_framecode(mchain, Tuple{typeof(WrapperDepTest.powf_chainlib), Float32, Float32}; world=w)
+        @test !isempty(fcchain.world_deps)   # the `Base.Math.libm` getproperty-chain resolution
+
+        # Rebinding the library const (e.g. after dlclosing one library and dlopening another)
+        # invalidates the framecode; the rebuild resolves the new value, so the call fails on the
+        # bogus path instead of silently calling into the stale library.
+        Core.eval(WrapperDepTest, :(const MYLIB = "/nonexistent_library_path"))
+        w2 = Base.get_world_counter()
+        @test !JuliaInterpreter.framecode_valid_world(fc, w2)
+        fc2, _ = JuliaInterpreter.prepare_framecode(mlib, Tuple{typeof(WrapperDepTest.powf_constlib), Float32, Float32}; world=w2)
+        @test fc2 !== fc
+        @test_throws "nonexistent_library_path" @interpret(WrapperDepTest.powf_constlib(2f0, 3f0))
+        # An unrelated rebinding must not invalidate the chain-library framecode.
+        @test JuliaInterpreter.framecode_valid_world(fcchain, w2)
+
+        # The llvmcall IR string is likewise baked into its compiled wrapper.
+        mll = only(methods(WrapperDepTest.llvmadd))
+        fcll, _ = JuliaInterpreter.prepare_framecode(mll, Tuple{typeof(WrapperDepTest.llvmadd), Int32, Int32}; world=w2)
+        @test !isempty(fcll.world_deps)
+        Core.eval(WrapperDepTest, :(const IR = """
+            %3 = sub i32 %0, %1
+            ret i32 %3
+            """))
+        w3 = Base.get_world_counter()
+        @test !JuliaInterpreter.framecode_valid_world(fcll, w3)
+        @test @interpret(WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 18   # rebuilt wrapper uses the new IR
+    end
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1060,3 +1060,69 @@ JuliaInterpreter.method_table(::OverlayInterpreter) = ex_method_table
     end
     @test cos(42.0) == @interpret interp=OverlayInterpreter() call_func_overlay(42.0)
 end
+
+module DispatchWorldTest
+    inner(::Number) = 1
+    helper() = inner(1)
+end
+
+@testset "local dispatch cache world-age invalidation" begin
+    # Within a single interpretation run, defining a more-specific method must invalidate the
+    # local method-table cache so a later call to the same helper dispatches to the new method.
+    # Across separate `@interpret` calls `clear_caches` masks this; it is only observable when the
+    # world advances mid-run, as in toplevel/module interpretation. The cached `DispatchableMethod`
+    # is stamped with its resolution world, and a higher frame world forces re-resolution.
+    stmts = Any[
+        :(x = helper()),
+        :(inner(::Int) = 2),   # advances the world age with a more-specific method
+        :(y = helper()),       # must re-dispatch to `inner(::Int)`
+        :(z = helper()),       # hits the refreshed cache entry at the now-current world
+    ]
+    frame = JuliaInterpreter.Frame(DispatchWorldTest, Expr(:toplevel, stmts...))
+    JuliaInterpreter.debug_command(JuliaInterpreter.RecursiveInterpreter(), frame, :c, true)
+    @test invokelatest(getproperty, DispatchWorldTest, :x) == 1
+    @test invokelatest(getproperty, DispatchWorldTest, :y) == 2   # stale cache would yield 1
+    @test invokelatest(getproperty, DispatchWorldTest, :z) == 2
+end
+
+module GenCacheTest
+    @generated gfun(x) = :(x + 1)
+    gcaller(x) = gfun(x)
+end
+
+@testset "dispatch cache keeps generator and body entries distinct" begin
+    # For a `@generated` method, the same call site can be resolved in two flavors: the
+    # specialized body (`enter_generated=false`) and the generator (`enter_generated=true`).
+    # Both must coexist in the `DispatchableMethod` chain; if the refresh-in-place store keyed
+    # on the signature alone, alternating flavors would overwrite a single entry and every
+    # alternation would re-dispatch.
+    m = only(methods(GenCacheTest.gcaller))
+    w = Base.get_world_counter()
+    fc, _ = JuliaInterpreter.prepare_framecode(m, Tuple{typeof(GenCacheTest.gcaller), Int}; world=w)
+    idx = findfirst(JuliaInterpreter.is_call, fc.src.code)   # the `gfun(x)` call, the only call
+    @test idx !== nothing
+    chainlength(idx) = begin
+        d = fc.methodtables[idx]
+        n = 0
+        while d !== nothing
+            n += 1
+            d = d.next
+        end
+        n
+    end
+    JuliaInterpreter.get_call_framecode(Any[GenCacheTest.gfun, 1], fc, idx; enter_generated=false, world=w)
+    @test chainlength(idx) == 1
+    JuliaInterpreter.get_call_framecode(Any[GenCacheTest.gfun, 1], fc, idx; enter_generated=true, world=w)
+    @test chainlength(idx) == 2
+    JuliaInterpreter.get_call_framecode(Any[GenCacheTest.gfun, 1], fc, idx; enter_generated=false, world=w)
+    @test chainlength(idx) == 2   # body entry still present: pure cache hit, no third entry
+    flavors = let d = fc.methodtables[idx], fl = Bool[]
+        while d !== nothing
+            fi = d.frameinstance
+            push!(fl, fi isa JuliaInterpreter.FrameInstance && fi.enter_generated)
+            d = d.next
+        end
+        fl
+    end
+    @test sort(flavors) == [false, true]
+end


### PR DESCRIPTION
The interpreter has two caches whose entries can go stale when the world advances, and both have been papered over by the defensive `clear_caches()` at every interpreter entry. This PR makes each cache world-age correct in its own commit:

1. **World-bound the local method-table dispatch cache.** Cached `DispatchableMethod` entries were re-validated only by argument-type checks, so a more-specific method defined in a later world was not detected within a single interpretation run (e.g. toplevel/module interpretation that defines a method and then calls a helper again). Each entry is now stamped with the world in which its dispatch was resolved; a world advance forces re-resolution of that call site, refreshing the entry in place.

2. **World-bound the compiled ccall/llvmcall wrappers.** `build_compiled_foreigncall!`/`build_compiled_llvmcall!` resolve bindings at framecode-build time and bake the values into compiled wrappers (library names, llvmcall IR/types). On Julia 1.12+ a `const` may be redefined, which means we could `dlclose` an open library, open its replacement, and re-assign the binding. This would leave the `FrameCode` in a broken state. Each build-time resolution now records the binding's `Core.BindingPartition` in a new `FrameCode.world_deps` field, and `prepare_framecode`/`get_framecode` drop and rebuild any cached `FrameCode` whose recorded partitions no longer cover the requested world. `world_deps` is empty for framecodes that bake nothing (the overwhelmingly common case), so the check is effectively free.

Worth noting: with both staleness classes tracked, `clear_caches()` is no longer needed for correctness. Removing it is left to a follow-up issue.

The intent is "merge" and not "squash" (it's worth keeping these two commits separate).