### PR TITLE
Run interpreted frames in the caller's task world

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -143,11 +143,11 @@ end
 
 get_source(meth::Method) = Base.uncompressed_ast(meth)
 
-function get_source(g::GeneratedFunctionStub, source::Method, env)
+function get_source(g::GeneratedFunctionStub, source::Method, env, world::UInt)
     b = @static if VERSION < v"1.12.0-DEV.1968"   # julia #57230
-        g(Base.get_world_counter(), LineNumberNode(Int(source.line), source.file), env..., g.argnames...)
+        g(world, LineNumberNode(Int(source.line), source.file), env..., g.argnames...)
     else
-        g(Base.get_world_counter(), source, env..., g.argnames...)
+        g(world, source, env..., g.argnames...)
     end
     b isa CodeInfo && return b
     return eval(b)
@@ -211,12 +211,12 @@ function prepare_framecode(method::Method, @nospecialize(argtypes); enter_genera
             # If we're stepping into a staged function, we need to use
             # the specialization, rather than stepping through the
             # unspecialized method.
-            code = get_staged(Core.Compiler.specialize_method(method, argtypes, lenv))
+            code = get_staged(Core.Compiler.specialize_method(method, argtypes, lenv), world)
             code === nothing && return nothing
             generator = false
         else
             if is_generated(method)
-                code = get_source(method.generator, method, lenv)
+                code = get_source(method.generator, method, lenv, world)
                 generator = true
             else
                 code = get_source(method)
@@ -826,15 +826,17 @@ function extract_args(__module__, ex0)
                * "break it down to simpler parts if possible")
 end
 
-function interpret(mod::Module, @nospecialize(ex0); interp=RecursiveInterpreter())
+function interpret(mod::Module, @nospecialize(ex0); interp=RecursiveInterpreter(), world=nothing)
     args = try
         extract_args(mod, ex0)
     catch e
         return :(throw($e))
     end
+    entercall = world === nothing ? :(enter_call_expr(Expr(:call, theargs...))) :
+                                    :(enter_call_expr(Expr(:call, theargs...); world=convert(UInt, $world)))
     quote
         local theargs = $(esc(args))
-        local frame = enter_call_expr(Expr(:call, theargs...))
+        local frame = $entercall
         if frame === nothing
             eval(Expr(:call, map(QuoteNode, theargs)...))
         elseif shouldbreak(frame, 1)
@@ -855,6 +857,8 @@ function interpret(mod::Module, opt, xs...; kwargs...)
         optname isa Symbol || error("Invalid @interpret call: $optname is not a symbol")
         if optname === :interp
             return interpret(mod, xs...; interp=esc(optval), kwargs...)
+        elseif optname === :world
+            return interpret(mod, xs...; world=esc(optval), kwargs...)
         else
             error("Invalid @interpret call: $optname is not a recognized option")
         end
@@ -864,9 +868,14 @@ function interpret(mod::Module, opt, xs...; kwargs...)
 end
 
 """
-    @interpret [interp] f(args; kwargs...)
+    @interpret [interp] [world=w] f(args; kwargs...)
 
 Evaluate `f` on the specified arguments using the interpreter.
+
+The optional `world=w` selects the world age in which the call is resolved and run,
+defaulting to the calling task's current world. Pass `world=Base.get_world_counter()`
+to reach methods defined more recently than the caller's world — for example a method
+just brought in by `include` within the same function.
 
 # Example
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -210,11 +210,22 @@ function pushuniquefiles!(unique_files::Set{Symbol}, lt)
 end
 end
 
-# The default world for entering interpretation is the latest committed world, so that
-# freshly-defined methods and bindings are visible (matching `Base.invokelatest` semantics).
-# A frame captures this once at construction and holds it, giving a consistent world while
-# stepping even if new code is defined mid-session; toplevel frames refresh it per statement.
-default_world() = Base.get_world_counter()
+# The running task's current world age. Unlike `Base.get_world_counter()` (the latest
+# committed world), this is the world the calling code itself executes in, so interpreted
+# method frames see exactly the methods and bindings a compiled call from the same point
+# would see — including raising a world-age error for a method defined too recently.
+@static if isdefined(Base, :tls_world_age)
+    const tls_world_age = Base.tls_world_age
+else
+    tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
+end
+
+# The default world for entering interpretation is the caller's task world, matching the
+# semantics of an ordinary (non-`invokelatest`) call. A frame captures this once at
+# construction and holds it, giving a consistent world while stepping even if new code is
+# defined mid-session; toplevel frames refresh to the latest committed world per statement
+# so that definitions from earlier statements become visible.
+default_world() = tls_world_age()
 
 function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::UInt=default_world(),
                    is_toplevel_surface::Bool=false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -226,7 +226,7 @@ end
 
 is_generated(meth::Method) = isdefined(meth, :generator)
 
-get_staged(mi::MethodInstance) = Core.Compiler.get_staged(mi, Base.get_world_counter())
+get_staged(mi::MethodInstance, world::UInt) = Core.Compiler.get_staged(mi, world)
 
 """
     is_doc_expr(ex)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -246,11 +246,14 @@ mktemp() do path, io
     close(io)
     breakpoint(path, 3)
     include(path)
