### PR TITLE
interpret: Match the runtime interpreter's syntactic dispatch for `Ex…

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -70,16 +70,29 @@ function lookup_expr(interp::Interpreter, frame::Frame, e::Expr)
     end
     head === :boundscheck && length(e.args) == 0 && return true
     if head === :foreignglobal
-        # On Julia ≥ 1.14, `cglobal` name lookups lower to `Expr(:foreignglobal, spec)`
-        # (JuliaLang/julia#61709), where `spec` is a (possibly quoted) symbol, string,
-        # or `(name, lib)` tuple. Evaluate it the same way the runtime interpreter
-        # does: resolve the symbol and return the raw `Ptr{Cvoid}` (issue #734).
+        # On Julia ≥ 1.14, `cglobal` lowers to `Expr(:foreignglobal, spec)`
+        # (JuliaLang/julia#61709). Mirror the runtime interpreter's syntactic
+        # dispatch (`eval_expr` in src/interpreter.c): a (possibly quoted) symbol,
+        # string, or `(name, lib)` tuple resolves through the foreign-symbol
+        # lookup; any other argument must evaluate to a pointer, which is
+        # returned as a raw `Ptr{Cvoid}` (issue #734).
         fptr = e.args[1]
-        isa(fptr, QuoteNode) && (fptr = fptr.value)
-        if isexpr(fptr, :tuple)
-            fptr = Core.tuple(Any[lookup_nested(interp, frame, arg) for arg in (fptr::Expr).args]...)
+        if isa(fptr, QuoteNode) && (isa(fptr.value, String) || isa(fptr.value, Tuple))
+            fptr = fptr.value
         end
-        return ccall(:jl_cglobal_auto, Any, (Any,), fptr)
+        if isexpr(fptr, :tuple)
+            # The `(name, lib)` elements may themselves be `getproperty` chains
+            # (e.g. `Base.Math.libm`), which `lookup_nested` resolves.
+            spec = Core.tuple(Any[lookup_nested(interp, frame, arg) for arg in (fptr::Expr).args]...)
+            return ccall(:jl_cglobal_auto, Any, (Any,), spec)
+        elseif isa(fptr, Tuple) || isa(fptr, String)
+            return ccall(:jl_cglobal_auto, Any, (Any,), fptr)
+        elseif isa(fptr, QuoteNode) && isa(fptr.value, Symbol)
+            return ccall(:jl_cglobal_auto, Any, (Any,), fptr.value)
+        end
+        v = lookup(interp, frame, fptr)
+        isa(v, Ptr) || throw(TypeError(:cglobal, Ptr, v))
+        return convert(Ptr{Cvoid}, v)
     end
     if head === :call
         f = lookup(interp, frame, e.args[1])

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -261,6 +261,15 @@ end
 # (JuliaLang/julia#61709), which the interpreter must evaluate itself (issue #734).
 cglobal_foreignglobal() = cglobal(:jl_options)
 @test @interpret(cglobal_foreignglobal()) == cglobal_foreignglobal() != C_NULL
+# The argument may also be a runtime value rather than a (quoted)
+# symbol/string/tuple literal, in which case it must already be a pointer:
+# `cglobal(p)` is then a typechecked cast to `Ptr{Cvoid}`, and a non-pointer
+# argument is a `TypeError`, matching the compiled semantics.
+cglobal_ptr_passthrough(p) = cglobal(p)
+let p = cglobal(:jl_options)
+    @test @interpret(cglobal_ptr_passthrough(p)) === cglobal_ptr_passthrough(p) === p
+    @test_throws TypeError @interpret(cglobal_ptr_passthrough(1))
+end
 @test @interpret(Base.JLOptions()) == Base.JLOptions()
 # Issue #354: an `llvmcall` argument computed from a function argument cannot be
 # interpreted directly. `build_compiled_llvmcall!` runs a mini-interpreter (with


### PR DESCRIPTION
…pr(:foreignglobal)`

The `Expr(:foreignglobal)` handler added in #742 was modeled on an earlier revision of the upstream lowering PR (JuliaLang/julia#61709); the version that landed restricts the foreign-symbol lookup to syntactic (possibly quoted) symbol, string, and `(name, lib)` tuple arguments, and treats anything else as a value that must evaluate to a pointer, returned as `Ptr{Cvoid}`.

The merged handler instead unwrapped any `QuoteNode` and funneled every argument straight to `jl_cglobal_auto`, so a runtime-valued argument (e.g. `cglobal(p)` with `p::Ptr`) passed the raw `SlotNumber`/`SSAValue` IR node to the runtime and threw a spurious `TypeError` instead of evaluating the operand. Mirror the landed dispatch from `eval_expr` in Julia's src/interpreter.c, including the pointer typecheck on the fallback path.

Addresses the post-merge review on #742.