### PR TITLE
Fix stale-world binding-access warnings

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -37,7 +37,12 @@ const RECENTLY_REMOVED = GlobalRef.(Ref(Core), [
     :_apply_pure, :_call_in_world, :_call_latest,
 ])
 const kwinvoke = Core.kwfunc(Core.invoke)
+# Builtins whose result depends on the world age (binding resolution): they must run in
+# `frame.world` rather than the interpreter's ambient world. Every entry here takes a `Module`
+# as its first argument, so the dependence is unconditional.
 const REQUIRES_WORLD = Core.Builtin[
+    getglobal,
+    isdefinedglobal,
     setglobal!,
     Core.get_binding_type,
     swapglobal!,

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -282,11 +282,11 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
         end
     elseif f === getglobal
         if nargs == 2
-            return Some{Any}(getglobal(lookup(interp, frame, args[2]), lookup(interp, frame, args[3])))
+            return Some{Any}(Base.invoke_in_world(frame.world, getglobal, lookup(interp, frame, args[2]), lookup(interp, frame, args[3])))
         elseif nargs == 3
-            return Some{Any}(getglobal(lookup(interp, frame, args[2]), lookup(interp, frame, args[3]), lookup(interp, frame, args[4])))
+            return Some{Any}(Base.invoke_in_world(frame.world, getglobal, lookup(interp, frame, args[2]), lookup(interp, frame, args[3]), lookup(interp, frame, args[4])))
         else
-            return Some{Any}(getglobal(getargs(interp, args, frame)...))
+            return Some{Any}(Base.invoke_in_world(frame.world, getglobal, getargs(interp, args, frame)...))
         end
     elseif f === invoke
         if !expand
@@ -323,7 +323,7 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
             return Some{Any}(isdefined(getargs(interp, args, frame)...))
         end
     elseif @static isdefinedglobal(Core, :isdefinedglobal) && f === isdefinedglobal
-        return Some{Any}(isdefinedglobal(getargs(interp, args, frame)...))
+        return Some{Any}(Base.invoke_in_world(frame.world, isdefinedglobal, getargs(interp, args, frame)...))
     elseif f === modifyfield!
         if nargs == 4
             return Some{Any}(modifyfield!(lookup(interp, frame, args[2]), lookup(interp, frame, args[3]), lookup(interp, frame, args[4]), lookup(interp, frame, args[5])))

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -844,10 +844,27 @@ function interpret(mod::Module, @nospecialize(ex0); interp=RecursiveInterpreter(
     catch e
         return :(throw($e))
     end
-    entercall = world === nothing ? :(enter_call_expr(Expr(:call, theargs...))) :
-                                    :(enter_call_expr(Expr(:call, theargs...); world=convert(UInt, $world)))
+    if world === nothing
+        wexpr = :nothing
+        theargs = :($(esc(args)))
+        entercall = :(enter_call_expr(Expr(:call, theargs...)))
+    else
+        if world === :latest
+            # Resolve the function and arguments in the latest committed world captured here at call time
+            wexpr = :(Base.get_world_counter())
+            theargs = :(Base.invoke_in_world(w, () -> $(esc(args))))
+        else
+            # Numeric world: the interpreted call runs in `world`, but the function and arguments are
+            # resolved in the caller's current world.
+            wexpr = :(convert(UInt, $world))
+            theargs = :($(esc(args)))
+        end
+        # The call itself always runs in the world that will be resolved from evaluating `wexpr`
+        entercall = :(enter_call_expr(Expr(:call, theargs...); world=w))
+    end
     quote
-        local theargs = $(esc(args))
+        local w = $wexpr
+        local theargs = $theargs
         local frame = $entercall
         if frame === nothing
             eval(Expr(:call, map(QuoteNode, theargs)...))
@@ -870,7 +887,10 @@ function interpret(mod::Module, opt, xs...; kwargs...)
         if optname === :interp
             return interpret(mod, xs...; interp=esc(optval), kwargs...)
         elseif optname === :world
-            return interpret(mod, xs...; world=esc(optval), kwargs...)
+            # `world=:latest` is a literal flag handled specially; any other value is an escaped
+            # expression evaluating to a `UInt` world age.
+            islatest = isa(optval, QuoteNode) && optval.value === :latest
+            return interpret(mod, xs...; world=(islatest ? :latest : esc(optval)), kwargs...)
         else
             error("Invalid @interpret call: $optname is not a recognized option")
         end
@@ -880,14 +900,22 @@ function interpret(mod::Module, opt, xs...; kwargs...)
 end
 
 """
-    @interpret [interp] [world=w] f(args; kwargs...)
+    @interpret [interp] [world=w | world=:latest] f(args; kwargs...)
 
 Evaluate `f` on the specified arguments using the interpreter.
 
-The optional `world=w` selects the world age in which the call is resolved and run,
-defaulting to the calling task's current world. Pass `world=Base.get_world_counter()`
-to reach methods defined more recently than the caller's world — for example a method
-just brought in by `include` within the same function.
+The optional `world` argument selects the world age for the call:
+
+- omitted (default): `f` and the arguments are resolved, and the call is run, in the calling
+  task's current world.
+- `world=:latest`: resolve `f`/arguments and run the call in the latest committed world,
+  sampled when the call is made. Use this to reach methods or bindings defined more recently
+  than the calling task's (possibly frozen) world — for example a method just brought in by
+  `include` within the same function (issue #617).
+- `world=w`, where `w` is a `UInt` world age: run the interpreted call in world `w`. The
+  function and arguments are still resolved in the caller's current world, so `w` controls only
+  the methods visible *during* interpretation. The caller is responsible for choosing a usable
+  `w`; to also resolve recently-defined functions, use `world=:latest`.
 
 # Example
 

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -248,12 +248,11 @@ mktemp() do path, io
     include(path)
     # `somefunc` is defined by `include` in a world later than this closure's, so the calls
     # must be resolved in the latest world to see it (issue #617).
-    w = Base.get_world_counter()
-    frame, bp = @interpret world=w somefunc(2, 3)
+    frame, bp = @interpret world=:latest somefunc(2, 3)
     @test bp isa BreakpointRef
     @test whereis(frame) == (path, 3)
     breakpoint(path, 2)
-    frame, bp = @interpret world=w somefunc(2, 3)
+    frame, bp = @interpret world=:latest somefunc(2, 3)
     @test bp isa BreakpointRef
     @test whereis(frame) == (path, 2)
     remove()
@@ -261,13 +260,13 @@ mktemp() do path, io
     mktempdir(dirname(path)) do tmp
         cd(tmp) do
             breakpoint(joinpath("..", basename(path)), 3)
-            frame, bp = @interpret world=w somefunc(2, 3)
+            frame, bp = @interpret world=:latest somefunc(2, 3)
             @test bp isa BreakpointRef
             @test whereis(frame) == (path, 3)
             remove()
             breakpoint(joinpath("..", basename(path)), 3)
             cd(homedir()) do
-                frame, bp = @interpret world=w somefunc(2, 3)
+                frame, bp = @interpret world=:latest somefunc(2, 3)
                 @test bp isa BreakpointRef
                 @test whereis(frame) == (path, 3)
             end
@@ -573,16 +572,15 @@ end
 
         # `f_check` is defined by `include` in a world later than this closure's, so the
         # calls must be resolved in the latest world to see it (issue #617).
-        w = Base.get_world_counter()
         with_logger(NullLogger()) do
-            frame, bp = @interpret world=w f_check(1)
+            frame, bp = @interpret world=:latest f_check(1)
             file, ln = whereis(frame)
             @test file == path # Should not have stopped in logging.jl at line `line_logging`
             @test ln == line_logging
             remove(bp_f)
-            @test (@interpret world=w f_check(1)) == 1
-            breakpoint(f_check, line_logging)
-            frame, bp = @interpret world=w f_check(1)
+            @test (@interpret world=:latest f_check(1)) == 1
+            breakpoint(invokelatest(() -> f_check), line_logging)
+            frame, bp = @interpret world=:latest f_check(1)
             file, ln = whereis(frame)
             @test file == path # Should not have stopped in logging.jl at line `line_logging`
             @test ln == line_logging

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1267,8 +1267,8 @@ end
             """))
         w3 = Base.get_world_counter()
         @test !JuliaInterpreter.framecode_valid_world(fcll, w3)
-        # `IR` was rebound later than this testset's world, so resolve in `w3` to see the new
-        # value; the rebuilt wrapper then bakes in the `sub` IR (issue #617).
+        # `IR` was rebound later than this testset's world; interpreting in `w3` rebuilds the
+        # framecode there, so the compiled wrapper bakes in the new `sub` IR (issue #617).
         @test (@interpret world=w3 WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 18
     end
 end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -119,7 +119,10 @@ module Toplevel end
 @testset "toplevel" begin
     modexs = ExprSplitter(Toplevel, read_and_parse(joinpath(@__DIR__, "toplevel_script.jl")))
     for (mod, ex) in modexs
-        frame = Frame(mod, ex)
+        # Build each frame in the latest world so framecode construction (e.g. resolving a
+        # `struct`'s supertype) sees the modules/types defined by earlier statements; `Frame`
+        # otherwise captures the caller's task world, which is frozen across this loop.
+        frame = Frame(mod, ex; world=Base.get_world_counter())
         while true
             invokelatest(JuliaInterpreter.through_methoddef_or_done!, frame) === nothing && break
         end
@@ -168,7 +171,9 @@ module Toplevel end
     @test Toplevel.ftrue(1) == 3
     @test Toplevel.fctrue(0) == 1
     @test_throws UndefVarError Toplevel.fcfalse(0)
-    @test !Toplevel.Consts.b2
+    # `Consts` was defined by the interpreter above, in a world later than this testset's,
+    # so its binding must be resolved in the latest world to be seen (issue #617).
+    @test !invokelatest(() -> Toplevel.Consts.b2)
     @test Toplevel.fb1true(0) == 1
     @test_throws UndefVarError Toplevel.fb1false(0)
     @test Toplevel.fb2false(0) == 1
@@ -191,7 +196,7 @@ module Toplevel end
     @test Toplevel.Inner.g() == 5
     @test Toplevel.Inner.InnerInner.g() == 6
     @test isdefinedglobal(Toplevel, :Beat)
-    @test Toplevel.Beat <: Toplevel.DatesMod.Period
+    @test invokelatest(() -> Toplevel.Beat <: Toplevel.DatesMod.Period)
 
     @test @interpret(Toplevel.f1(0)) == 1
     @test @interpret(Toplevel.f1(0.0)) == 2


### PR DESCRIPTION
Julia 1.12+ warns when a global binding is accessed in a world prior to its definition world. Several such accesses surfaced while running the test suite; eliminate them at their sources:

- The `getglobal` and `isdefinedglobal` builtins resolved bindings in the interpreter's ambient world rather than `frame.world`. Add them to `REQUIRES_WORLD` in the builtins generator (and regenerate) so they run in `frame.world`, matching the existing write-side builtins. On 1.13 `using .X` lowers to a `getglobal` call, which is the path that warned.

- `@interpret` gains a `world=:latest` flag that resolves the function and arguments *and* runs the call in the latest committed world, sampled at call time. This reaches definitions newer than the caller's (possibly frozen) task world without resolving them in a stale world (issue #617). Numeric `world=w` is unchanged: `w` governs only the interpretation and the caller owns it. The breakpoint tests move to `world=:latest`.

- The toplevel-evaluation test loop builds each `Frame` in the latest world, so framecode construction (e.g. resolving a `struct`'s supertype) sees the modules and types defined by earlier statements.

- Test accesses to interpreter-defined modules from a frozen testset world are wrapped in `invokelatest`.