### PR TITLE
Read freshly-included test functions in the latest world

### DIFF
--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -246,6 +246,10 @@ mktemp() do path, io
     close(io)
     breakpoint(path, 3)
     include(path)
+    # `somefunc` is defined by `include` in a world later than this closure's; bind a local in
+    # the latest world so the references below don't read the global at an earlier world (which
+    # warns under Julia 1.12's strict binding semantics).
+    somefunc = Base.invokelatest(getglobal, @__MODULE__, :somefunc)
     frame, bp = @interpret somefunc(2, 3)
     @test bp isa BreakpointRef
     @test whereis(frame) == (path, 3)
@@ -567,6 +571,10 @@ end
         bp_f = breakpoint(path, line_logging)
         flush(io)
         include(path)
+        # `f_check` is defined by `include` in a world later than this closure's; bind a local in
+        # the latest world so the references below don't read the global at an earlier world (which
+        # warns under Julia 1.12's strict binding semantics).
+        f_check = Base.invokelatest(getglobal, @__MODULE__, :f_check)
 
         with_logger(NullLogger()) do
             frame, bp = @interpret f_check(1)


### PR DESCRIPTION
`somefunc` and `f_check` are defined by `include` inside a `mktemp() do ... end` closure and then referenced from that same already-compiled closure. Under Julia 1.12's strict binding world-age semantics this reads the global at a world before its definition, emitting a "binding accessed in a world prior to its definition world" warning (and erroring on future Julia versions). The interpreter is not involved: the `@interpret` macro splices the function value into the caller's code, so the offending read is the test closure's.

Bind a local from the latest world via `invokelatest` right after `include`, so the references below resolve the local rather than re-reading the global.