### PR TITLE
Test toplevel on both interpretation paths

### DIFF
--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -115,164 +115,182 @@ end
 end
 
 module Toplevel end
+module ToplevelDirect end
 
-@testset "toplevel" begin
-    modexs = ExprSplitter(Toplevel, read_and_parse(joinpath(@__DIR__, "toplevel_script.jl")))
-    for (mod, ex) in modexs
+# Drive a whole `:toplevel` expression two ways: the historical `ExprSplitter` trampoline
+# (still used by Revise to chunk source into top-level expressions) and direct surface
+# interpretation as a single `Frame` (the default for `Frame(mod, ::Expr)`). Evaluating the
+# same source through both paths into independent modules checks that the direct path
+# reproduces the observable results of the established path.
+function eval_via_exprsplitter!(mod::Module, ex)
+    for (m, e) in ExprSplitter(mod, ex)
         # Build each frame in the latest world so framecode construction (e.g. resolving a
         # `struct`'s supertype) sees the modules/types defined by earlier statements; `Frame`
         # otherwise captures the caller's task world, which is frozen across this loop.
-        frame = Frame(mod, ex; world=Base.get_world_counter())
+        frame = Frame(m, e; world=Base.get_world_counter())
         while true
             invokelatest(JuliaInterpreter.through_methoddef_or_done!, frame) === nothing && break
         end
     end
+    return nothing
+end
 
-    @test isconst(Toplevel, :StructParent)
-    @test isconst(Toplevel, :Struct)
-    @test isconst(Toplevel, :MyInt8)
+eval_via_direct_frame!(mod::Module, ex) =
+    invokelatest(JuliaInterpreter.finish_and_return!, Frame(mod, ex), true)
 
-    s = Toplevel.Struct([2.0])
+# Pair each evaluator with the module it should populate, for parametrized dual-path testsets.
+toplevel_eval_pairs(m_split::Module, m_direct::Module) =
+    ((m_split, eval_via_exprsplitter!), (m_direct, eval_via_direct_frame!))
 
-    @test Toplevel.f1(0) == 1
-    @test Toplevel.f1(0.0) == 2
-    @test Toplevel.f1(0.0f0) == 3
-    @test Toplevel.f2("hi") == -1
-    @test Toplevel.f2(UInt16(1)) == UInt16
-    @test Toplevel.f2(3.2) == 0
-    @test Toplevel.f2(view([1,2], 1:1)) == 2
-    @test Toplevel.f2([1,2]) == 3
-    @test Toplevel.f2(reshape(view([1,2], 1:2), 2, 1)) == 4
-    @test Toplevel.f3(1, 1) == 1
-    @test Toplevel.f3(1, :hi) == 2
-    @test Toplevel.f3(UInt16(1), :hi) == Symbol
-    @test Toplevel.f3(rand(2, 2), :hi, :there) == 2
-    @test_throws MethodError Toplevel.f3([1.0], :hi, :there)
-    @test Toplevel.f4(1, 1.0) == 1
-    @test Toplevel.f4(1, 1) == Toplevel.f4(1) == 2
-    @test Toplevel.f4(UInt(1), "hey", 2) == 3
-    @test Toplevel.f4(rand(2,2)) == 2
-    @test Toplevel.f5(Int8(1); y=22) == 22
-    @test Toplevel.f5(Int16(1)) == 2
-    @test Toplevel.f5(Int32(1)) == 3
-    @test Toplevel.f5(Int64(1)) == 4
-    @test Toplevel.f5(rand(2,2); y=7) == 2
-    @test Toplevel.f6(1, "hi"; z=8) == 1
-    @test Toplevel.f7(1, (1, :hi)) == 1
-    @test Toplevel.f8(0) == 1
-    @test Toplevel.f9(3) == 9
-    @test Toplevel.f9(3.0) == 3.0
+# Assertions on the bindings and methods defined by `toplevel_script.jl`, parametrized on the
+# module the script was evaluated into so the same checks apply to both evaluation paths.
+function check_toplevel_script(M::Module)
+    @test isconst(M, :StructParent)
+    @test isconst(M, :Struct)
+    @test isconst(M, :MyInt8)
+
+    s = M.Struct([2.0])
+
+    @test M.f1(0) == 1
+    @test M.f1(0.0) == 2
+    @test M.f1(0.0f0) == 3
+    @test M.f2("hi") == -1
+    @test M.f2(UInt16(1)) == UInt16
+    @test M.f2(3.2) == 0
+    @test M.f2(view([1,2], 1:1)) == 2
+    @test M.f2([1,2]) == 3
+    @test M.f2(reshape(view([1,2], 1:2), 2, 1)) == 4
+    @test M.f3(1, 1) == 1
+    @test M.f3(1, :hi) == 2
+    @test M.f3(UInt16(1), :hi) == Symbol
+    @test M.f3(rand(2, 2), :hi, :there) == 2
+    @test_throws MethodError M.f3([1.0], :hi, :there)
+    @test M.f4(1, 1.0) == 1
+    @test M.f4(1, 1) == M.f4(1) == 2
+    @test M.f4(UInt(1), "hey", 2) == 3
+    @test M.f4(rand(2,2)) == 2
+    @test M.f5(Int8(1); y=22) == 22
+    @test M.f5(Int16(1)) == 2
+    @test M.f5(Int32(1)) == 3
+    @test M.f5(Int64(1)) == 4
+    @test M.f5(rand(2,2); y=7) == 2
+    @test M.f6(1, "hi"; z=8) == 1
+    @test M.f7(1, (1, :hi)) == 1
+    @test M.f8(0) == 1
+    @test M.f9(3) == 9
+    @test M.f9(3.0) == 3.0
     @test s("hello") == [2.0]
