### PR TITLE
Bug fixes: straightforward defects (easy tier)

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -16,8 +16,8 @@ jobs:
           version: 'lts'
           show-versioninfo: true         # print versioninfo in the action log
       - uses: actions/checkout@v7
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 version = "0.11.3"
-authors = ["Tim Holy <tim.holy@gmail.com>, Kristoffer Carlsson <kcarlsson89@gmail.com>, Shuhei Kadowaki <aviatesk@gmail.com> and contributors"]
+authors = ["Tim Holy <tim.holy@gmail.com>", "Kristoffer Carlsson <kcarlsson89@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>", "and contributors"]
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.10"
+julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "626fcfe445ef175200e70abe75ac9e8a2d255b38"
+project_hash = "076b998186ce266cae7c6103dca17b14b437d6fc"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -103,7 +103,7 @@ version = "0.21.4"
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
 path = ".."
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.10.3"
+version = "0.11.3"
 
 [[deps.LazilyInitializedFields]]
 git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
@@ -159,14 +159,14 @@ version = "0.1.2"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
+version = "2.28.1010+0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.12.2"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -279,4 +279,4 @@ version = "1.52.0+1"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.6.1+0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,6 +5,12 @@ Normally, Julia compiles your code when you first execute it; using JuliaInterpr
 avoid compilation and execute the expressions that define your code directly.
 Interpreters have a number of applications, including support for stepping debuggers.
 
+!!! warning
+    JuliaInterpreter is not thread-safe: its frame, cache, and breakpoint state is
+    process-global and unsynchronized, so running interpretations concurrently from
+    multiple tasks or threads can produce errors or silently wrong results. Perform all
+    interpretation from a single task.
+
 ## Use as an interpreter
 
 Using this package as an interpreter is straightforward:

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -6,8 +6,12 @@ const _breakpoints = AbstractBreakpoint[]
     breakpoints()::Vector{AbstractBreakpoint}
 
 Return an array with all breakpoints.
