### PR TITLE
Skip `nothing` files when collecting framecode files

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -257,6 +257,9 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
     pushuniquefiles!(unique_files, lt)
     else # VERSION < v"1.12.0-DEV.173"
     for entry in lt
+        # issue #701: macro-generated `LineNumberNode`s (e.g. MacroTools' `@q`/`@qq`) can
+        # carry a `nothing` file, which has no path to match a breakpoint against.
+        entry.file === nothing && continue
         push!(unique_files, entry.file)
     end
     end # @static if

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -775,6 +775,15 @@ frame = JuliaInterpreter.enter_call(f_345)
     @test JuliaInterpreter.getfirstline(frame) isa Integer
 end
 
+@testset "issue #701 LineNumberNode with `nothing` file" begin
+    # Macros such as MacroTools' `@q`/`@qq` can emit `LineNumberNode`s whose file is
+    # `nothing`; building the framecode must not choke when collecting source files.
+    ex = Expr(:function, Expr(:call, :f_nothing_file),
+              Expr(:block, LineNumberNode(0, nothing), :(return 701)))
+    Core.eval(@__MODULE__, ex)
+    @test @interpret(f_nothing_file()) == 701
+end
+
 # issue #285
 using LinearAlgebra, SparseArrays, Random
 @testset "issue 285" begin


### PR DESCRIPTION
Macro-generated `LineNumberNode`s can carry a `nothing` file (e.g. MacroTools' `@q`/`@qq`). Such a node has no path to match a breakpoint against, so skip it instead of pushing `nothing` into the `Set{Symbol}` of source files, which threw a `MethodError`.

Fixes #701