-    @test Toplevel.Struct{Float32}(Dict(1=>"two")) == 4
-    @test Toplevel.first_two_funcs == (Toplevel.f1, Toplevel.f2)
-    @test isconst(Toplevel, :first_two_funcs)
-    @test Toplevel.myint isa Toplevel.MyInt8
-    @test_throws UndefVarError Toplevel.ffalse(1)
-    @test Toplevel.ftrue(1) == 3
-    @test Toplevel.fctrue(0) == 1
-    @test_throws UndefVarError Toplevel.fcfalse(0)
+    @test M.Struct{Float32}(Dict(1=>"two")) == 4
+    @test M.first_two_funcs == (M.f1, M.f2)
+    @test isconst(M, :first_two_funcs)
+    @test M.myint isa M.MyInt8
+    @test_throws UndefVarError M.ffalse(1)
+    @test M.ftrue(1) == 3
+    @test M.fctrue(0) == 1
+    @test_throws UndefVarError M.fcfalse(0)
     # `Consts` was defined by the interpreter above, in a world later than this testset's,
     # so its binding must be resolved in the latest world to be seen (issue #617).
-    @test !invokelatest(() -> Toplevel.Consts.b2)
-    @test Toplevel.fb1true(0) == 1
-    @test_throws UndefVarError Toplevel.fb1false(0)
-    @test Toplevel.fb2false(0) == 1
-    @test_throws UndefVarError Toplevel.fb2true(0)
-    @test Toplevel.fstrue(0) == 1
-    @test Toplevel.fouter(1) === 2
-    @test Toplevel.feval1(1.0) === 1
-    @test Toplevel.feval1(1.0f0) === 1
-    @test_throws MethodError Toplevel.feval1(1)
-    @test Toplevel.feval2(1.0, Int8(1)) == 2
+    @test !invokelatest(() -> M.Consts.b2)
+    @test M.fb1true(0) == 1
+    @test_throws UndefVarError M.fb1false(0)
+    @test M.fb2false(0) == 1
+    @test_throws UndefVarError M.fb2true(0)
+    @test M.fstrue(0) == 1
+    @test M.fouter(1) === 2
+    @test M.feval1(1.0) === 1
+    @test M.feval1(1.0f0) === 1
+    @test_throws MethodError M.feval1(1)
+    @test M.feval2(1.0, Int8(1)) == 2
     @test length(s) === nothing
     @test size(s) === nothing
