### PR TITLE
Make StackFrame total when line info is missing

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,6 +297,22 @@ end
 
 @static if VERSION ≥ v"1.12.0-DEV.173"
 
+getfirstline(arg) = getfirstline(linetable(arg))
+function getfirstline(debuginfo::Core.DebugInfo)
+    while true
+        ltnext = debuginfo.linetable
+        ltnext === nothing && break
+        debuginfo = ltnext
+    end
+    firstline = typemax(Int)
+    for k = 0:typemax(Int)
+        codeloc = Core.Compiler.getdebugidx(debuginfo, k)
+        line::Int = codeloc[1]
+        line < 0 && break
+        line > 0 && (firstline = min(firstline, line))
+    end
+    return firstline == typemax(Int) ? 0 : firstline
+end
 getlastline(arg) = getlastline(linetable(arg))
 function getlastline(debuginfo::Core.DebugInfo)
     while true
@@ -432,7 +448,8 @@ function linenumber(framecode::FrameCode, pc)
     end
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
-    return getline(linetable(framecode, codeloc))
+    lineinfo = linetable(framecode, codeloc)
+    return lineinfo === nothing ? nothing : getline(lineinfo)
 end
 linenumber(frame::Frame, pc=frame.pc) = linenumber(frame.framecode, pc)
 
@@ -444,7 +461,8 @@ function getfile(framecode::FrameCode, pc)
     end
     codeloc = codelocation(framecode.src, pc)
     codeloc == 0 && return nothing
-    return getfile(linetable(framecode, codeloc))
+    lineinfo = linetable(framecode, codeloc)
+    return lineinfo === nothing ? nothing : getfile(lineinfo)
 end
 getfile(frame::Frame, pc=frame.pc) = getfile(frame.framecode, pc)
 
@@ -820,7 +838,7 @@ function Base.StackTraces.StackFrame(frame::Frame)
     end
     Base.StackFrame(
         fname,
-        Symbol(getfile(frame)),
+        Symbol(@something(getfile(frame), :none)),
         @something(linenumber(frame), getfirstline(frame)),
         mi,
         false,

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -762,6 +762,19 @@ end
 frame = JuliaInterpreter.enter_call(f_345)
 @test JuliaInterpreter.whereis(frame) == (@__FILE__(), @__LINE__() - 2)
 
+# Building a `StackFrame` must not throw when a statement has no recoverable line
+# information (the cause of `getfile(::Nothing)` in Revise#931). `getfile`/`linenumber`
+# return `nothing` and the frame is reported at the `none:0` sentinel.
+@testset "StackFrame with missing line info" begin
+    lwr = Meta.lower(@__MODULE__, :(f_missing_lineinfo(x) = x + does_not_exist(x)))
+    frame = JuliaInterpreter.Frame(@__MODULE__, lwr.args[1])
+    for pc in 1:length(frame.framecode.src.code)
+        frame.pc = pc
+        @test Base.StackTraces.StackFrame(frame) isa Base.StackTraces.StackFrame
+    end
+    @test JuliaInterpreter.getfirstline(frame) isa Integer
+end
+
 # issue #285
 using LinearAlgebra, SparseArrays, Random
 @testset "issue 285" begin


### PR DESCRIPTION
On Julia 1.12 a frame statement can have a code location whose linetable entry is `nothing`. `getfile(framecode, pc)` and `linenumber(framecode, pc)` then called `getfile`/`getline` on `nothing` and threw, so constructing a `StackFrame` for such a frame raised `MethodError: getfile(::Nothing)`. This surfaced in Revise as a confusing error that masked the real revision error (Revise#931).

Guard both accessors to return `nothing` when the linetable entry is absent, mirroring the toplevel-surface branch and `whereis`. Define `getfirstline` for 1.12 (it existed only for older Julia, leaving `compute_linerange` and the `StackFrame` line fallback broken), and report an undescribable frame at the `none:0` sentinel instead of `nothing:0`.