+
+The returned array is a copy of the internal breakpoint registry; mutating it does
+not affect the set of breakpoints. Use [`remove`](@ref), [`enable`](@ref), and
+[`disable`](@ref) to update the breakpoints themselves.
 """
-breakpoints() = _breakpoints
+breakpoints() = copy(_breakpoints)
 
 
 const breakpoint_update_hooks = []

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -541,7 +541,7 @@ function debug_command(interp::Interpreter, frame::Frame, cmd::Symbol, rootistop
                 ret = @invoke evaluate_call!(BreakOnCall()::Interpreter, frame::Frame, stmt::Expr, enter_generated::Bool)
             catch err
                 ret = handle_err(interp, frame, err)
-                return isa(ret, BreakpointRef) ? (leaf(frame), ret) : ret
+                return isa(ret, BreakpointRef) ? (leaf(frame), ret) : (frame, ret)
             end
             if isa(ret, BreakpointRef)
                 newframe = leaf(frame)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -564,9 +564,9 @@ function debug_command(interp::Interpreter, frame::Frame, cmd::Symbol, rootistop
     catch err
         frame = unwind_exception(frame, err)
         if cmd === :c
-            return debug_command(interp, frame, :c, istoplevel)
+            return debug_command(interp, frame, :c, rootistoplevel)
         else
-            return debug_command(interp, frame, :nc, istoplevel)
+            return debug_command(interp, frame, :nc, rootistoplevel)
         end
     end
     throw(ArgumentError("command $cmd not recognized"))

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -208,10 +208,15 @@ execute until the current frame reaches any line greater than the current line.
 function until_line!(interp::Interpreter, frame::Frame, line::Union{Nothing, Integer}=nothing, istoplevel::Bool=false)
     pc = frame.pc
     initialline, initialfile = linenumber(frame, pc), getfile(frame, pc)
+    if initialline === nothing || initialfile === nothing
+        return step_expr!(interp, frame, istoplevel)
+    end
     line === nothing && (line = initialline + 1)
     line_final = line
     pc = next_until!(interp, frame, istoplevel) do frame::Frame
-        return is_return(pc_expr(frame)) || (linenumber(frame) >= line_final && getfile(frame) == initialfile)
+        is_return(pc_expr(frame)) && return true
+        ln = linenumber(frame)
+        return ln !== nothing && ln >= line_final && getfile(frame) == initialfile
     end
     (pc === nothing || isa(pc, BreakpointRef)) && return pc
     maybe_step_through_kwprep!(interp, frame, istoplevel)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -453,7 +453,9 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
             elseif i <= nargs
                 locals[i], last_reference[i] = Some{Any}(argvals[i]), 1
             else
-                locals[i] = Some{Any}(())
+                # An empty vararg is still a defined local (`x === ()`); mark it referenced
+                # so `locals(frame)`/`eval_code` can see it.
+                locals[i], last_reference[i] = Some{Any}(()), 1
             end
         end
         if islastva

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -717,7 +717,7 @@ function determine_method_for_expr(expr::Expr;
                                    world::UInt=default_world(),
                                    method_table::Union{Nothing,MethodTable}=nothing)
     f = to_function(expr.args[1], world)
-    allargs = expr.args
+    allargs = copy(expr.args)  # keyword extraction below must not mutate the caller's AST
     # Extract keyword args
     kwargs = Expr(:parameters)
     if length(allargs) > 1 && isexpr(allargs[2], :parameters)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -860,7 +860,7 @@ function extract_args(__module__, ex0)
             a11 = a1.args[1]
             if a11 === :setindex!
                 return Expr(:tuple,
-                    mapany(x->isexpr(x, :parameters) ? QuoteNode(x) : x, arg.args)...)
+                    mapany(x->isexpr(x, :parameters) ? QuoteNode(x) : x, a1.args)...)
             end
         end
     end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -641,7 +641,10 @@ function queuenext!(iter::ExprSplitter)
         push_modex!(iter, mod, ex)
         return queuenext!(iter)
     elseif head === :macrocall
-        iter.lnn = ex.args[2]::LineNumberNode
+        # The canonical second argument is a LineNumberNode, but `nothing` is also legal
+        # (common in programmatically constructed ASTs).
+        a2 = ex.args[2]
+        a2 isa LineNumberNode && (iter.lnn = a2)
     elseif head === :block || head === :toplevel
         # Container expression
         idx = iter.index[end]

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -346,9 +346,10 @@ end
     ret = evaluate_call!(frame::Frame, call_expr::Expr, enter_generated::Bool=false)
 
 Evaluate a `:call` expression `call_expr` in the context of `frame`.
-The first causes it to be executed using Julia's normal dispatch (compiled code),
-whereas the second recurses in via the interpreter.
-`interp` has a default value of [`RecursiveInterpreter`](@ref).
+How the call is executed depends on `interp`: with `NonRecursiveInterpreter()` the call
+runs natively via Julia's normal dispatch (compiled code), whereas the default
+[`RecursiveInterpreter`](@ref) constructs a child frame and interprets the callee's
+lowered code recursively.
 """
 evaluate_call!(frame::Frame, call_expr::Expr, enter_generated::Bool=false) =
     evaluate_call!(RecursiveInterpreter(), frame, call_expr, enter_generated)

--- a/src/types.jl
+++ b/src/types.jl
@@ -510,9 +510,11 @@ Variable(value, name) = Variable(value, name, false, false)
 Variable(value, name, isparam) = Variable(value, name, isparam, false)
 Base.show(io::IO, var::Variable) = (print(io, var.name, " = "); show(io,var.value))
 Base.isequal(var1::Variable, var2::Variable) =
-    var1.value == var2.value && var1.name === var2.name && var1.isparam == var2.isparam &&
+    isequal(var1.value, var2.value) && var1.name === var2.name && var1.isparam == var2.isparam &&
     var1.is_captured_closure == var2.is_captured_closure
 Base.:(==)(var1::Variable, var2::Variable) = isequal(var1, var2)