-    @test Toplevel.nbytes(Float32) == 4
-    @test Toplevel.typestring(1.0) == "Float64"
-    @test Toplevel._feval3(0) == 3
-    @test Toplevel.feval_add!(0) == 1
-    @test Toplevel.feval_min!(0) == 1
-    @test Toplevel.paramtype(Vector{Int8}) == Int8
-    @test Toplevel.paramtype(Vector) == Toplevel.NoParam
-    @test Toplevel.Inner.g() == 5
-    @test Toplevel.Inner.InnerInner.g() == 6
-    @test isdefinedglobal(Toplevel, :Beat)
-    @test invokelatest(() -> Toplevel.Beat <: Toplevel.DatesMod.Period)
+    @test M.nbytes(Float32) == 4
+    @test M.typestring(1.0) == "Float64"
+    @test M._feval3(0) == 3
+    @test M.feval_add!(0) == 1
+    @test M.feval_min!(0) == 1
+    @test M.paramtype(Vector{Int8}) == Int8
+    @test M.paramtype(Vector) == M.NoParam
+    @test M.Inner.g() == 5
+    @test M.Inner.InnerInner.g() == 6
+    @test isdefinedglobal(M, :Beat)
+    @test invokelatest(() -> M.Beat <: M.DatesMod.Period)
 
-    @test @interpret(Toplevel.f1(0)) == 1
-    @test @interpret(Toplevel.f1(0.0)) == 2
-    @test @interpret(Toplevel.f1(0.0f0)) == 3
-    @test @interpret(Toplevel.f2("hi")) == -1
-    @test @interpret(Toplevel.f2(UInt16(1))) == UInt16
-    @test @interpret(Toplevel.f2(3.2)) == 0
-    @test @interpret(Toplevel.f2(view([1,2], 1:1))) == 2
-    @test @interpret(Toplevel.f2([1,2])) == 3
-    @test @interpret(Toplevel.f2(reshape(view([1,2], 1:2), 2, 1))) == 4
-    @test @interpret(Toplevel.f3(1, 1)) == 1
-    @test @interpret(Toplevel.f3(1, :hi)) == 2
-    @test @interpret(Toplevel.f3(UInt16(1), :hi)) == Symbol
-    @test @interpret(Toplevel.f3(rand(2, 2), :hi, :there)) == 2
-    @test_throws MethodError @interpret(Toplevel.f3([1.0], :hi, :there))
-    @test @interpret(Toplevel.f4(1, 1.0)) == 1
-    @test @interpret(Toplevel.f4(1, 1)) == @interpret(Toplevel.f4(1)) == 2
-    @test @interpret(Toplevel.f4(UInt(1), "hey", 2)) == 3
-    @test @interpret(Toplevel.f4(rand(2,2))) == 2
-    @test @interpret(Toplevel.f5(Int8(1); y=22)) == 22
-    @test @interpret(Toplevel.f5(Int16(1))) == 2
-    @test @interpret(Toplevel.f5(Int32(1))) == 3
-    @test @interpret(Toplevel.f5(Int64(1))) == 4
-    @test @interpret(Toplevel.f5(rand(2,2); y=7)) == 2
-    @test @interpret(Toplevel.f6(1, "hi"; z=8)) == 1
-    @test @interpret(Toplevel.f7(1, (1, :hi))) == 1
-    @test @interpret(Toplevel.f8(0)) == 1
-    @test @interpret(Toplevel.f9(3)) == 9
-    @test @interpret(Toplevel.f9(3.0)) == 3.0
+    @test @interpret(M.f1(0)) == 1
+    @test @interpret(M.f1(0.0)) == 2
+    @test @interpret(M.f1(0.0f0)) == 3
+    @test @interpret(M.f2("hi")) == -1
+    @test @interpret(M.f2(UInt16(1))) == UInt16
+    @test @interpret(M.f2(3.2)) == 0
+    @test @interpret(M.f2(view([1,2], 1:1))) == 2
+    @test @interpret(M.f2([1,2])) == 3
+    @test @interpret(M.f2(reshape(view([1,2], 1:2), 2, 1))) == 4
+    @test @interpret(M.f3(1, 1)) == 1
+    @test @interpret(M.f3(1, :hi)) == 2
+    @test @interpret(M.f3(UInt16(1), :hi)) == Symbol
+    @test @interpret(M.f3(rand(2, 2), :hi, :there)) == 2
+    @test_throws MethodError @interpret(M.f3([1.0], :hi, :there))
+    @test @interpret(M.f4(1, 1.0)) == 1
+    @test @interpret(M.f4(1, 1)) == @interpret(M.f4(1)) == 2
+    @test @interpret(M.f4(UInt(1), "hey", 2)) == 3
+    @test @interpret(M.f4(rand(2,2))) == 2
+    @test @interpret(M.f5(Int8(1); y=22)) == 22
+    @test @interpret(M.f5(Int16(1))) == 2
+    @test @interpret(M.f5(Int32(1))) == 3
+    @test @interpret(M.f5(Int64(1))) == 4
+    @test @interpret(M.f5(rand(2,2); y=7)) == 2
+    @test @interpret(M.f6(1, "hi"; z=8)) == 1
+    @test @interpret(M.f7(1, (1, :hi))) == 1
+    @test @interpret(M.f8(0)) == 1
+    @test @interpret(M.f9(3)) == 9
+    @test @interpret(M.f9(3.0)) == 3.0
     @test @interpret(s("hello")) == [2.0]
