### PR TITLE
Resolve a nested `module` to a fresh local module

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -67,8 +67,9 @@ else
     String(first(methods(getfield(mod, :eval))).file)
 end
 
-# Resolve `module newname ... end` (with source expression `ex`), evaluated into
-# `parentmod`, to the `PkgId` of the module it refers to, or `nothing`.
+# Resolve a top-level `module newname ... end` (with source expression `ex`),
+# evaluated into `parentmod === Base.__toplevel__`, to the `PkgId` of the module it
+# refers to, or `nothing`.
 # `Base.identify_package` is the normal lookup; it returns `nothing` when
 # `newname` is not a declared dependency of the active project (an stdlib in a
 # bare test environment, or a package extension), in which case toplevel
@@ -85,7 +86,6 @@ function find_toplevel_module_id(parentmod::Module, newname::Symbol, ex::Expr)
     newnamestr = String(newname)
     id = Base.identify_package(parentmod, newnamestr)
     id === nothing || return id
-    parentmod === Base.__toplevel__ || return nothing
     lnn = firstline(ex)
     exfile = (lnn === nothing || lnn.file === nothing) ? nothing : String(lnn.file)
     fallback = nothing
@@ -116,26 +116,34 @@ function find_or_create_module(parentmod::Module, ex::Expr)
         error("unexpected :module form with $(length(ex.args)) args")
     end
     newname = newname::Symbol
+    mod = nothing
     if invokelatest(isdefinedglobal, parentmod, newname)
-        mod = invokelatest(getglobal, parentmod, newname)
-        mod isa Module || throw(ErrorException("invalid redefinition of constant $(newname)"))
-    else
+        found = invokelatest(getglobal, parentmod, newname)
+        found isa Module || throw(ErrorException("invalid redefinition of constant $(newname)"))
+        # Reuse a loaded package only when it loads itself (`parentmod === Base.__toplevel__`)
+        # or when `newname` already names a genuine submodule of `parentmod` (re-revision of a
+        # module we created). A nested `module newname` that merely shares a loaded package's
+        # name is a fresh local module that shadows the package, matching `include`
+        # (Revise issue #747).
+        if parentmod === Base.__toplevel__ || parentmodule(found) === parentmod
+            mod = found
+        end
+    elseif parentmod === Base.__toplevel__
         id = find_toplevel_module_id(parentmod, newname, ex)
         # Atomically fetch the loaded module under `require_lock` (see
         # `find_toplevel_module_id`); `nothing` means `id` is identifiable but
         # not yet loaded, so we create the module below.
         existing = id === nothing ? nothing :
             @lock Base.require_lock get(Base.loaded_modules, id, nothing)
-        if existing !== nothing
-            mod = existing::Module
-        else
-            loc = firstline(ex)
-            module_ex = Expr(:module, std_imports, newname, Expr(:block, loc))
-            if syntax_version !== nothing
-                pushfirst!(module_ex.args, syntax_version)
-            end
-            mod = Core.eval(parentmod, module_ex)::Module
+        existing === nothing || (mod = existing::Module)
+    end
+    if mod === nothing
+        loc = firstline(ex)
+        module_ex = Expr(:module, std_imports, newname, Expr(:block, loc))
+        if syntax_version !== nothing
+            pushfirst!(module_ex.args, syntax_version)
         end
+        mod = Core.eval(parentmod, module_ex)::Module
     end
     return mod, modbody::Expr
 end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -83,15 +83,22 @@ end
                     """)
         end
         @eval using TmpPkg1
-        # Every package is technically parented in Main but the name may not be visible in Main
         @test @eval isdefinedglobal(@__MODULE__, :TmpPkg1)
         @test @eval !isdefinedglobal(@__MODULE__, :TmpPkg2)
-        collect(ExprSplitter(@__MODULE__, quote
-                module TmpPkg2
-                f() = 2
-                end
-            end))
-        @test @eval isdefinedglobal(@__MODULE__, :TmpPkg1)
+        # A top-level `module TmpPkg2` (the form used when a package loads itself, evaluated
+        # into `Base.__toplevel__`) resolves to the already-loaded package rather than
+        # building a duplicate, even when the name is not visible in the parsing module.
+        for (m, _) in ExprSplitter(Base.__toplevel__, :(module TmpPkg2; f() = 2; end))
+            @test nameof(m) === :TmpPkg2 && parentmodule(m) === m
+        end
+        @test @eval !isdefinedglobal(@__MODULE__, :TmpPkg2)
+        # The same declaration nested in an ordinary module is a *local* module that merely
+        # shares the package's name: it is built fresh as a submodule of that module and
+        # shadows the package, matching `include` (Revise issue #747).
+        for (m, _) in ExprSplitter(JIVisible, :(module TmpPkg2; f() = 3; end))
+            @test parentmodule(m) === JIVisible
+        end
+        @test isdefinedglobal(JIVisible, :TmpPkg2)
         @test @eval !isdefinedglobal(@__MODULE__, :TmpPkg2)
     end
 


### PR DESCRIPTION
`ExprSplitter` resolved any `module X` whose name matched an already-loaded package to that package, even when the declaration was nested in an ordinary module. A file `includet`ed into `Main` that defined `module Test` (or any other name shared with a loaded package) therefore had its body evaluated inside the loaded package, e.g. `using SomeDep` failed because the package was not a dependency of stdlib `Test`.

Reuse of a loaded package now happens only when the declaration is evaluated into `Base.__toplevel__` (a package loading itself) or when the name already refers to a genuine submodule of the parent (`parentmodule(found) === parent`, i.e. re-revising a module we created). Otherwise the module is built fresh, so a nested `module X` shadows any loaded package of the same name, matching `include`.

The shared logic for both the `ExprSplitter` trampoline and direct toplevel interpretation now lives in `resolve_module`.

Fixes timholy/Revise.jl#747