+Base.hash(var::Variable, h::UInt) =
+    hash(var.value, hash(var.name, hash(var.isparam, hash(var.is_captured_closure, hash(:Variable, h)))))
 
 # A type that is unique to this package for which there are no valid operations
 struct Unassigned end

--- a/src/types.jl
+++ b/src/types.jl
@@ -575,7 +575,7 @@ same_location(::AbstractBreakpoint, ::AbstractBreakpoint) = false
 
 function print_bp_condition(io::IO, cond::Condition)
     if cond !== nothing
-        if isa(cond, Tuple{Module, Expr}) && (expr = expr[2])
+        if isa(cond, Tuple{Module, Expr})
             cond = (cond[1], Base.remove_linenums!(copy(cond[2])))
         elseif isa(cond, Expr)
             cond = Base.remove_linenums!(copy(cond))

--- a/src/types.jl
+++ b/src/types.jl
@@ -377,11 +377,13 @@ function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing,
     end
 end
 """
-    frame = Frame(mod::Module, src::CodeInfo; world=get_world_counter(), kwargs...)
+    frame = Frame(mod::Module, src::CodeInfo; world=JuliaInterpreter.default_world(), kwargs...)
 
-Construct a `Frame` to evaluate `src` in module `mod`. `world` sets the world
-age used for dispatch (defaults to the latest committed world). Additional
-keyword arguments (`generator`, `optimize`) are forwarded to [`FrameCode`](@ref).
+Construct a `Frame` to evaluate `src` in module `mod`. `world` sets the world age used for
+dispatch; it defaults to the calling task's current world, matching the semantics of an
+ordinary (non-`invokelatest`) call. Pass `world=Base.get_world_counter()` to instead resolve
+methods and bindings in the latest committed world. Additional keyword arguments
+(`generator`, `optimize`) are forwarded to [`FrameCode`](@ref).
 """
 function Frame(mod::Module, src::CodeInfo; world::UInt=default_world(), kwargs...)
     framecode = FrameCode(mod, src; world, kwargs...)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -668,3 +668,14 @@ end
     @test occursin("x > 0", sprint(show, bp))
     remove()
 end
+
+@testset "breakpoints() does not leak the registry" begin
+    remove()
+    registry_bp_f(x) = x
+    fr = JuliaInterpreter.enter_call(registry_bp_f, 1)
+    breakpoint(registry_bp_f)
+    empty!(JuliaInterpreter.breakpoints())
+    @test length(JuliaInterpreter.breakpoints()) == 1
+    remove()
+    @test !JuliaInterpreter.shouldbreak(fr, fr.pc)
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -660,3 +660,11 @@ end
         remove()
     end
 end
+
+@testset "Showing a module-qualified condition" begin
+    remove()
+    showcond_f(x) = x
+    bp = breakpoint(showcond_f, (Main, :(x > 0)))
+    @test occursin("x > 0", sprint(show, bp))
+    remove()
+end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -630,3 +630,32 @@ end
     end
     @test ret === nothing || ret isa Tuple
 end
+
+@testset "Exception recovery keeps rootistoplevel" begin
+    ex = quote
+        function unwind_thrower() error("boom") end
+        try
+            unwind_thrower()
+        catch
+            function defined_in_catch() 42 end
+            defined_in_catch()
+        end
+    end
+    fr = Frame(Main, ex)
+    ret = JuliaInterpreter.debug_command(fr, :s, true)
+    count = 0
+    while ret isa Tuple && count < 100
+        cframe = ret[1]
+        sc = JuliaInterpreter.scopeof(cframe)
+        sc isa Method && sc.name === :unwind_thrower && break
+        ret = JuliaInterpreter.debug_command(cframe, :s, true)
+        count += 1
+    end
+    r = JuliaInterpreter.debug_command(ret[1], :n, true)
+    inner = 0
+    while r isa Tuple && !(r[2] isa BreakpointRef) && inner < 200
+        r = JuliaInterpreter.debug_command(r[1], :n, true)
+        inner += 1
+    end
+    @test r === nothing
+end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -618,3 +618,15 @@ end
     frame, _ = JuliaInterpreter.debug_command(frame, :sr)
     @test JuliaInterpreter.get_return(frame) == g()
 end