-    @test @interpret(Toplevel.Struct{Float32}(Dict(1=>"two"))) == 4
-    @test_throws UndefVarError @interpret(Toplevel.ffalse(1))
-    @test @interpret(Toplevel.ftrue(1)) == 3
-    @test @interpret(Toplevel.fctrue(0)) == 1
-    @test_throws UndefVarError @interpret(Toplevel.fcfalse(0))
-    @test @interpret(Toplevel.fb1true(0)) == 1
-    @test_throws UndefVarError @interpret(Toplevel.fb1false(0))
-    @test @interpret(Toplevel.fb2false(0)) == 1
-    @test_throws UndefVarError @interpret(Toplevel.fb2true(0))
-    @test @interpret(Toplevel.fstrue(0)) == 1
-    @test @interpret(Toplevel.fouter(1)) === 2
-    @test @interpret(Toplevel.feval1(1.0)) === 1
-    @test @interpret(Toplevel.feval1(1.0f0)) === 1
-    @test_throws MethodError @interpret(Toplevel.feval1(1))
-    @test @interpret(Toplevel.feval2(1.0, Int8(1))) == 2
+    @test @interpret(M.Struct{Float32}(Dict(1=>"two"))) == 4
+    @test_throws UndefVarError @interpret(M.ffalse(1))
+    @test @interpret(M.ftrue(1)) == 3
+    @test @interpret(M.fctrue(0)) == 1
+    @test_throws UndefVarError @interpret(M.fcfalse(0))
+    @test @interpret(M.fb1true(0)) == 1
+    @test_throws UndefVarError @interpret(M.fb1false(0))
+    @test @interpret(M.fb2false(0)) == 1
+    @test_throws UndefVarError @interpret(M.fb2true(0))
+    @test @interpret(M.fstrue(0)) == 1
+    @test @interpret(M.fouter(1)) === 2
+    @test @interpret(M.feval1(1.0)) === 1
+    @test @interpret(M.feval1(1.0f0)) === 1
+    @test_throws MethodError @interpret(M.feval1(1))
+    @test @interpret(M.feval2(1.0, Int8(1))) == 2
     @test @interpret(length(s)) === nothing
     @test @interpret(size(s)) === nothing
-    @test @interpret(Toplevel.nbytes(Float32)) == 4
-    @test @interpret(Toplevel.typestring(1.0)) == "Float64"
-    @test @interpret(Toplevel._feval3(0)) == 3
-    @test @interpret(Toplevel.feval_add!(0)) == 1
-    @test @interpret(Toplevel.feval_min!(0)) == 1
-    @test @interpret(Toplevel.paramtype(Vector{Int8})) == Int8
-    @test @interpret(Toplevel.paramtype(Vector)) == Toplevel.NoParam
-    @test @interpret(Toplevel.Inner.g()) == 5
-    @test @interpret(Toplevel.Inner.InnerInner.g()) == 6
+    @test @interpret(M.nbytes(Float32)) == 4
+    @test @interpret(M.typestring(1.0)) == "Float64"
+    @test @interpret(M._feval3(0)) == 3
+    @test @interpret(M.feval_add!(0)) == 1
+    @test @interpret(M.feval_min!(0)) == 1
+    @test @interpret(M.paramtype(Vector{Int8})) == Int8
+    @test @interpret(M.paramtype(Vector)) == M.NoParam
+    @test @interpret(M.Inner.g()) == 5
+    @test @interpret(M.Inner.InnerInner.g()) == 6
     # FIXME: even though they pass, these tests break Test!
-    # @test @interpret(isdefinedglobal(Toplevel, :Beat))
-    # @test @interpret(Toplevel.Beat <: Toplevel.DatesMod.Period)
+    # @test @interpret(isdefinedglobal(M, :Beat))
+    # @test @interpret(M.Beat <: M.DatesMod.Period)
+    return nothing
+end
 
