### PR TITLE
Pool each frame at most once when recycling

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -35,6 +35,8 @@ const compiled_modules = Set{Module}()
 
 const junk_framedata = FrameData[] # to allow re-use of allocated memory (this is otherwise a bottleneck)
 const junk_frames = Frame[]
+# Tracks which frames are currently pooled, so `recycle` can be idempotent (see below).
+const pooled_frames = Base.IdSet{Frame}()
 debug_mode() = false
 @noinline function _check_frame_not_in_junk(frame)
     @assert frame.framedata ∉ junk_framedata
@@ -42,7 +44,14 @@ debug_mode() = false
 end
 
 @inline function recycle(frame)
+    # A single exception can recycle the same frame twice: `handle_err` recycles the
+    # throwing frame, then `unwind_exception` walks the same frames again to reach the
+    # catch block. `return_from`'s link-clearing is idempotent, but pooling a frame twice
+    # lets it be handed out twice, aliasing a live frame into its own caller chain (an
+    # infinite loop on the next exception). Pool each frame at most once.
+    frame in pooled_frames && return
     debug_mode() && _check_frame_not_in_junk(frame)
+    push!(pooled_frames, frame)
     push!(junk_framedata, frame.framedata)
     push!(junk_frames, frame)
 end
@@ -163,6 +172,7 @@ function clear_caches()
     empty!(framedict)
     empty!(genframedict)
     empty!(junk_frames)
+    empty!(pooled_frames)
     for bp in breakpoints()
         empty!(bp.instances)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -362,6 +362,7 @@ function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing,
                world::UInt=default_world())
     if length(junk_frames) > 0
         frame = pop!(junk_frames)
+        delete!(pooled_frames, frame)
         frame.framecode = framecode
         frame.framedata = framedata
         frame.pc = pc

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -317,6 +317,14 @@ end
         @test first(err_caught) isa ErrorException
         @test stacklength(fr) == 1
 
+        # Regression: a caught exception recycles the throwing frame twice (once in
+        # `handle_err`, once as `unwind_exception` walks to the catch block). Pooling a
+        # frame twice let it be handed back out while still live, aliasing it into its own
+        # caller chain and hanging `unwind_exception` on the next exception. Recycling must
+        # pool each frame at most once.
+        @test allunique(objectid.(JuliaInterpreter.junk_frames))
+        @test allunique(objectid.(JuliaInterpreter.junk_framedata))
+
         err_caught = Any[nothing]
         fr = JuliaInterpreter.enter_call(f_exc_outer)
         fr, pc = debug_command(fr, :s)


### PR DESCRIPTION
This fixes an infinite loop+OOM when trying to run Debugger.jl test suite with JuliaInterpreter 0.11.

A single exception can recycle the same Frame twice: `handle_err` recycles the throwing frame, then `unwind_exception` walks the same frames again to reach the catch block. `return_from`'s link-clearing is idempotent, but pushing a frame into the junk pool twice let `prepare_frame` hand it back out while it was still live, aliasing it into its own caller chain (`caller.callee === caller`). The next exception then hung `unwind_exception`'s `while frame !== nothing` loop, allocating frames until OOM.

This was latent for years, masked because `enter_call` used to call `clear_caches()` (emptying the pool) on every entry; f83049b (#733) stopped doing that, unmasking it.

Track pooled frames in an `IdSet` and make the pool push in `recycle` idempotent, keeping it in sync on reuse and in `clear_caches`.

Bug identified and fixed by Opus. Not sure this is the best fix, but I can confirm that it fixes the Debugger tests.