### PR TITLE
Support Julia 1.13 (syntactic ccall, print_stackframe)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,4 +61,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,3 +62,4 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,10 @@ jobs:
           - version: '1' # current stable
             os: ubuntu-latest
             arch: x64
-          - version: '1.10' # lowest version supported
+          - version: 'min' # lowest version supported
+            os: ubuntu-latest
+            arch: x64
+          - version: 'pre' # upcoming release, or duplicate of '1'
             os: ubuntu-latest
             arch: x64
           - version: 'nightly' # dev

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -140,6 +140,9 @@ function resolvefc(frame::Frame, @nospecialize(expr))
     isa(expr, Tuple{String,String}) && return expr
     isa(expr, Tuple{Symbol,String}) && return expr
     isa(expr, Tuple{String,Symbol}) && return expr
+    # Julia 1.13 (`:syntacticccall`) keeps the foreigncall target as a literal `(name, lib)`
+    # tuple expression; the eval'd `:foreigncall` expects that form unchanged.
+    isexpr(expr, :tuple) && return expr
     if isexpr(expr, :call)
         a = (expr::Expr).args[1]
         (isa(a, QuoteNode) && a.value === Core.tuple) || error("unexpected ccall to ", expr)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -267,10 +267,19 @@ function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector
 
     dynamic_ccall = false
     argcfunc = cfunc = stmt.args[1]
+    cfunc_resolved = nothing
     if @isdefined(__has_internal_change) && __has_internal_change(v"1.13.0", :syntacticccall)
         if !isexpr(cfunc, :tuple)
             dynamic_ccall = true
             cfunc = gensym("ptr")
+        else
+            # The `(name, lib)` tuple expression is baked into the compiled wrapper, so the
+            # library binding it references is resolved at framecode-build time: record it.
+            # The wrapper body keeps the symbolic tuple, but its resolved value is folded into
+            # the cache key (below) so that rebinding the library const builds a fresh wrapper
+            # that rebakes the current value rather than reusing the stale one.
+            record_globalref_deps!(world_deps, world, cfunc)
+            cfunc_resolved = try Core.eval(evalmod, cfunc) catch nothing end
         end
     else
         while isa(cfunc, SSAValue)
@@ -300,7 +309,7 @@ function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector
     end
     args = stmt.args[6:end]
     # When the ccall is dynamic we pass the pointer as an argument so can reuse the function