-    # Check that nested expressions are handled appropriately (module-in-block, internal `using`)
-    ex = quote
-       module Testing
-       if true
-           using JuliaInterpreter
-       end
-       end
-   end
-   modexs = ExprSplitter(Toplevel, ex)
-   for (mod, ex) in modexs
-       frame = Frame(mod, ex)
-       while true
-           JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-       end
-   end
-   @test Toplevel.Testing.Frame === Frame
+@testset "toplevel ($(nameof(M)))" for (M, eval!) in toplevel_eval_pairs(Toplevel, ToplevelDirect)
+    eval!(M, read_and_parse(joinpath(@__DIR__, "toplevel_script.jl")))
+    # The script's methods/bindings are defined in a world later than this testset's frozen
+    # one, so run the checks in the latest world (sampled now) to see them (issue #617).
+    invokelatest(check_toplevel_script, M)
+
+    # Check that nested expressions are handled appropriately (a `using` guarded by an `if`
+    # inside a module body).
+    ex = Expr(:toplevel, :(module Testing
+        if true
+            using JuliaInterpreter
+        end
+    end))
+    eval!(M, ex)
+    @test invokelatest(() -> M.Testing.Frame) === Frame
 end
 
 # Proper handling of namespaces
@@ -351,78 +369,45 @@ for (i, (mod, ex)) in enumerate(modexs)
     end
 end
 
-@testset "Enum" begin
-    ex = Expr(:toplevel,
+module EnumSplit end
+module EnumDirect end
+@testset "Enum ($(nameof(M)))" for (M, eval!) in toplevel_eval_pairs(EnumSplit, EnumDirect)
+    eval!(M, Expr(:toplevel,
         :(@enum EnumParent begin
               EnumChild0
               EnumChild1
-          end))
-    modexs = ExprSplitter(Toplevel, ex)
-    for (mod, ex) in modexs
-        frame = Frame(mod, ex)
-        while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-        end
-    end
-    @test isa(Toplevel.EnumChild1, Toplevel.EnumParent)
+          end)))
+    @test invokelatest(() -> isa(M.EnumChild1, M.EnumParent))
 end
 
 module LowerAnon
 ret = Ref{Any}(nothing)
 end
+module LowerAnonDirect
+ret = Ref{Any}(nothing)
+end
+@testset "Anonymous functions ($(nameof(M)))" for (M, eval!) in toplevel_eval_pairs(LowerAnon, LowerAnonDirect)
+    eval!(M, Expr(:toplevel,
+        :(f = x -> parse(Int16, x)),
+        :(ret[] = map(f, AbstractString[]))))
+    @test isa(M.ret[], Vector{Int16})
+    M.ret[] = nothing
 
-@testset "Anonymous functions" begin
-    ex1 = quote
-        f = x -> parse(Int16, x)
-        ret[] = map(f, AbstractString[])
-    end
-    ex2 = quote
-        ret[] = map(x->parse(Int16, x), AbstractString[])
-    end
-    modexs = ExprSplitter(LowerAnon, ex1)
-    for (mod, ex) in modexs
-        frame = Frame(mod, ex)
-        while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-        end
-    end
-    @test isa(LowerAnon.ret[], Vector{Int16})
-    LowerAnon.ret[] = nothing
-    modexs = ExprSplitter(LowerAnon, ex2)
-    for (mod, ex) in modexs
-        frame = Frame(mod, ex)
-        while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-        end
-    end
-    @test isa(LowerAnon.ret[], Vector{Int16})
-    LowerAnon.ret[] = nothing
+    eval!(M, Expr(:toplevel, :(ret[] = map(x->parse(Int16, x), AbstractString[]))))
+    @test isa(M.ret[], Vector{Int16})
+    M.ret[] = nothing
 
-    ex3 = quote
-        const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...}
-    end
-    modexs = ExprSplitter(LowerAnon, ex3)
-    for (mod, ex) in modexs
-        frame = Frame(mod, ex)
-        while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-        end
-    end
-    @test isa(LowerAnon.BitIntegerType, Union)
+    eval!(M, Expr(:toplevel,
+        :(const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...})))
+    @test isa(invokelatest(() -> M.BitIntegerType), Union)
 
