### PR TITLE
Run expanded invokelatest in the latest world

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -54,7 +54,7 @@ const CALL_LATEST = """args = getargs(interp, args, frame)
         for x in args
             push!(new_expr.args, QuoteNode(x))
         end
-        return maybe_recurse_expanded_builtin(interp, frame, new_expr)
+        return recurse_expanded_builtin_latest(interp, frame, new_expr)
 """
 
 function scopedname(f)
@@ -161,6 +161,24 @@ function maybe_recurse_expanded_builtin(interp::Interpreter, frame::Frame, new_e
         return maybe_evaluate_builtin(interp, frame, new_expr, true)
     else
         return new_expr
+    end
+end
+
+# Evaluate the target of an expanded `invokelatest`/`_call_latest` in the latest world, so that
+# bindings, methods, and types defined since the enclosing frame's world are visible.
+function recurse_expanded_builtin_latest(interp::Interpreter, frame::Frame, new_expr::Expr)
+    world = Base.get_world_counter()
+    oldworld = frame.world
+    frame.world = world
+    try
+        f = new_expr.args[1]
+        if supertype(typeof(f)) === Core.Builtin || isa(f, Core.IntrinsicFunction)
+            return invoke_in_world(world, maybe_evaluate_builtin, interp, frame, new_expr, true)
+        end
+        fargs = collect_args(interp, frame, new_expr)
+        return Some{Any}(invoke_in_world(world, evaluate_call!, interp, frame, fargs, false))
+    finally
+        frame.world = oldworld
     end
 end
 

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -20,6 +20,24 @@ function maybe_recurse_expanded_builtin(interp::Interpreter, frame::Frame, new_e
     end
 end
 
+# Evaluate the target of an expanded `invokelatest`/`_call_latest` in the latest world, so that
+# bindings, methods, and types defined since the enclosing frame's world are visible.
+function recurse_expanded_builtin_latest(interp::Interpreter, frame::Frame, new_expr::Expr)
+    world = Base.get_world_counter()
+    oldworld = frame.world
+    frame.world = world
+    try
+        f = new_expr.args[1]
+        if supertype(typeof(f)) === Core.Builtin || isa(f, Core.IntrinsicFunction)
+            return invoke_in_world(world, maybe_evaluate_builtin, interp, frame, new_expr, true)
+        end
+        fargs = collect_args(interp, frame, new_expr)
+        return Some{Any}(invoke_in_world(world, evaluate_call!, interp, frame, fargs, false))
+    finally
+        frame.world = oldworld
+    end
+end
+
 """
     ret = maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Expr, expand::Bool)
 
@@ -288,7 +306,7 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
         for x in args
             push!(new_expr.args, QuoteNode(x))
         end
-        return maybe_recurse_expanded_builtin(interp, frame, new_expr)
+        return recurse_expanded_builtin_latest(interp, frame, new_expr)
 
     elseif f === isa
         if nargs == 2
@@ -532,7 +550,7 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
         for x in args
             push!(new_expr.args, QuoteNode(x))
         end
-        return maybe_recurse_expanded_builtin(interp, frame, new_expr)
+        return recurse_expanded_builtin_latest(interp, frame, new_expr)
 
     elseif f === Core.Intrinsics.llvmcall
         return Some{Any}(Core.Intrinsics.llvmcall(getargs(interp, args, frame)...))

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1079,6 +1079,43 @@ module DispatchWorldTest
     helper() = inner(1)
 end
 
+module InvokeLatestWorldTest
+    const REBOUND = 1
+    gen(::Any) = 1
+end
+
+@testset "invokelatest runs in the latest world" begin
+    # `invokelatest`/`_call_latest` must execute their target in the latest world even when the
+    # interpreter expands them. The world is raised uniformly, not keyed to the target: a builtin
+    # is evaluated inline, an ordinary function in a child frame, but both see methods/bindings
+    # defined since the frame's world. Each call is pinned to `world` (before the new definitions),
+    # as toplevel interpretation does; the old world would yield the stale result.
+    world = Base.get_world_counter()
+    finish(f) = Base.invoke_in_world(world, JuliaInterpreter.finish_and_return!,
+                                     JuliaInterpreter.RecursiveInterpreter(),
+                                     JuliaInterpreter.enter_call(f))
+
+    # Ordinary-function target: a more-specific method added mid-run must be dispatched to.
+    # `gen` exists before `world`, so reading the binding is fine; only dispatch depends on the world.
+    function dispatch_reader()
+        Core.eval(InvokeLatestWorldTest, :(gen(::Int) = 2))
+        return Base.invokelatest(InvokeLatestWorldTest.gen, 5)
+    end
+    @test finish(dispatch_reader) == 2   # the old world would dispatch to `gen(::Any) == 1`
+
+    # Builtin target: `Base.Docs.meta` relies on this to read back a `##meta##` const it has just
+    # created. A rebound const keeps its old value in the old world (Julia 1.12 partitions const
+    # bindings by world), so the world of the read is observable; earlier versions reject the
+    # rebinding and do not partition bindings, so the distinction does not exist there.
+    if VERSION >= v"1.12"
+        function binding_reader()
+            Core.eval(InvokeLatestWorldTest, :(const REBOUND = 2))
+            return Base.invokelatest(getglobal, InvokeLatestWorldTest, :REBOUND)
+        end
+        @test finish(binding_reader) == 2   # the old world would read `REBOUND == 1`
+    end
+end
+
 @testset "local dispatch cache world-age invalidation" begin
     # Within a single interpretation run, defining a more-specific method must invalidate the
     # local method-table cache so a later call to the same helper dispatches to the new method.


### PR DESCRIPTION
When the recursive interpreter expands `Core.invokelatest`/`Core._call_latest`, it strips the wrapper and interprets the target itself. The world the wrapper implies ("latest") is not an argument, so interpreting the target at the enclosing `frame.world` silently dropped it: a binding, method, or type defined since the frame's world was then invisible.

Added `recurse_expanded_builtin_latest` to handle this correctly. The frame's original world is stashed, and then temporarily set to the latest before executing the call.

`invoke_in_world`/`_call_in_world` need no equivalent change: they are not expanded, so the explicit world argument is passed straight to the genuine builtin and honored end-to-end.