### PR TITLE
Stop clearing caches on every interpreter entry

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -109,6 +109,7 @@ JuliaInterpreter.compiled_methods
 JuliaInterpreter.compiled_modules
 JuliaInterpreter.interpreted_methods
 JuliaInterpreter.framecode_valid_world
+JuliaInterpreter.clear_caches
 ```
 
 ## Utilities

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -109,6 +109,16 @@ function find_or_create_module(parentmod::Module, ex::Expr)
     return mod, modbody::Expr
 end
 
+"""
+    JuliaInterpreter.clear_caches()
+
+Empty the internal caches of interpreted code: [`framedict`](@ref), [`genframedict`](@ref),
+the pools of reusable `FrameData`/`Frame` objects, and the per-breakpoint instance lists.
+
+This is not called automatically; framecodes are individually invalidated by world age (see
+[`framecode_valid_world`](@ref)) when their cached state goes stale. `clear_caches` is a
+coarse reset useful during debugging and development of JuliaInterpreter itself.
+"""
 function clear_caches()
     empty!(junk_framedata)
     empty!(framedict)
@@ -724,7 +734,6 @@ function enter_call_expr(expr::Expr;
                          enter_generated::Bool=false,
                          world::UInt=default_world(),
                          method_table::Union{Nothing,MethodTable}=nothing)
-    clear_caches()
     r = determine_method_for_expr(expr; enter_generated, world, method_table)
     if r !== nothing && !isa(r[1], Compiled)
         return prepare_frame(Base.front(r)...; world)
@@ -767,7 +776,6 @@ function enter_call(@nospecialize(finfo), @nospecialize(args...);
                     world::UInt=default_world(),
                     method_table::Union{Nothing,MethodTable}=nothing,
                     kwargs...)
-    clear_caches()
     if isa(finfo, Tuple)
         f = finfo[1]
         enter_generated = finfo[2]::Bool

--- a/src/localmethtable.jl
+++ b/src/localmethtable.jl
@@ -19,14 +19,16 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
         local d_methprev
         depth = 1
         while true
-            # Reuse a cached dispatch only if it was resolved in the current world. A world advance
-            # can change which method applies (e.g. a newly defined, more-specific method), so an
-            # entry stamped at an older world must be re-resolved rather than trusted by argument
-            # type alone. Method lookup reports no usable upper world bound for a live match (it
-            # returns `typemax`), so the resolution world itself is the invalidation key.
+            # Reuse a cached dispatch only if it was resolved in the current world and with the same
+            # method table. A world advance can change which method applies (e.g. a newly defined,
+            # more-specific method), so an entry stamped at an older world must be re-resolved rather
+            # than trusted by argument type alone. Method lookup reports no usable upper world bound
+            # for a live match (it returns `typemax`), so the resolution world itself is the
+            # invalidation key. The method table is part of the dispatch context — the same call
+            # resolves differently under an overlay table — so it too must match.
             # Determine whether the argument types match the signature
             sig = d_meth.sig.parameters::SimpleVector
-            if d_meth.world == world && length(sig) == nargs
+            if d_meth.world == world && d_meth.mt === method_table && length(sig) == nargs
                 # If this is generated, match only if `enter_generated` also matches
                 fi = d_meth.frameinstance
                 if fi isa FrameInstance
@@ -86,12 +88,12 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
     # superseded entries; otherwise prepend a new entry, dropping the oldest once the chain
     # exceeds `max_methods`.
     if isassigned(parentframe.methodtables, idx)
-        existing = find_dispatchable(parentframe.methodtables[idx]::DispatchableMethod, argtypes, fi)
+        existing = find_dispatchable(parentframe.methodtables[idx]::DispatchableMethod, argtypes, fi, method_table)
         if existing !== nothing
             existing.frameinstance = fi
             existing.world = world
         else
-            d_meth = DispatchableMethod(parentframe.methodtables[idx]::DispatchableMethod, fi, argtypes, world)
+            d_meth = DispatchableMethod(parentframe.methodtables[idx]::DispatchableMethod, fi, argtypes, world, method_table)
             d_methtmp = d_meth.next::DispatchableMethod
             depth = 2
             while d_methtmp.next !== nothing
@@ -105,7 +107,7 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
             parentframe.methodtables[idx] = d_meth
         end
     else
-        parentframe.methodtables[idx] = DispatchableMethod(nothing, fi, argtypes, world)
+        parentframe.methodtables[idx] = DispatchableMethod(nothing, fi, argtypes, world, method_table)
     end
     if is_compiled
         return Compiled(), nothing
@@ -115,15 +117,17 @@ function get_call_framecode(fargs::Vector{Any}, parentframe::FrameCode, idx::Int
 end
 
 # Return the cached entry that stores the same kind of dispatch as `fi`: the (concrete) signature
-# must be `argtypes` and the entry's generator/body flavor must match, since for a `@generated`
-# method the generator and the specialized body are distinct entries that coexist in the chain
-# (see the `enter_generated` check in the cache-hit loop). Returns `nothing` if there is no such
-# entry. Types are interned, so an identity comparison of signatures suffices and is cheap.
-function find_dispatchable(d::DispatchableMethod, @nospecialize(argtypes), fi::Union{Compiled,FrameInstance})
+# must be `argtypes`, the entry's generator/body flavor must match (since for a `@generated`
+# method the generator and the specialized body are distinct entries that coexist in the chain;
+# see the `enter_generated` check in the cache-hit loop), and the method table must match (an
+# overlay table is a distinct resolution context that coexists in the chain). Returns `nothing`
+# if there is no such entry. Types are interned, so an identity comparison of signatures suffices
+# and is cheap.
+function find_dispatchable(d::DispatchableMethod, @nospecialize(argtypes), fi::Union{Compiled,FrameInstance}, mt::Union{Nothing,MethodTable})
     wants_generator = fi isa FrameInstance && fi.enter_generated
     dd = d
     while true
-        if dd.sig === argtypes
+        if dd.sig === argtypes && dd.mt === mt
             dfi = dd.frameinstance
             (dfi isa FrameInstance && dfi.enter_generated) == wants_generator && return dd
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -104,10 +104,11 @@ mutable struct _DispatchableMethod{FrameCode}
     frameinstance::Union{Compiled,_FrameInstance{FrameCode}} # really a Union{Compiled, FrameInstance} but we have a cyclic dependency
     sig::Type # for speed of matching, this is a *concrete* signature. `sig <: frameinstance.framecode.scope.sig`
     world::UInt # world age in which `frameinstance` was resolved for `sig`; a later world forces re-resolution
+    mt::Union{Nothing,MethodTable} # method table the resolution used; a different table forces re-resolution
     # Without this explicit inner constructor, Julia auto-generates an outer one where
     # `FrameCode` is unbound when next=nothing and frameinstance=Compiled().
-    _DispatchableMethod{FrameCode}(next, frameinstance, sig, world) where {FrameCode} =
-        new{FrameCode}(next, frameinstance, sig, world)
+    _DispatchableMethod{FrameCode}(next, frameinstance, sig, world, mt) where {FrameCode} =
+        new{FrameCode}(next, frameinstance, sig, world, mt)
 end
 
 # 0: none

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -996,6 +996,26 @@ end
     @test JuliaInterpreter.finish_and_return!(fr) isa JuliaInterpreter.BreakpointRef
 end
 
+@testset "clear_caches" begin
+    # `clear_caches` is not called automatically on entry to the interpreter; this test keeps it
+    # exercised so it stays usable for debugging and development.
+    cleared_caches(x) = x + 1
+    @interpret cleared_caches(1)
+    @test haskey(JuliaInterpreter.framedict, only(methods(cleared_caches)))
+
+    bp = @breakpoint cleared_caches(1)
+    @interpret cleared_caches(1)
+    @test !isempty(bp.instances)
+
+    JuliaInterpreter.clear_caches()
+    @test isempty(JuliaInterpreter.framedict)
+    @test isempty(JuliaInterpreter.genframedict)
+    @test isempty(JuliaInterpreter.junk_framedata)
+    @test isempty(JuliaInterpreter.junk_frames)
+    @test isempty(bp.instances)
+    remove(bp)
+end
+
 # CassetteOverlay, issue #552
 using CassetteOverlay
 function cassette_overlay_func()
@@ -1075,6 +1095,10 @@ JuliaInterpreter.method_table(::OverlayInterpreter) = ex_method_table
         @test JuliaInterpreter.finish_and_return!(OverlayInterpreter(), frame) == cos(42.0)
     end
     @test cos(42.0) == @interpret interp=OverlayInterpreter() call_func_overlay(42.0)
+    # The local dispatch cache is keyed by method table: alternating interpreters must each
+    # re-resolve `func_overlay` through their own table rather than reuse the other's cached entry.
+    @test sin(42.0) == @interpret call_func_overlay(42.0)
+    @test cos(42.0) == @interpret interp=OverlayInterpreter() call_func_overlay(42.0)
 end
 
 module DispatchWorldTest
@@ -1122,9 +1146,9 @@ end
 @testset "local dispatch cache world-age invalidation" begin
     # Within a single interpretation run, defining a more-specific method must invalidate the
     # local method-table cache so a later call to the same helper dispatches to the new method.
-    # Across separate `@interpret` calls `clear_caches` masks this; it is only observable when the
-    # world advances mid-run, as in toplevel/module interpretation. The cached `DispatchableMethod`
-    # is stamped with its resolution world, and a higher frame world forces re-resolution.
+    # This is observable when the world advances mid-run, as in toplevel/module interpretation:
+    # the cached `DispatchableMethod` is stamped with its resolution world, and a higher frame
+    # world forces re-resolution.
     stmts = Any[
         :(x = helper()),
         :(inner(::Int) = 2),   # advances the world age with a more-specific method


### PR DESCRIPTION
`enter_call` and `enter_call_expr` no longer call `clear_caches()`; framecodes are individually invalidated by world age, so the blunt per-entry reset is unnecessary. `clear_caches` is retained for debugging and development, now with a docstring and a test that keeps it exercised.

Persisting the caches across `@interpret` calls exposed that the local dispatch cache keyed entries only by signature, generator flavor, and resolution world, not by the method table used to resolve them. A call resolved under the default table could then be reused for an overlay interpreter (and vice versa), dispatching to the wrong method. The cached DispatchableMethod now records its method table and re-resolves when it differs.

Fixes #722

@aviatesk, exactly as you predicted: this surfaced a bug! (Fixed as part of this PR.)