### PR TITLE
Bug fixes: mechanism-level defects (intermediate tier)

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -210,13 +210,21 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
 
     if f isa Core.OpaqueClosure
         if expand
-            if !Base.uncompressed_ir(f.source).inferred
-                return Expr(:call, f, args[2:end]...)
-            else
-                @debug "not interpreting opaque closure \$f since it contains inferred code"
+            meth = f.source
+            # Don't try to interpret optimized/inferred ir, or closures whose source is
+            # unavailable (e.g. constructed from an `IRCode`); call those natively below.
+            if isa(meth, Method) && (isdefined(meth, :source) || isdefined(meth, :generator))
+                src = Base.uncompressed_ir(meth)
+                isinferred = hasfield(Core.CodeInfo, :inferred) ? src.inferred :
+                    !isa(src.ssavaluetypes, Int)  # inferred code has a type vector here
+                if !isinferred
+                    return Expr(:call, f, args[2:end]...)
+                else
+                    @debug "not interpreting opaque closure \$f since it contains inferred code"
+                end
             end
         end
-        return Some{Any}(f(args...))
+        return Some{Any}(f(getargs(interp, args, frame)...))
     end
     if !(supertype(typeof(f)) === Core.Builtin || isa(f, Core.IntrinsicFunction))
         return call_expr

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -88,7 +88,8 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
         sig = Base.unwrap_unionall(m.sig)
         ft0 = sig.parameters[1]
         ft = Base.unwrap_unionall(ft0)
-        if ft <: Function && isa(ft, DataType) && isdefined(ft, :instance)
+        # Check `isa` first: `ft` can be a non-Type (e.g. `Vararg`), on which `<:` throws.
+        if isa(ft, DataType) && ft <: Function && isdefined(ft, :instance)
             return ft.instance
         elseif _isType(ft)
             return _Type_parameter(ft)