-    ex4 = quote
-        y = 3
-        z = map(x->x^2+y, [1,2,3])
-        y = 4
-    end
-    modexs = ExprSplitter(LowerAnon, ex4)
-    for (mod, ex) in modexs
-        frame = Frame(mod, ex)
-        while true
-            JuliaInterpreter.through_methoddef_or_done!(frame) === nothing && break
-        end
-    end
-    @test LowerAnon.z == [4,7,12]
+    # The closure captures `y` by reference, so `map` sees `y == 3` even though `y` is
+    # reassigned afterward.
+    eval!(M, Expr(:toplevel,
+        :(y = 3),
+        :(z = map(x->x^2+y, [1,2,3])),
+        :(y = 4)))
+    @test invokelatest(() -> M.z) == [4,7,12]
 end
 
 @testset "Docstrings" begin
@@ -764,4 +749,49 @@ module DirectKwdef end
     JuliaInterpreter.finish_and_return!(Frame(DirectKwdef, Base.parse_input_line(srck)), true)
     @test @invokelatest(DirectKwdef.p) == @invokelatest(DirectKwdef.KW(1, 2))
     @test @invokelatest(DirectKwdef.q) == @invokelatest(DirectKwdef.KW(10, 2))
+end
+
+# Targeted coverage of the direct surface-interpretation path (`step_toplevel!` /
+# `interpret_toplevel_stmt!` / `find_or_create_module`) for cases the dual-path testsets
+# above do not reach: error propagation, module reopening, and bare import/export/public/
+# literal statements fed as surface `:toplevel` expressions.
+module DirectSurface end
+@testset "Direct toplevel surface paths" begin
+    # A runtime error in a surface statement propagates through `step_toplevel!`'s handler.
+    @test_throws "boom" JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(error("boom")))), true)
+
+    # A statement that lowering rejects surfaces as an `ArgumentError`.
+    @test_throws "lowering returned an error" JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(1 = 2))), true)
+
+    # A bare literal statement is evaluated and returned.
+    @test JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, 42)), true) == 42
+
+    # Reopening a module: the second `:module` declaration reuses the existing module rather
+    # than creating a new one, so bindings from both declarations coexist.
+    JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(module Reopened; a = 1; end))), true)
+    mod1 = invokelatest(getglobal, DirectSurface, :Reopened)
+    JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(module Reopened; b = 2; end))), true)
+    @test invokelatest(getglobal, DirectSurface, :Reopened) === mod1
+    @test invokelatest(() -> mod1.a) == 1
+    @test invokelatest(() -> mod1.b) == 2
+
+    # `import`/`export`/`public` are handled directly as surface statements.
+    JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(import Base.Iterators))), true)
+    @test invokelatest(isdefinedglobal, DirectSurface, :Iterators)
+    @test JuliaInterpreter.finish_and_return!(
+        Frame(DirectSurface, Expr(:toplevel, :(export some_unbound_sym))), true) === nothing
+    @static if VERSION >= v"1.11"
+        @test JuliaInterpreter.finish_and_return!(
+            Frame(DirectSurface, Expr(:toplevel, Expr(:public, :pubsym))), true) === nothing
+    end
+
+    # `whereis` on a toplevel-surface frame reads the surface `LineNumberNode`s directly.
+    fr = JuliaInterpreter.toplevel_frame(DirectSurface, Any[LineNumberNode(7, :somefile), :(x = 1)])
+    @test JuliaInterpreter.whereis(fr, 2) == ("somefile", 7)
 end


### PR DESCRIPTION
JuliaInterpreter's recommended mechanism for toplevel code is direct toplevel `Frame` interpretation. However, Revise uses `ExprSplitter`: it breaks toplevel code into independent toplevel expressions, which is useful for Revise's `diff`-like evaluation. The original test suite was designed around the `ExprSplitter` path, and an analysis suggested that we didn't have full coverage of the direct `Frame` path.

With this PR, we now evaluate the same top-level source through `ExprSplitter` trampolining *and* direct surface `Frame` interpretation, into independent modules, and assert both produce identical observable bindings and results. The `toplevel`, `Enum`, and `Anonymous functions` testsets are now parametrized over both paths via `eval_via_exprsplitter!`/`eval_via_direct_frame!` and `toplevel_eval_pairs`.

Also add a "Direct toplevel surface paths" testset covering cases not covered by the above: error propagation through `step_toplevel!`, statements that lowering rejects, bare literal/global statements, module reopening in `find_or_create_module`, surface `import`/`export`/`public`, and `whereis` on a toplevel-surface frame.