### PR TITLE
builtins: Run `_apply_iterate` in frame world

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -247,14 +247,14 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
     $head f === Core._apply_iterate
         argswrapped = getargs(interp, args, frame)
         if !expand
-            return Some{Any}(Core._apply_iterate(argswrapped...))
+            return Some{Any}(invoke_in_world(frame.world, Core._apply_iterate, argswrapped...))
         end
         aw1 = argswrapped[1]::Function
         @assert aw1 === Core.iterate || aw1 === Core.Compiler.iterate || aw1 === Base.iterate "cannot handle `_apply_iterate` with non iterate as first argument, got \$(aw1), \$(typeof(aw1))"
         new_expr = Expr(:call, argswrapped[2])
         popfirst!(argswrapped) # pop the iterate
         popfirst!(argswrapped) # pop the function
-        argsflat = append_any(argswrapped...)
+        argsflat = invoke_in_world(frame.world, append_any, argswrapped...)
         for x in argsflat
             push!(new_expr.args, QuoteNode(x))
         end

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -88,14 +88,14 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
     elseif f === Core._apply_iterate
         argswrapped = getargs(interp, args, frame)
         if !expand
-            return Some{Any}(Core._apply_iterate(argswrapped...))
+            return Some{Any}(invoke_in_world(frame.world, Core._apply_iterate, argswrapped...))
         end
         aw1 = argswrapped[1]::Function
         @assert aw1 === Core.iterate || aw1 === Core.Compiler.iterate || aw1 === Base.iterate "cannot handle `_apply_iterate` with non iterate as first argument, got $(aw1), $(typeof(aw1))"
         new_expr = Expr(:call, argswrapped[2])
         popfirst!(argswrapped) # pop the iterate
         popfirst!(argswrapped) # pop the function
-        argsflat = append_any(argswrapped...)
+        argsflat = invoke_in_world(frame.world, append_any, argswrapped...)
         for x in argsflat
             push!(new_expr.args, QuoteNode(x))
         end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -410,6 +410,26 @@ end
     @test invokelatest(() -> M.z) == [4,7,12]
 end
 
+module ApplyIterateSplit end
+module ApplyIterateDirect end
+@testset "_apply_iterate world age ($(nameof(M)))" for (M, eval!) in toplevel_eval_pairs(ApplyIterateSplit, ApplyIterateDirect)
+    ex = Base.parse_input_line(raw"""
+        for n = 1:4
+            func_name = Symbol("fn$n")
+            arg_names = Tuple(Symbol("child$j") for j in 1:n)
+            @eval function $func_name(
+                    w,
+                    $((:($arg_name::Int) for arg_name in arg_names)...)
+                )
+                return (w, ($(arg_names...),))
+            end
+        end
+        """)
+    eval!(M, ex)
+    @test invokelatest(() -> M.fn1(:w, 1)) == (:w, (1,))
+    @test invokelatest(() -> M.fn4(:w, 1, 2, 3, 4)) == (:w, (1, 2, 3, 4))
+end
+
 @testset "Docstrings" begin
     ex = quote
         """
@@ -461,7 +481,6 @@ end
     JuliaInterpreter.finish!(frame, true)
     @test Toplevel.Node isa Type
 end
-
 
 @testset "Non-frames" begin
     ex = Base.parse_input_line("""


### PR DESCRIPTION
Interpreting top-level code can define generator closure methods and then immediately consume those generators while expanding `Core._apply_iterate` for varargs calls. The expansion previously called `append_any` in the interpreter ambient world, so newly defined generator methods could appear too new and raise a world-age `MethodError`.

Run both the non-expanded `_apply_iterate` path and the expanded `append_any` flattening path in `frame.world`. This matches the rest of the interpreter world-age model, where top-level frames advance their world after world-incrementing statements and method frames remain fixed.

Add a top-level regression test that evaluates an `@eval` loop with a spliced generator in a function signature through both the `ExprSplitter` and direct frame paths.