@@ -102,7 +103,7 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
     bp.f isa Method && return meth === bp.f
     f = extract_function_from_method(meth)
     if !(bp.f === f || (f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3]
-                !Base.has_free_typevars(ftype) && bp.f isa ftype
+                isa(ftype, Type) && !Base.has_free_typevars(ftype) && bp.f isa ftype
             end))
         return false
     end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -176,7 +176,13 @@ function breakpoint(file::AbstractString, line::Integer, condition::Condition=no
     bp = BreakpointFileLocation(file, apath, line, condition, Ref(true), BreakpointRef[])
     add_to_existing_framecodes(bp)
     idx = findfirst(bp2 -> same_location(bp, bp2), _breakpoints)
-    idx === nothing ? push!(_breakpoints, bp) : (_breakpoints[idx] = bp)
+    if idx === nothing  # creating new
+        push!(_breakpoints, bp)
+    else  # replace existing breakpoint
+        old_bp = _breakpoints[idx]
+        _breakpoints[idx] = bp
+        firehooks(remove, old_bp)
+    end
     firehooks(breakpoint, bp)
     return bp
 end
@@ -335,10 +341,11 @@ disable() = foreach(disable, _breakpoints)
 Remove all breakpoints.
 """
 function remove()
-    for bp in _breakpoints
-        foreach(remove, bp.instances)
+    # Iterate over a copy: `remove(bp)` deletes from `_breakpoints` (and fires the
+    # `remove` hooks, which the previous `empty!`-based implementation skipped).
+    for bp in copy(_breakpoints)
+        remove(bp)
     end
-    empty!(_breakpoints)
 end
 
 """

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -61,7 +61,12 @@ function firehooks(hooked_fun, bp::AbstractBreakpoint)
 end
 
 function add_to_existing_framecodes(bp::AbstractBreakpoint)
-    for framecode in values(framedict)
+    # Cover both caches: `genframedict` holds the framecodes for expanded @generated
+    # bodies, which would otherwise never receive breakpoints added after they were cached.
+    seen = Base.IdSet{FrameCode}()
+    for framecode in Iterators.flatten((values(framedict), values(genframedict)))
+        framecode in seen && continue
+        push!(seen, framecode)
         add_breakpoint_if_match!(framecode, bp)
     end
 end

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -251,7 +251,10 @@ function prepare_slotfunction(framecode::FrameCode, body::Union{Symbol,Expr})
     if isa(scope, Method)
         syms = sparam_syms(scope)
         for i = 1:length(syms)
-            push!(assignments, Expr(:(=), syms[i], :($dataname.sparams[$i])))
+            # A static parameter can be unbound (e.g. declared but unused); guard the read
+            # so conditions that don't reference it still work.
+            push!(assignments, Expr(:(=), syms[i],
+                :(isassigned($dataname.sparams, $i) ? $dataname.sparams[$i] : $default)))
         end
     end
     funcname = isa(scope, Method) ? gensym("slotfunction") : gensym(Symbol(scope, "_slotfunction"))

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -432,7 +432,10 @@ macro breakpoint(call_expr, args...)
         end
         args = Base.tail(args)
     end
-    condexpr = condition === nothing ? nothing : esc(Expr(:quote, condition))
+    # Pair the condition with the macro caller's module so it is evaluated with
+    # that module's bindings (see `_unpack`), not in `Main`.
+    condexpr = condition === nothing ? nothing :
+        Expr(:tuple, __module__, esc(Expr(:quote, condition)))
     if haveline
         return quote
             local method = $whichexpr

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -197,12 +197,21 @@ function breakpoint(file::AbstractString, line::Integer, condition::Condition=no
     return bp
 end
 
+# Like `endswith`, but the match must begin at a path-component boundary, so that
+# a breakpoint on "foo.jl" does not match "notfoo.jl".
+function endswith_at_pathsep(filepath::AbstractString, path::AbstractString)
+    endswith(filepath, path) || return false
+    nprefix = ncodeunits(filepath) - ncodeunits(path)
+    nprefix == 0 && return true
+    return codeunit(filepath, nprefix) in (UInt8('/'), UInt8('\\'))
+end
+
 function add_breakpoint_if_match!(framecode::FrameCode, bp::BreakpointFileLocation)
     framecode_contains_file = false
     matching_file = nothing
     for file in framecode.unique_files
         filepath = CodeTracking.maybe_fix_path(String(file))
-        if Base.samefile(bp.abspath, filepath) || endswith(filepath, bp.path)
+        if Base.samefile(bp.abspath, filepath) || endswith_at_pathsep(filepath, bp.path)
             framecode_contains_file = true
             matching_file = file
             break

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -152,6 +152,10 @@ function breakpoint(f::Union{Method, Callable}, sig=nothing, line::Integer=0, co
         push!(_breakpoints, bp)
     else  #Replace existing breakpoint
         old_bp = _breakpoints[idx]
+        # Detach the replaced handle: its instances point at the same statement slots the
+        # new breakpoint just (re)installed, so e.g. `disable(old_bp)` must not keep
+        # controlling the replacement.
+        empty!(old_bp.instances)
         _breakpoints[idx] = bp
         firehooks(remove, old_bp)
     end
@@ -185,6 +189,7 @@ function breakpoint(file::AbstractString, line::Integer, condition::Condition=no
         push!(_breakpoints, bp)
     else  # replace existing breakpoint
         old_bp = _breakpoints[idx]
+        empty!(old_bp.instances)  # see the note in the method-breakpoint path above
         _breakpoints[idx] = bp
         firehooks(remove, old_bp)
     end

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -58,13 +58,21 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
 
     if f isa Core.OpaqueClosure
         if expand
-            if !Base.uncompressed_ir(f.source).inferred
-                return Expr(:call, f, args[2:end]...)
-            else
-                @debug "not interpreting opaque closure $f since it contains inferred code"
+            meth = f.source
+            # Don't try to interpret optimized/inferred ir, or closures whose source is
+            # unavailable (e.g. constructed from an `IRCode`); call those natively below.
+            if isa(meth, Method) && (isdefined(meth, :source) || isdefined(meth, :generator))
+                src = Base.uncompressed_ir(meth)
+                isinferred = hasfield(Core.CodeInfo, :inferred) ? src.inferred :
+                    !isa(src.ssavaluetypes, Int)  # inferred code has a type vector here
+                if !isinferred
+                    return Expr(:call, f, args[2:end]...)
+                else
+                    @debug "not interpreting opaque closure $f since it contains inferred code"
+                end
             end
         end
-        return Some{Any}(f(args...))
+        return Some{Any}(f(getargs(interp, args, frame)...))
     end
     if !(supertype(typeof(f)) === Core.Builtin || isa(f, Core.IntrinsicFunction))
         return call_expr

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -518,7 +518,9 @@ function debug_command(interp::Interpreter, frame::Frame, cmd::Symbol, rootistop
         cmd === :until && return maybe_reset_frame!(interp, frame, until_line!(interp, frame, line, istoplevel), rootistoplevel)
         if cmd === :sl
             while more_calls_on_current_line(frame)
-                next_call!(interp, frame, istoplevel)
+                pc = next_call!(interp, frame, istoplevel)
+                (pc === nothing || isa(pc, BreakpointRef)) &&
+                    return maybe_reset_frame!(interp, frame, pc, rootistoplevel)
             end
             return debug_command(interp, frame, :s, rootistoplevel; line)
         end

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -525,7 +525,9 @@ function debug_command(interp::Interpreter, frame::Frame, cmd::Symbol, rootistop
             return debug_command(interp, frame, :s, rootistoplevel; line)
         end
         if cmd === :sr
-            maybe_next_until!(frame::Frame -> is_return(pc_expr(frame)), interp, frame, istoplevel)
+            pc = maybe_next_until!(frame::Frame -> is_return(pc_expr(frame)), interp, frame, istoplevel)
+            (pc === nothing || isa(pc, BreakpointRef)) &&
+                return maybe_reset_frame!(interp, frame, pc, rootistoplevel)
             return frame, frame.pc
         end
         enter_generated = false

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -383,9 +383,16 @@ function prepare_call(@nospecialize(f), allargs;
     argtypes = Tuple{argtypesv...}
     if f isa Core.OpaqueClosure
         method = f.source
-        # don't try to interpret optimized ir
+        # Don't try to interpret closures whose source is unavailable (e.g. constructed
+        # from an `IRCode`) ...
+        if !(isa(method, Method) && (isdefined(method, :source) || isdefined(method, :generator)))
+            return nothing
+        end
+        # ... or optimized/inferred ir
         src = Base.uncompressed_ir(method)
-        if hasfield(CodeInfo, :inferred) && src.inferred   # xref https://github.com/JuliaLang/julia/pull/53219
+        isinferred = hasfield(CodeInfo, :inferred) ? src.inferred :   # xref https://github.com/JuliaLang/julia/pull/53219
+            !isa(src.ssavaluetypes, Int)  # inferred code has a type vector here
+        if isinferred
             @debug "not interpreting opaque closure $f since it contains inferred code"
             return nothing
         end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -697,12 +697,11 @@ function Base.iterate(iter::ExprSplitter, state=nothing)
         end
     end
     if ex.head === :block || ex.head === :toplevel
-        # This was a block that we couldn't safely descend into (issue #427)
-        if !isempty(iter.index) && iter.index[end] > length(iter.stack[end][2].args)
-            pop!(iter.stack)
-            pop!(iter.index)
-            queuenext!(iter)
-        end
+        # This was a block that we couldn't safely descend into (issue #427).
+        # Queue the parent container's next statement (`queuenext!` pops exhausted
+        # containers itself); failing to do so would re-yield the parent wholesale,
+        # evaluating the already-returned statements a second time.
+        queuenext!(iter)
         return (mod, ex), nothing
     end
     queuenext!(iter)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -762,7 +762,12 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
         elseif isa(node, ReturnNode)
             return nothing
         elseif isa(node, NewvarNode)
-            # FIXME: undefine the slot?
+            # A `NewvarNode` marks the (re-)entry of a variable's scope: the slot must be
+            # reset to undefined, e.g. so a value from a previous loop iteration does not
+            # remain visible (native code would throw `UndefVarError`).
+            id = node.slot.id
+            data.locals[id] = nothing
+            data.last_reference[id] = 0
         elseif istoplevel && isa(node, LineNumberNode)
         elseif istoplevel && isa(node, Symbol)
             rhs = invoke_in_world(frame.world, getfield, moduleof(frame), node)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -318,9 +318,21 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
         throw(err)
     end
     if fargs[1] === Core.invoke # invoke needs special handling
-        f_invoked = which(fargs[2], fargs[3])::Method
+        argtypes = fargs[3]
         fargs_pruned = [fargs[2]; fargs[4:end]]
         sig = Tuple{mapany(_Typeof, fargs_pruned)...}
+        if isa(argtypes, Method)
+            # `invoke(f, method::Method, args...)` (Julia 1.12+)
+            f_invoked = argtypes
+            # An inapplicable method is an error; defer to the native `invoke` to raise it.
+            sig <: f_invoked.sig || return invoke(fargs[2:end]...)
+        elseif isa(argtypes, Core.CodeInstance)
+            # `invoke(f, ci::CodeInstance, args...)` requests that specific compiled code:
+            # run it natively.
+            return invoke(fargs[2:end]...)
+        else
+            f_invoked = which(fargs[2], argtypes)::Method
+        end
         ret = prepare_framecode(f_invoked, sig; enter_generated, world=frame.world)
         isa(ret, Compiled) && return invoke(fargs[2:end]...)
         @assert ret !== nothing

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -200,7 +200,15 @@ function evaluate_foreigncall(interp::Interpreter, frame::Frame, call_expr::Expr
     args = collect_args(interp, frame, call_expr; isfc = head === :foreigncall)
     for i = 2:length(args)
         arg = args[i]
-        args[i] = isa(arg, Symbol) ? QuoteNode(arg) : arg
+        if head === :foreigncall && i >= 6
+            # args[2:5] are metadata (return type, argument types, nreq, calling convention);
+            # args[6:end] are the evaluated argument values (plus GC roots). The rebuilt
+            # expression is passed to `Core.eval`, which re-evaluates raw `Expr`/`Symbol`/
+            # `QuoteNode`/`GlobalRef` values as code, so quote every value unconditionally.
+            args[i] = QuoteNode(arg)
+        else
+            args[i] = isa(arg, Symbol) ? QuoteNode(arg) : arg
+        end
     end
     head === :cfunction && (args[2] = QuoteNode(args[2]))
     if head === :foreigncall && !isa(args[5], QuoteNode)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -309,7 +309,12 @@ function build_compiled_foreigncall!(stmt::Expr, code::CodeInfo, sparams::Vector
     end
     args = stmt.args[6:end]
     # When the ccall is dynamic we pass the pointer as an argument so can reuse the function
-    cc_key = ((dynamic_ccall ? :ptr : @something(cfunc_resolved, cfunc)), RetType, ArgType, evalmod, length(sparams), length(args))  # compiled call key
+    # `stmt.args[4]` (nreq) and `stmt.args[5]` (calling convention, including e.g. the
+    # `gc_safe` flag) are baked into the wrapper body, so they must be part of the key:
+    # otherwise two ccalls to the same function differing only in those would share
+    # whichever wrapper was built first.
+    cc_key = ((dynamic_ccall ? :ptr : @something(cfunc_resolved, cfunc)), RetType, ArgType,
+              evalmod, length(sparams), length(args), stmt.args[4], stmt.args[5])  # compiled call key
     f = get(compiled_calls, cc_key, nothing)
     if f === nothing
         ArgType = Expr(:tuple, Any[parametric_type_to_expr(t) for t in ArgType::SimpleVector]...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -765,8 +765,6 @@ end
 function eval_code(frame::Frame, expr::Expr)
     code = frame.framecode
     data = frame.framedata
-    isexpr(expr, :toplevel) && (expr = expr.args[end])
-
     if isexpr(expr, :toplevel)
         expr = Expr(:block, expr.args...)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -757,6 +757,17 @@ function extract_usage!(s::Set{Symbol}, @nospecialize expr)
     return s
 end
 
+function flatten_toplevel!(args::Vector{Any}, @nospecialize(ex))
+    if isexpr(ex, :toplevel)
+        for a in (ex::Expr).args
+            flatten_toplevel!(args, a)
+        end
+    else
+        push!(args, ex)
+    end
+    return args
+end
+
 function eval_code(frame::Frame, command::AbstractString)
     expr = Base.parse_input_line(command)
     expr === nothing && return nothing
@@ -766,7 +777,10 @@ function eval_code(frame::Frame, expr::Expr)
     code = frame.framecode
     data = frame.framedata
     if isexpr(expr, :toplevel)
-        expr = Expr(:block, expr.args...)
+        # Flatten (possibly nested) `:toplevel` wrappers into a single block:
+        # `parse_input_line` wraps multi-statement input in a nested `:toplevel`, and an
+        # embedded `:toplevel` cannot be lowered inside the `let` built below.
+        expr = Expr(:block, flatten_toplevel!(Any[], expr)...)
     end
 
     used_symbols = Set{Symbol}((Symbol("#self#"),))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -788,11 +788,13 @@ function eval_code(frame::Frame, expr::Expr)
             Expr(:tuple, res, Expr(:tuple, [v.name for v in vars]...))
         ))
     eval_res, res = Core.eval(moduleof(frame), eval_expr)
-    j = 1
     for (i, v) in enumerate(vars)
         if v.isparam
-            data.sparams[j] = res[i]
-            j += 1
+            # `vars` only holds the variables used by `expr`, so look the static parameter
+            # up by name; a running counter would write into the wrong slot whenever an
+            # earlier sparam is not referenced.
+            j = findfirst(==(v.name), sparam_syms(code.scope::Method))
+            j === nothing || (data.sparams[j] = res[i])
         elseif v.is_captured_closure
             selfidx = findfirst(v -> v.name === Symbol("#self#"), vars)
             @assert selfidx !== nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -809,7 +809,14 @@ function eval_code(frame::Frame, expr::Expr)
             idx = argmax(data.last_reference[slot_indices])
             slot_idx = slot_indices[idx]
             data.last_reference[slot_idx] = (frame.assignment_counter += 1)
-            data.locals[slot_idx] = Some{Any}(v.value isa Core.Box ? Core.Box(res[i]) : res[i])
+            if v.value isa Core.Box
+                # Mutate the existing Box in place: closures that captured the variable
+                # hold a reference to this same Box and must observe the new value.
+                v.value.contents = res[i]
+                data.locals[slot_idx] = Some{Any}(v.value)
+            else
+                data.locals[slot_idx] = Some{Any}(res[i])
+            end
         end
     end
     eval_res

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -679,3 +679,14 @@ end
     remove()
     @test !JuliaInterpreter.shouldbreak(fr, fr.pc)
 end
+
+@testset "Function breakpoints tolerate non-Type signature parameters" begin
+    remove()
+    oc_bp = Base.Experimental.@opaque x -> x + 1
+    oc_bp_wrap(f, x) = f(x)
+    @interpret oc_bp_wrap(oc_bp, 1)  # caches a framecode whose method signature holds a bare Vararg
+    nontype_sig_f(x) = x
+    bp = breakpoint(nontype_sig_f)   # must not throw while scanning cached framecodes
+    @test bp isa JuliaInterpreter.BreakpointSignature
+    remove()
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -710,3 +710,16 @@ end
         remove()
     end
 end
+
+@testset "@breakpoint conditions see the caller module's globals" begin
+    remove()
+    @eval module BreakpointCondModule
+    using JuliaInterpreter
+    const LIMIT = 0
+    f(x) = x
+    const bp = @breakpoint f(1) x > LIMIT
+    end
+    ret = @interpret BreakpointCondModule.f(1)
+    @test ret isa Tuple && ret[2] isa JuliaInterpreter.BreakpointRef
+    remove()
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -723,3 +723,14 @@ end
     @test ret isa Tuple && ret[2] isa JuliaInterpreter.BreakpointRef
     remove()
 end
+
+@testset "Breakpoints reach cached generated-function framecodes" begin
+    remove()
+    @generated genbp(x) = :(x + 1)
+    fr = JuliaInterpreter.enter_call(genbp, 1)  # warms genframedict
+    JuliaInterpreter.finish_and_return!(fr)
+    breakpoint(genbp)
+    ret = @interpret genbp(1)
+    @test ret isa Tuple && ret[2] isa JuliaInterpreter.BreakpointRef
+    remove()
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -734,3 +734,12 @@ end
     @test ret isa Tuple && ret[2] isa JuliaInterpreter.BreakpointRef
     remove()
 end
+
+@testset "Conditions tolerate unbound static parameters" begin
+    remove()
+    unbound_sparam(x::T) where {T,S} = x
+    breakpoint(unbound_sparam, :(1 == 1))
+    fr = JuliaInterpreter.enter_call(unbound_sparam, 1)
+    @test JuliaInterpreter.shouldbreak(fr, fr.pc)
+    remove()
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -743,3 +743,15 @@ end
     @test JuliaInterpreter.shouldbreak(fr, fr.pc)
     remove()
 end
+
+@testset "A replaced breakpoint handle no longer controls the replacement" begin
+    remove()
+    replaced_bp_f(x) = x
+    fr = JuliaInterpreter.enter_call(replaced_bp_f, 1)
+    oldbp = breakpoint(replaced_bp_f)
+    newbp = breakpoint(replaced_bp_f)
+    disable(oldbp)
+    @test newbp.enabled[]
+    @test JuliaInterpreter.shouldbreak(fr, fr.pc)
+    remove()
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -690,3 +690,23 @@ end
     @test bp isa JuliaInterpreter.BreakpointSignature
     remove()
 end
+
+@testset "Replacement and remove-all fire remove hooks" begin
+    remove()
+    events = []
+    hook = (f, bp) -> push!(events, nameof(f))
+    JuliaInterpreter.on_breakpoints_updated(hook)
+    try
+        hookfire(x) = x
+        JuliaInterpreter.enter_call(hookfire, 1)
+        breakpoint(hookfire)
+        breakpoint(hookfire)    # replacement must fire a remove for the old handle
+        @test count(==(:remove), events) == 1
+        empty!(events)
+        remove()                # remove-all must fire remove hooks
+        @test count(==(:remove), events) == 1
+    finally
+        filter!(!=(hook), JuliaInterpreter.breakpoint_update_hooks)
+        remove()
+    end
+end

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -755,3 +755,17 @@ end
     @test JuliaInterpreter.shouldbreak(fr, fr.pc)
     remove()
 end
+
+@testset "File suffix matching respects path-component boundaries" begin
+    @test JuliaInterpreter.endswith_at_pathsep("/a/b/foo.jl", "foo.jl")
+    @test JuliaInterpreter.endswith_at_pathsep("/a/b/foo.jl", "b/foo.jl")
+    @test JuliaInterpreter.endswith_at_pathsep("foo.jl", "foo.jl")
+    @test !JuliaInterpreter.endswith_at_pathsep("/a/notfoo.jl", "foo.jl")
+    @test !JuliaInterpreter.endswith_at_pathsep("/a/xb/foo.jl", "b/foo.jl")
+    remove()
+    Base.include_string(@__MODULE__, "suffix_bp_f() = 1", "/tmp/not_target_file.jl")
+    JuliaInterpreter.enter_call(suffix_bp_f)  # cache the framecode
+    bp = breakpoint("target_file.jl", 1)
+    @test isempty(bp.instances)
+    remove()
+end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -677,3 +677,14 @@ end
     @test ret isa Tuple && ret[2] isa BreakpointRef
     remove()
 end
+
+@testset ":sr reports breakpoints in callees" begin
+    remove()
+    sr_callee(x) = x + 1
+    sr_caller(x) = (y = sr_callee(x); y * 2)
+    breakpoint(sr_callee)
+    fr = enter_call(sr_caller, 3)
+    ret = JuliaInterpreter.debug_command(fr, :sr)
+    @test ret isa Tuple && ret[2] isa BreakpointRef
+    remove()
+end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -665,3 +665,15 @@ end
     ret = JuliaInterpreter.debug_command(fr, :until, true)
     @test ret === nothing || ret isa Tuple
 end
+
+@testset ":sl reports breakpoints in callees" begin
+    remove()
+    sl_callee(x) = x + 1
+    sl_other(x) = x * 2
+    sl_caller(x) = sl_other(sl_callee(x))
+    breakpoint(sl_callee)
+    fr = enter_call(sl_caller, 3)
+    ret = JuliaInterpreter.debug_command(fr, :sl)
+    @test ret isa Tuple && ret[2] isa BreakpointRef
+    remove()
+end

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -149,3 +149,7 @@ toplevel_eval_arg(x) = x
 frame = JuliaInterpreter.enter_call(toplevel_eval_arg, 1)
 @test eval_code(frame, Expr(:toplevel, :(x = 5), :(x + 1))) == 6
 @test only(filter(v -> v.name === :x, JuliaInterpreter.locals(frame))).value == 5
+
+# Multi-statement strings arrive as a nested :toplevel from parse_input_line
+frame = JuliaInterpreter.enter_call(toplevel_eval_arg, 1)
+@test eval_code(frame, "x = 7; x + 1") == 8

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -143,3 +143,9 @@ while !any(v -> v.name === :getx, JuliaInterpreter.locals(frame))
 end
 eval_code(frame, "x = 42")
 @test JuliaInterpreter.finish_and_return!(frame) == 42
+
+# eval_code evaluates every form of a toplevel expression
+toplevel_eval_arg(x) = x
+frame = JuliaInterpreter.enter_call(toplevel_eval_arg, 1)
+@test eval_code(frame, Expr(:toplevel, :(x = 5), :(x + 1))) == 6
+@test only(filter(v -> v.name === :x, JuliaInterpreter.locals(frame))).value == 5

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -123,3 +123,9 @@ frame = JuliaInterpreter.enter_call(empty_code, 1)
 @test eval_code(frame, "") === nothing
 @test eval_code(frame, " ") === nothing
 @test eval_code(frame, "\n") === nothing
+
+# Static parameters are written back to the right slots when only some are requested
+sparam_slots(x::T, y::S) where {T,S} = (x, y)
+frame = JuliaInterpreter.enter_call(sparam_slots, 1, 2.0)
+eval_code(frame, "S")
+@test frame.framedata.sparams == Any[Int, Float64]  # Int, not Int64: CI runs 32-bit too

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -129,3 +129,17 @@ sparam_slots(x::T, y::S) where {T,S} = (x, y)
 frame = JuliaInterpreter.enter_call(sparam_slots, 1, 2.0)
 eval_code(frame, "S")
 @test frame.framedata.sparams == Any[Int, Float64]  # Int, not Int64: CI runs 32-bit too
+
+# eval_code mutates a captured Core.Box in place
+function box_capture()
+    x = 1
+    setx = () -> (x = 99)
+    getx = () -> x
+    return getx()
+end
+frame = JuliaInterpreter.enter_call(box_capture)
+while !any(v -> v.name === :getx, JuliaInterpreter.locals(frame))
+    JuliaInterpreter.step_expr!(frame)
+end
+eval_code(frame, "x = 42")
+@test JuliaInterpreter.finish_and_return!(frame) == 42

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1381,3 +1381,16 @@ end
     @test (@interpret invoke_by_method_wrap(invoke_by_method, m, 1)) == 2
 end
 end
+
+@testset "NewvarNode undefines a reused slot" begin
+    function newvar_reuse(flags)
+        out = Bool[]
+        for flag in flags
+            flag && (x = 1)
+            push!(out, @isdefined(x))
+        end
+        out
+    end
+    fr = JuliaInterpreter.enter_call(newvar_reuse, [true, false])
+    @test finish_and_return!(fr) == newvar_reuse([true, false]) == [true, false]
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1366,3 +1366,9 @@ end
     JuliaInterpreter.determine_method_for_expr(ex)
     @test ex == before
 end
+
+@testset "Foreigncall values that look like ASTs are passed as data" begin
+    astval = :(1 + 2)
+    frame = Frame(Main, :(ccall(:jl_typeof, Any, (Any,), $(QuoteNode(astval)))))
+    @test finish_and_return!(frame, true) === Expr
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1394,3 +1394,10 @@ end
     fr = JuliaInterpreter.enter_call(newvar_reuse, [true, false])
     @test finish_and_return!(fr) == newvar_reuse([true, false]) == [true, false]
 end
+
+@testset "Nested OpaqueClosure calls" begin
+    oc = Base.Experimental.@opaque (x, y) -> x + y
+    oc_wrapper(f, x, y) = f(x, y)
+    @test (@interpret oc_wrapper(oc, 1, 2)) == 3
+    @test (@interpret interp=NonRecursiveInterpreter() oc_wrapper(oc, 1, 2)) == 3
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1372,3 +1372,12 @@ end
     frame = Frame(Main, :(ccall(:jl_typeof, Any, (Any,), $(QuoteNode(astval)))))
     @test finish_and_return!(frame, true) === Expr
 end
+
+@static if VERSION >= v"1.12-"
+@testset "invoke(f, ::Method, args...)" begin
+    invoke_by_method(x::Real) = x + 1
+    m = only(methods(invoke_by_method))
+    invoke_by_method_wrap(f, m, x) = invoke(f, m, x)
+    @test (@interpret invoke_by_method_wrap(invoke_by_method, m, 1)) == 2
+end
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1401,3 +1401,15 @@ end
     @test (@interpret oc_wrapper(oc, 1, 2)) == 3
     @test (@interpret interp=NonRecursiveInterpreter() oc_wrapper(oc, 1, 2)) == 3
 end
+
+@static if VERSION >= v"1.12-"
+@testset "Calling convention is part of the compiled-ccall wrapper key" begin
+    ccall_plain() = @ccall jl_gc_safepoint()::Cvoid
+    ccall_gcsafe() = @ccall gc_safe=true jl_gc_safepoint()::Cvoid
+    @interpret ccall_plain()
+    @interpret ccall_gcsafe()
+    ccs = [k for k in keys(JuliaInterpreter.compiled_calls) if occursin("jl_gc_safepoint", string(k[1]))]
+    # the two ccalls differ only in the calling-convention field and must not share a wrapper
+    @test length(unique(last.(ccs))) >= 2
+end
+end

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -881,3 +881,18 @@ end
     ex = Expr(:toplevel, Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), nothing, "docstr", :(split_nolineinfo() = 1)))
     @test length(collect(ExprSplitter(@__MODULE__, ex))) == 1
 end
+
+@testset "ExprSplitter executes an unsplittable block exactly once" begin
+    hits = Ref(0)
+    ex = quote
+        begin
+            local t = 1
+            $hits[] += t
+        end
+        split_once_after() = 2
+    end
+    for (mod, e) in ExprSplitter(@__MODULE__, ex)
+        JuliaInterpreter.finish_and_return!(Frame(mod, e), true)
+    end
+    @test hits[] == 1
+end


### PR DESCRIPTION
Second of three PRs splitting #750 by review difficulty. These fixes require understanding the surrounding machinery (lowered-IR handling, framecode caching, the breakpoint registry, ExprSplitter) to see the bug, but the defects are still localized.

Each fix commit carries its own regression test in the logical test file.

**eval_code**
- Fix `eval_code` writing static parameters back to the wrong slots
- Mutate captured `Core.Box` in place in `eval_code`
- Evaluate every form of a toplevel expression in `eval_code`
- Flatten nested `:toplevel` expressions in `eval_code`

**Interpreter / FFI / calls**
- Quote foreigncall value arguments before `Core.eval` of the rebuilt expression
- Include nreq and calling convention in the compiled-ccall wrapper cache key
- Support `invoke(f, ::Method, args...)` and `invoke(f, ::CodeInstance, args...)`
- Undefine the slot when interpreting a `NewvarNode`
- Fix `Core.OpaqueClosure` calls in the interpreter
- Guard `framecode_matches_breakpoint` against non-Type signature parameters

**ExprSplitter**
- Fix ExprSplitter re-yielding the parent block after an unsplittable scope-block

**Breakpoints**
- Fire remove hooks when replacing a file breakpoint and in remove-all
- Evaluate `@breakpoint` conditions in the macro caller's module
- Apply breakpoints to cached generated-function framecodes
- Guard unbound static parameters in breakpoint condition functions
- Detach replaced breakpoint handles from the installed statement states
- Match file-breakpoint suffixes only at path-component boundaries

**debug_command**
- Handle termination and breakpoints in the `:sl` pre-stepping loop
- Report breakpoints hit in callees during `:sr`

Companion PRs: easy and hard tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