-    cc_key = ((dynamic_ccall ? :ptr : cfunc), RetType, ArgType, evalmod, length(sparams), length(args))  # compiled call key
+    cc_key = ((dynamic_ccall ? :ptr : @something(cfunc_resolved, cfunc)), RetType, ArgType, evalmod, length(sparams), length(args))  # compiled call key
     f = get(compiled_calls, cc_key, nothing)
     if f === nothing
         ArgType = Expr(:tuple, Any[parametric_type_to_expr(t) for t in ArgType::SimpleVector]...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -859,7 +859,11 @@ function Base.show_backtrace(io::IO, frame::Frame)
     for (i, (last_frame, n)) in enumerate(stackframes)
         frame_counter += 1
         println(io)
-        Base.print_stackframe(io, i, last_frame, n, nd, Base.info_color())
+        @static if VERSION >= v"1.13.0-DEV.927"
+            Base.print_stackframe(io, i, last_frame, nd, 0, 0, 0, Base.info_color())
+        else
+            Base.print_stackframe(io, i, last_frame, n, nd, Base.info_color())
+        end
     end
 end
 

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -1,4 +1,4 @@
-using CodeTracking, JuliaInterpreter, Test
+using CodeTracking, JuliaInterpreter, Test, InteractiveUtils
 using JuliaInterpreter: enter_call, enter_call_expr, get_return
 using Base.Meta: isexpr
 include("utils.jl")
@@ -410,14 +410,31 @@ end
 
     @testset "Issue #178" begin
         remove()
+        # A breakpoint inside a callee, resumed with `:c`, must restore the caller's
+        # slots. The breakpoint target is called exactly once so that `:c` runs to
+        # completion. Local functions are used rather than `length`/`sum`: Base's
+        # reductions route through `length(::AbstractArray)` on some versions, which
+        # would hit a `length` breakpoint more than once and leave one set for later
+        # tests.
+        inner178(v) = length(v)
+        function outer178(v)
+            n = inner178(v)
+            s = 0
+            for x in v
+                s += x
+            end
+            return s + n
+        end
         a = [1, 2, 3, 4]
-        @breakpoint length(LinearIndices(a))
-        frame, bp = @interpret sum(a)
+        @breakpoint inner178(a)
+        frame, bp = @interpret outer178(a)
         @test debug_command(frame, :c) === nothing
-        @test get_return(frame) == sum(a)
+        @test get_return(frame) == outer178(a)
+        remove()
     end
 
     @testset "Stepping over kwfunc preparation" begin
+        remove()
         stepkw! = JuliaInterpreter.maybe_step_through_kwprep! # for brevity
         a = [4, 1, 3, 2]
         reversesort(x) = sort(x; rev=true)

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -628,12 +628,12 @@ qcopy = @interpret deepcopy(q)
 f217() = <:(Float64, Float32, Float16)
 @test_throws ArgumentError @interpret(f217())
 
-# issue #220
-function hash220(x::Tuple{Ptr{UInt8},Int}, h::UInt)
-    h += Base.memhash_seed
-    ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), x[1], x[2], h % UInt32) + h
-end
-@test @interpret(hash220((Ptr{UInt8}(0),0), UInt(1))) == hash220((Ptr{UInt8}(0),0), UInt(1))
+# issue #220: a `ccall` whose target is a runtime function-pointer value reached through a
+# binding (the original report used `Base.memhash`, removed in 1.13; see issue #696).
+add_one_220(x::Cint)::Cint = x + Cint(1)
+const PTR_220 = @cfunction(add_one_220, Cint, (Cint,))
+call220(x) = ccall(PTR_220, Cint, (Cint,), x)
+@test @interpret(call220(Cint(41))) == call220(Cint(41)) == Cint(42)
 
 # ccall with type parameters
 @static if VERSION < v"1.11-"

--- a/test/limits.jl
+++ b/test/limits.jl
@@ -87,7 +87,9 @@ module EvalLimited end
     modexs = collect(ExprSplitter(EvalLimited, ex))
     # See "uncomment the following..." in test/utils.jl for how to calibrate `nstmts` below
     # Adjust α so that the recursive mode ends up back in "fake.jl"
-    @static if VERSION >= v"1.12-"
+    @static if VERSION >= v"1.13-"
+        nstmts = 10*27 + 6 # 10 * 27 statements per iteration + α in compiled mode
+    elseif VERSION >= v"1.12-"
         nstmts = 10*24 + 50 # 10 * 24 statements per iteration + α in compiled mode
     elseif VERSION >= v"1.11-"
         nstmts = 10*17 + 20 # 10 * 17 statements per iteration + α


### PR DESCRIPTION
Adapt to Base changes in Julia 1.13:

- `show_backtrace`: Base's `print_stackframe` gained cycle-tracking arguments (Julia #55841); call the new 8-argument form on 1.13+.
- `resolvefc`: under the 1.13 `:syntacticccall` lowering a foreigncall target is a literal `(name, lib)` tuple expression; pass it through unchanged so the eval'd `:foreigncall` receives the expected form.
- `build_compiled_foreigncall!`: the `:syntacticccall` branch keeps the target tuple symbolic, so record the library binding it resolves in `world_deps` and fold the resolved tuple value into the compiled-call cache key. Otherwise rebinding the library const reused a wrapper that baked the old library.

Tests:

- limits.jl: recalibrate `nstmts` for 1.13's per-iteration statement count.
- debug.jl (#178): the breakpoint target is now reached via local helpers called once, rather than `length`/`sum`; Base routes reductions through `length(::AbstractArray)` on 1.13, which hit a stale `length` breakpoint more than once and leaked it into later tests. Clear breakpoints in the #178 and kwprep testsets, and import InteractiveUtils directly.
- interpret.jl (#220): exercise the ccall-through-binding path with a `@cfunction` pointer instead of `Base.memhash`, removed in 1.13 (#696).

Fixes #696.

This gets tests passing on julia 1.13.0-rc1. There are a number of new binding-access warnings, but these are left for a future PR.