### PR TITLE
Add Aqua.jl quality checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,17 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Aqua = "0.8"
+CassetteOverlay = "0.2"
 CodeTracking = "2, 3"
+DataFrames = "1"
+DeepDiffs = "1"
+FunctionWrappers = "1"
+LoopVectorization = "0.12"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CassetteOverlay = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -29,4 +36,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "SHA", "SparseArrays", "Test"]
+test = ["Aqua", "CassetteOverlay", "DataFrames", "Dates", "DeepDiffs", "Distributed", "FunctionWrappers", "LinearAlgebra", "Logging", "LoopVectorization", "Mmap", "SHA", "SparseArrays", "Test"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | **Documentation**                                                               | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] | [![][gh-actions-img]][gh-actions-url]  [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] | [![][gh-actions-img]][gh-actions-url]  [![][codecov-img]][codecov-url] [![Aqua QA](https://juliatesting.github.io/Aqua.jl/dev/assets/badge.svg)](https://github.com/JuliaTesting/Aqua.jl) |
 
 ## Installation
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,6 +105,10 @@ mutable struct _DispatchableMethod{FrameCode}
     frameinstance::Union{Compiled,_FrameInstance{FrameCode}} # really a Union{Compiled, FrameInstance} but we have a cyclic dependency
     sig::Type # for speed of matching, this is a *concrete* signature. `sig <: frameinstance.framecode.scope.sig`
     world::UInt # world age in which `frameinstance` was resolved for `sig`; a later world forces re-resolution
+    # Without this explicit inner constructor, Julia auto-generates an outer one where
+    # `FrameCode` is unbound when next=nothing and frameinstance=Compiled().
+    _DispatchableMethod{FrameCode}(next, frameinstance, sig, world) where {FrameCode} =
+        new{FrameCode}(next, frameinstance, sig, world)
 end
 
 # 0: none

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,13 @@
 using JuliaInterpreter
 using Test
 using Logging
+using Aqua
 
 @test isempty(detect_ambiguities(JuliaInterpreter, Base, Core))
+Aqua.test_all(JuliaInterpreter; deps_compat=(
+    ignore=[:InteractiveUtils, :Random, :UUIDs],
+    check_extras=(ignore=[:Dates, :Distributed, :LinearAlgebra, :Logging, :Mmap, :SHA, :SparseArrays, :Test],),
+))
 
 if isdefined(Test, :detect_closure_boxes)
     @test isempty(Test.detect_closure_boxes(JuliaInterpreter))


### PR DESCRIPTION
Adds `Aqua.test_all` to the test suite. One real fix: add an explicit inner constructor to `_DispatchableMethod{FrameCode}` to suppress the auto-generated outer constructor, which has an unbound `FrameCode` when `next=nothing` and `frameinstance=Compiled()`.