-    frame, bp = @interpret somefunc(2, 3)
+    # `somefunc` is defined by `include` in a world later than this closure's, so the calls
+    # must be resolved in the latest world to see it (issue #617).
+    w = Base.get_world_counter()
+    frame, bp = @interpret world=w somefunc(2, 3)
     @test bp isa BreakpointRef
     @test whereis(frame) == (path, 3)
     breakpoint(path, 2)
-    frame, bp = @interpret somefunc(2, 3)
+    frame, bp = @interpret world=w somefunc(2, 3)
     @test bp isa BreakpointRef
     @test whereis(frame) == (path, 2)
     remove()
@@ -258,13 +261,13 @@ mktemp() do path, io
     mktempdir(dirname(path)) do tmp
         cd(tmp) do
             breakpoint(joinpath("..", basename(path)), 3)
-            frame, bp = @interpret somefunc(2, 3)
+            frame, bp = @interpret world=w somefunc(2, 3)
             @test bp isa BreakpointRef
             @test whereis(frame) == (path, 3)
             remove()
             breakpoint(joinpath("..", basename(path)), 3)
             cd(homedir()) do
-                frame, bp = @interpret somefunc(2, 3)
+                frame, bp = @interpret world=w somefunc(2, 3)
                 @test bp isa BreakpointRef
                 @test whereis(frame) == (path, 3)
             end
@@ -568,15 +571,18 @@ end
         flush(io)
         include(path)
 
+        # `f_check` is defined by `include` in a world later than this closure's, so the
+        # calls must be resolved in the latest world to see it (issue #617).
+        w = Base.get_world_counter()
         with_logger(NullLogger()) do
-            frame, bp = @interpret f_check(1)
+            frame, bp = @interpret world=w f_check(1)
             file, ln = whereis(frame)
             @test file == path # Should not have stopped in logging.jl at line `line_logging`
             @test ln == line_logging
             remove(bp_f)
-            @test (@interpret f_check(1)) == 1
+            @test (@interpret world=w f_check(1)) == 1
             breakpoint(f_check, line_logging)
-            frame, bp = @interpret f_check(1)
+            frame, bp = @interpret world=w f_check(1)
             file, ln = whereis(frame)
             @test file == path # Should not have stopped in logging.jl at line `line_logging`
             @test ln == line_logging

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1197,6 +1197,8 @@ end
             """))
         w3 = Base.get_world_counter()
         @test !JuliaInterpreter.framecode_valid_world(fcll, w3)
-        @test @interpret(WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 18   # rebuilt wrapper uses the new IR
+        # `IR` was rebound later than this testset's world, so resolve in `w3` to see the new
+        # value; the rebuilt wrapper then bakes in the `sub` IR (issue #617).
+        @test (@interpret world=w3 WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 18
     end
 end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -837,6 +837,9 @@ end
     @test (true === @interpret issue476())
 end
 
+# A method redefined inside the running function is not visible to the function's own
+# fixed world age. Interpretation must use that same task-local world (issue #617), so the
+# interpreted call sees the original `foobar`, exactly as the compiled call does.
 @noinline foobar() = (GC.safepoint(); 42)
 function run_foobar()
     @eval foobar() = "nope"
@@ -844,7 +847,7 @@ function run_foobar()
 end
 @testset "unreachable worlds" begin
     interpret, compiled = run_foobar()
-    @test_broken interpret == compiled == 42
+    @test interpret == compiled == 42
 end
 
 @testset "issue #479" begin


### PR DESCRIPTION
`default_world()` returned the latest committed world (`Base.get_world_counter()`), so every interpreted call behaved like `invokelatest`: methods and bindings newer than the calling code's own world were visible. Compiled code from the same point sees only its fixed task world and raises a world-age error for a method defined too recently; interpretation must match that.

Resolve and run frames in the caller's task world age (`tls_world_age`, defined via a ccall on Julia before 1.12) and thread that world through generated-function expansion. Toplevel/module frames still refresh to the latest world per statement, so earlier definitions remain visible.

`@interpret` gains a `world=w` option for the legitimate case of reaching a method newer than the caller's world — e.g. one just brought in by `include` within the same function; the breakpoint tests that do this now pass `world=Base.get_world_counter()`.

Fixes #617 Closes #731