+
+@testset ":s keeps the (frame, pc) contract on caught errors" begin
+    caught_error_s() = try; throw(ArgumentError("x")); catch; 42; end
+    fr = enter_call(caught_error_s)
+    local ret = nothing
+    for _ in 1:10
+        ret = JuliaInterpreter.debug_command(fr, :s)
+        ret isa Tuple || break
+        fr = ret[1]
+    end
+    @test ret === nothing || ret isa Tuple
+end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -659,3 +659,9 @@ end
     end
     @test r === nothing
 end
+
+@testset "until_line! without location metadata" begin
+    fr = Frame(Main, Base.remove_linenums!(quote nolineinfo_a = 1; nolineinfo_b = nolineinfo_a + 1; nolineinfo_b end))
+    ret = JuliaInterpreter.debug_command(fr, :until, true)
+    @test ret === nothing || ret isa Tuple
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1358,3 +1358,11 @@ end
     @test hash(v) isa UInt
     @test isequal(hash(v), hash(JuliaInterpreter.Variable(missing, :x)))
 end
+
+@testset "determine_method_for_expr does not mutate the caller's AST" begin
+    kwfunc_ast(x; y=2) = x + y
+    ex = Expr(:call, kwfunc_ast, Expr(:parameters, Expr(:kw, :y, 2)), 1)
+    before = deepcopy(ex)
+    JuliaInterpreter.determine_method_for_expr(ex)
+    @test ex == before
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1345,3 +1345,9 @@ end
         @test (@interpret world=w3 WrapperDepTest.llvmadd(Int32(30), Int32(12))) == 18
     end
 end
+
+@testset "Empty varargs are visible to locals" begin
+    empty_vararg(x...) = x
+    fr = JuliaInterpreter.enter_call(empty_vararg)
+    @test only(filter(v -> v.name === :x, JuliaInterpreter.locals(fr))).value === ()
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1351,3 +1351,10 @@ end
     fr = JuliaInterpreter.enter_call(empty_vararg)
     @test only(filter(v -> v.name === :x, JuliaInterpreter.locals(fr))).value === ()
 end
+
+@testset "Variable equality is total" begin
+    v = JuliaInterpreter.Variable(missing, :x)
+    @test isequal(v, v) === true
+    @test hash(v) isa UInt
+    @test isequal(hash(v), hash(JuliaInterpreter.Variable(missing, :x)))
+end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -876,3 +876,8 @@ module DirectSurface end
     fr = JuliaInterpreter.toplevel_frame(DirectSurface, Any[LineNumberNode(7, :somefile), :(x = 1)])
     @test JuliaInterpreter.whereis(fr, 2) == ("somefile", 7)
 end
+
+@testset "macrocall with nothing line info" begin
+    ex = Expr(:toplevel, Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), nothing, "docstr", :(split_nolineinfo() = 1)))
+    @test length(collect(ExprSplitter(@__MODULE__, ex))) == 1
+end


### PR DESCRIPTION
First of three PRs splitting #750 by review difficulty. This tier contains the fixes where the defect is visible in the diff itself: wrong variable referenced, missing copy, wrong return shape, a throwing `==` on `missing`, missing nothing-guards — plus the documentation/metadata commits.

Each fix commit carries its own regression test in the logical test file.

- Fix UndefVarError when showing a breakpoint with a (Module, Expr) condition
- Accept `:macrocall` expressions with nothing line info in ExprSplitter
- Make an empty vararg visible to `locals()` and `eval_code`
- Fix undefined variable reference in `extract_args`' dead `:body` branch
- Return `(frame, pc)` from `:s` when a stepped-into call throws and is caught
- Pass `rootistoplevel` when retrying a command after exception unwinding
- Guard `until_line!` against frames without line info
- Make `Variable` equality total and add a consistent hash
- Stop `determine_method_for_expr` from mutating the caller's expression
- Return a copy from `breakpoints()` instead of the live registry
- Docstring corrections, package metadata, concurrency documentation note

Companion PRs: intermediate and hard tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
