### PR TITLE
Bug fixes: subtle semantic defects (hard tier)

### DIFF
--- a/bin/generate_builtins.jl
+++ b/bin/generate_builtins.jl
@@ -40,9 +40,8 @@ const RECENTLY_REMOVED = GlobalRef.(Ref(Core), [
     :_apply_pure, :_call_in_world, :_call_latest, :_defaultctors,
 ])
 const kwinvoke = Core.kwfunc(Core.invoke)
-# Builtins whose result depends on the world age (binding resolution): they must run in
-# `frame.world` rather than the interpreter's ambient world. Every entry here takes a `Module`
-# as its first argument, so the dependence is unconditional.
+# Builtins whose result depends on the world age (binding or method resolution): they must
+# run in `frame.world` rather than the interpreter's ambient world.
 const REQUIRES_WORLD = Core.Builtin[
     getglobal,
     isdefinedglobal,
@@ -52,6 +51,7 @@ const REQUIRES_WORLD = Core.Builtin[
     modifyglobal!,
     replaceglobal!,
     setglobalonce!,
+    applicable,
 ]
 const CALL_LATEST = """args = getargs(interp, args, frame)
         if !expand

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -287,7 +287,7 @@ function maybe_evaluate_builtin(interp::Interpreter, frame::Frame, call_expr::Ex
     elseif @static isdefinedglobal(Core, :throw_methoderror) && f === Core.throw_methoderror
         return Some{Any}(Core.throw_methoderror(getargs(interp, args, frame)...))
     elseif f === applicable
-        return Some{Any}(applicable(getargs(interp, args, frame)...))
+        return Some{Any}(Base.invoke_in_world(frame.world, applicable, getargs(interp, args, frame)...))
     elseif f === fieldtype
         if nargs == 2
             return Some{Any}(fieldtype(lookup(interp, frame, args[2]), lookup(interp, frame, args[3]))::Type)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -431,8 +431,13 @@ function unwind_exception(frame::Frame, @nospecialize(exc))
         if !isempty(frame.framedata.exception_frames)
             # Exception caught
             @assert is_leaf(frame)
-            frame.pc = frame.framedata.exception_frames[end]
-            frame.framedata.last_exception[] = exc
+            data = frame.framedata
+            # Restore the scope stack to its depth when the handler was entered (see
+            # `handle_err`).
+            scope_depth = data.exception_scopes[end]
+            scope_depth < length(data.current_scopes) && resize!(data.current_scopes, scope_depth)
+            frame.pc = data.exception_frames[end]
+            data.last_exception[] = exc
             return frame
         end
         frame = return_from(frame)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -429,15 +429,11 @@ maybe_reset_frame!(frame::Frame, @nospecialize(pc), rootistoplevel::Bool) =
 function unwind_exception(frame::Frame, @nospecialize(exc))
     while frame !== nothing
         if !isempty(frame.framedata.exception_frames)
-            # Exception caught
+            # Exception caught: land in the handler with the same state updates as
+            # `handle_err` (scope restore, handler pop, exception-stack push), so the
+            # handler cannot be reused for a later exception outside its `try`.
             @assert is_leaf(frame)
-            data = frame.framedata
-            # Restore the scope stack to its depth when the handler was entered (see
-            # `handle_err`).
-            scope_depth = data.exception_scopes[end]
-            scope_depth < length(data.current_scopes) && resize!(data.current_scopes, scope_depth)
-            frame.pc = data.exception_frames[end]
-            data.last_exception[] = exc
+            frame.pc = enter_exception_handler!(frame.framedata, exc)
             return frame
         end
         frame = return_from(frame)

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -907,7 +907,14 @@ function interpret(mod::Module, @nospecialize(ex0); interp=RecursiveInterpreter(
         local theargs = $theargs
         local frame = $entercall
         if frame === nothing
-            eval(Expr(:call, map(QuoteNode, theargs)...))
+            # Call the (already-resolved) function directly rather than through `Core.eval`:
+            # `eval` would run the call in the latest world, changing the semantics of an
+            # invocation issued from an older task world or an explicitly requested world.
+            if w === nothing
+                theargs[1](theargs[2:end]...)
+            else
+                Base.invoke_in_world(w, theargs[1], theargs[2:end]...)
+            end
         elseif shouldbreak(frame, 1)
             frame, BreakpointRef(frame.framecode, 1)
         else

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -426,7 +426,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         olddata = pop!(junk_framedata)
         locals, ssavalues, sparams = olddata.locals, olddata.ssavalues, olddata.sparams
         exception_frames, current_scopes, last_reference = olddata.exception_frames, olddata.current_scopes, olddata.last_reference
-        exception_scopes = olddata.exception_scopes
+        exception_scopes, exceptions = olddata.exception_scopes, olddata.exceptions
         last_exception = olddata.last_exception
         callargs = olddata.callargs
         resize!(locals, ns)
@@ -437,6 +437,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         resize!(sparams, 0)
         empty!(exception_frames)
         empty!(exception_scopes)
+        empty!(exceptions)
         empty!(current_scopes)
         resize!(last_reference, ns)
         last_exception[] = _INACTIVE_EXCEPTION.instance
@@ -446,6 +447,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         sparams = Vector{Any}(undef, 0)
         exception_frames = Int[]
         exception_scopes = Int[]
+        exceptions = Any[]
         current_scopes = Scope[]
         last_reference = Vector{Int}(undef, ns)
         callargs = Any[]
@@ -489,7 +491,8 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         sparams[i] = T
     end
     return FrameData(locals, ssavalues, sparams, exception_frames, exception_scopes,
-                     current_scopes, last_exception, caller_will_catch_err, last_reference, callargs)
+                     exceptions, current_scopes, last_exception, caller_will_catch_err,
+                     last_reference, callargs)
 end
 
 """

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -426,6 +426,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         olddata = pop!(junk_framedata)
         locals, ssavalues, sparams = olddata.locals, olddata.ssavalues, olddata.sparams
         exception_frames, current_scopes, last_reference = olddata.exception_frames, olddata.current_scopes, olddata.last_reference
+        exception_scopes = olddata.exception_scopes
         last_exception = olddata.last_exception
         callargs = olddata.callargs
         resize!(locals, ns)
@@ -435,6 +436,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         # for check_isdefined to work properly, we need sparams to start out unassigned
         resize!(sparams, 0)
         empty!(exception_frames)
+        empty!(exception_scopes)
         empty!(current_scopes)
         resize!(last_reference, ns)
         last_exception[] = _INACTIVE_EXCEPTION.instance
@@ -443,6 +445,7 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         ssavalues = Vector{Any}(undef, ng)
         sparams = Vector{Any}(undef, 0)
         exception_frames = Int[]
+        exception_scopes = Int[]
         current_scopes = Scope[]
         last_reference = Vector{Int}(undef, ns)
         callargs = Any[]
@@ -485,8 +488,8 @@ function prepare_framedata(framecode, argvals::Vector{Any}, lenv::SimpleVector=e
         end
         sparams[i] = T
     end
-    return FrameData(locals, ssavalues, sparams, exception_frames, current_scopes,
-                     last_exception, caller_will_catch_err, last_reference, callargs)
+    return FrameData(locals, ssavalues, sparams, exception_frames, exception_scopes,
+                     current_scopes, last_exception, caller_will_catch_err, last_reference, callargs)
 end
 
 """

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -314,8 +314,19 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
     if fargs[1] === Core.eval
         return Core.eval(fargs[2], fargs[3])  # not a builtin, but worth treating specially
     elseif fargs[1] === Base.rethrow
-        err = length(fargs) > 1 ? fargs[2] : frame.framedata.last_exception[]
-        throw(err)
+        length(fargs) > 1 && throw(fargs[2])
+        # `rethrow()` rethrows the task's innermost exception being handled, which may live
+        # in a caller's frame when it is reached from a function called inside a `catch`
+        # block. Each frame records only its own caught exception, so walk the caller chain.
+        fr = frame
+        while fr !== nothing
+            err = fr.framedata.last_exception[]
+            isa(err, _INACTIVE_EXCEPTION) || throw(err)
+            fr = fr.caller
+        end
+        # No interpreted frame is handling an exception; fall back to the native rethrow
+        # (interpreted code may be running inside a native `catch` block).
+        rethrow()
     end
     if fargs[1] === Core.invoke # invoke needs special handling
         argtypes = fargs[3]

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -317,11 +317,12 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
         length(fargs) > 1 && throw(fargs[2])
         # `rethrow()` rethrows the task's innermost exception being handled, which may live
         # in a caller's frame when it is reached from a function called inside a `catch`
-        # block. Each frame records only its own caught exception, so walk the caller chain.
+        # block. Each frame tracks its own active-exception stack, so walk the caller chain
+        # for the innermost frame with a nonempty stack.
         fr = frame
         while fr !== nothing
-            err = fr.framedata.last_exception[]
-            isa(err, _INACTIVE_EXCEPTION) || throw(err)
+            exs = fr.framedata.exceptions
+            isempty(exs) || throw(exs[end])
             fr = fr.caller
         end
         # No interpreted frame is handling an exception; fall back to the native rethrow
@@ -688,9 +689,11 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
                 isa(rhs, BreakpointRef) && return rhs
                 do_assignment!(frame, lhs, rhs)
             elseif node.head === :enter
-                rhs = node.args[1]::Int
-                push!(data.exception_frames, rhs)
+                push!(data.exception_frames, node.args[1]::Int)
                 push!(data.exception_scopes, length(data.current_scopes))
+                # The enter's SSA value is the token consumed by `:pop_exception`: the
+                # active-exception stack depth to restore.
+                rhs = length(data.exceptions)
             elseif node.head === :leave
                 if length(node.args) == 1 && isa(node.args[1], Int)
                     arg = node.args[1]::Int
@@ -712,8 +715,15 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
                     end
                 end
             elseif node.head === :pop_exception
-                # TODO: This needs to handle the exception stack properly
-                # (https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/591)
+                # Restore the active-exception stack to its depth at the corresponding
+                # `:enter` (recorded as that statement's SSA value); this runs at the
+                # normal exit of a `catch` block (issue #591).
+                depth = lookup(interp, frame, node.args[1])::Int
+                if depth < length(data.exceptions)
+                    resize!(data.exceptions, depth)
+                    data.last_exception[] = isempty(data.exceptions) ?
+                        _INACTIVE_EXCEPTION.instance : data.exceptions[end]
+                end
             elseif istoplevel
                 # This branch handles `:module`/`:toplevel` reached from a *lowered* `:thunk`.
                 # `step_toplevel!` handles the same heads reached from *unlowered* surface
@@ -789,11 +799,13 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
         elseif istoplevel && isa(node, Symbol)
             rhs = invoke_in_world(frame.world, getfield, moduleof(frame), node)
         elseif @static (isdefinedglobal(Core.IR, :EnterNode) && true) && isa(node, Core.IR.EnterNode)
-            rhs = node.catch_dest
-            push!(data.exception_frames, rhs)
+            push!(data.exception_frames, node.catch_dest)
             # Record the scope depth at handler entry (before any scope introduced by this
             # `EnterNode`), so exception unwinding can restore `current_scopes`.
             push!(data.exception_scopes, length(data.current_scopes))
+            # The enter's SSA value is the token consumed by `:pop_exception`: the
+            # active-exception stack depth to restore.
+            rhs = length(data.exceptions)
             if isdefined(node, :scope)
                 push!(data.current_scopes, lookup(interp, frame, node.scope))
             end
@@ -866,15 +878,25 @@ function handle_err(::Interpreter, frame::Frame, @nospecialize(err))
         end
         rethrow(err)
     end
-    data.last_exception[] = err
-    # Native unwinding restores the scope state saved when the handler was entered
-    # (`jl_eh_restore_state`); mirror that by truncating `current_scopes`.
-    scope_depth = data.exception_scopes[end]
-    scope_depth < length(data.current_scopes) && resize!(data.current_scopes, scope_depth)
-    pc = @static VERSION >= v"1.11-" ? pop!(data.exception_frames) : data.exception_frames[end] # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
-    @static VERSION >= v"1.11-" && pop!(data.exception_scopes)
+    pc = enter_exception_handler!(data, err)
     @assert is_leaf(frame)
     frame.pc = pc
+    return pc
+end
+
+# Land a frame in its innermost active exception handler for `err`: restore the
+# dynamic-scope stack to its depth at handler entry (native `jl_eh_restore_state`),
+# pop the handler (on Julia 1.11+, where lowering no longer emits an explicit `:leave`
+# at the catch entry), record `err` on the frame's active-exception stack, and return
+# the catch-destination pc. Shared by `handle_err` and the debugger's
+# `unwind_exception` so both unwind paths have identical semantics.
+function enter_exception_handler!(data::FrameData, @nospecialize(err))
+    scope_depth = data.exception_scopes[end]
+    scope_depth < length(data.current_scopes) && resize!(data.current_scopes, scope_depth)
+    data.last_exception[] = err
+    push!(data.exceptions, err)
+    pc = @static VERSION >= v"1.11-" ? pop!(data.exception_frames) : data.exception_frames[end] # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
+    @static VERSION >= v"1.11-" && pop!(data.exception_scopes)
     return pc
 end
 

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -342,10 +342,13 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
             # run it natively.
             return invoke(fargs[2:end]...)
         else
-            f_invoked = which(fargs[2], argtypes)::Method
+            # Select the method in the frame's world; plain `which` would use the task's
+            # (possibly newer) world.
+            f_invoked = whichtt(Base.signature_type(fargs[2], argtypes); world=frame.world)
+            f_invoked === nothing && throw(MethodError(fargs[2], argtypes, frame.world))
         end
         ret = prepare_framecode(f_invoked, sig; enter_generated, world=frame.world)
-        isa(ret, Compiled) && return invoke(fargs[2:end]...)
+        isa(ret, Compiled) && return invoke_in_world(frame.world, invoke, fargs[2:end]...)
         @assert ret !== nothing
         framecode, lenv = ret
         lenv === nothing && return framecode  # this was a Builtin

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -687,11 +687,13 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
             elseif node.head === :enter
                 rhs = node.args[1]::Int
                 push!(data.exception_frames, rhs)
+                push!(data.exception_scopes, length(data.current_scopes))
             elseif node.head === :leave
                 if length(node.args) == 1 && isa(node.args[1], Int)
                     arg = node.args[1]::Int
                     for _ = 1:arg
                         pop!(data.exception_frames)
+                        pop!(data.exception_scopes)
                     end
                 else
                     for i = 1:length(node.args)
@@ -700,6 +702,7 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
                         enterstmt = frame.framecode.src.code[(targ::SSAValue).id]
                         enterstmt === nothing && continue
                         pop!(data.exception_frames)
+                        pop!(data.exception_scopes)
                         if isdefined(enterstmt, :scope)
                             pop!(data.current_scopes)
                         end
@@ -785,6 +788,9 @@ function step_expr!(interp::Interpreter, frame::Frame, @nospecialize(node), isto
         elseif @static (isdefinedglobal(Core.IR, :EnterNode) && true) && isa(node, Core.IR.EnterNode)
             rhs = node.catch_dest
             push!(data.exception_frames, rhs)
+            # Record the scope depth at handler entry (before any scope introduced by this
+            # `EnterNode`), so exception unwinding can restore `current_scopes`.
+            push!(data.exception_scopes, length(data.current_scopes))
             if isdefined(node, :scope)
                 push!(data.current_scopes, lookup(interp, frame, node.scope))
             end
@@ -858,7 +864,12 @@ function handle_err(::Interpreter, frame::Frame, @nospecialize(err))
         rethrow(err)
     end
     data.last_exception[] = err
+    # Native unwinding restores the scope state saved when the handler was entered
+    # (`jl_eh_restore_state`); mirror that by truncating `current_scopes`.
+    scope_depth = data.exception_scopes[end]
+    scope_depth < length(data.current_scopes) && resize!(data.current_scopes, scope_depth)
     pc = @static VERSION >= v"1.11-" ? pop!(data.exception_frames) : data.exception_frames[end] # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
+    @static VERSION >= v"1.11-" && pop!(data.exception_scopes)
     @assert is_leaf(frame)
     frame.pc = pc
     return pc

--- a/src/types.jl
+++ b/src/types.jl
@@ -306,6 +306,8 @@ Important fields:
   the value of `T` given the particular input `x`.
 - `exception_frames`: a list of indexes to `catch` blocks for handling exceptions within
   the current frame. The active handler is the last one on the list.
+- `exception_scopes`: parallel to `exception_frames`, the depth of `current_scopes` when
+  each handler was entered, so unwinding an exception can restore the scope stack.
 - `last_exception`: the exception `throw`n by this frame or one of its callees.
 """
 struct FrameData
@@ -313,6 +315,7 @@ struct FrameData
     ssavalues::Vector{Any}
     sparams::Vector{Any}
     exception_frames::Vector{Int}
+    exception_scopes::Vector{Int}
     current_scopes::Vector{Scope}
     last_exception::Base.RefValue{Any}
     caller_will_catch_err::Bool

--- a/src/types.jl
+++ b/src/types.jl
@@ -308,7 +308,11 @@ Important fields:
   the current frame. The active handler is the last one on the list.
 - `exception_scopes`: parallel to `exception_frames`, the depth of `current_scopes` when
   each handler was entered, so unwinding an exception can restore the scope stack.
-- `last_exception`: the exception `throw`n by this frame or one of its callees.
+- `exceptions`: the stack of exceptions currently being handled by this frame (innermost
+  last), mirroring the task's exception stack in native execution. A handler entry pushes;
+  `Expr(:pop_exception, token)` restores the depth recorded at the corresponding `:enter`.
+- `last_exception`: the exception currently being handled by this frame or one of its
+  callees (the top of `exceptions` while nonempty).
 """
 struct FrameData
     locals::Vector{Union{Nothing,Some{Any}}}
@@ -316,6 +320,7 @@ struct FrameData
     sparams::Vector{Any}
     exception_frames::Vector{Int}
     exception_scopes::Vector{Int}
+    exceptions::Vector{Any}
     current_scopes::Vector{Scope}
     last_exception::Base.RefValue{Any}
     caller_will_catch_err::Bool

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -688,3 +688,27 @@ end
     @test ret isa Tuple && ret[2] isa BreakpointRef
     remove()
 end
+
+@testset "Debugger unwinding must not reuse a consumed handler" begin
+    handler_reuse_inner(tag) = error(String(tag))
+    function handler_reuse_outer()
+        n = 0
+        try
+            handler_reuse_inner(:first)
+        catch
+            n += 1
+        end
+        n < 2 && handler_reuse_inner(:second)
+        n
+    end
+    native = try handler_reuse_outer() catch err; err.msg end
+    fr = enter_call(handler_reuse_outer)
+    leaffr, _ = JuliaInterpreter.debug_command(fr, :s)
+    interp = try
+        JuliaInterpreter.debug_command(leaffr, :c)
+        "no throw"
+    catch err
+        (err::ErrorException).msg
+    end
+    @test native == interp == "second"
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1419,3 +1419,14 @@ end
     rethrow_caller() = try; error("boom"); catch; rethrow_callee(); end
     @test_throws ErrorException("boom") finish_and_return!(JuliaInterpreter.enter_call(rethrow_caller))
 end
+
+@testset "applicable respects the frame world" begin
+    @eval module ApplicableWorld
+    function target end
+    probe() = applicable(target, 1)
+    end
+    w = Base.get_world_counter()
+    @eval ApplicableWorld target(::Int) = 1
+    @test Base.invoke_in_world(w, ApplicableWorld.probe) == false
+    @test finish_and_return!(JuliaInterpreter.enter_call(ApplicableWorld.probe; world=w)) == false
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1413,3 +1413,9 @@ end
     @test length(unique(last.(ccs))) >= 2
 end
 end
+
+@testset "rethrow() from a callee of a catch block" begin
+    rethrow_callee() = rethrow()
+    rethrow_caller() = try; error("boom"); catch; rethrow_callee(); end
+    @test_throws ErrorException("boom") finish_and_return!(JuliaInterpreter.enter_call(rethrow_caller))
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1459,3 +1459,32 @@ end
     # the resolved form still works at the current world
     @test finish_and_return!(JuliaInterpreter.enter_call(InvokeWorld.probe, 1)) === :too_new
 end
+
+@testset "pop_exception restores the active-exception stack" begin
+    function nested_rethrow()
+        try
+            error("outer")
+        catch
+            try
+                error("inner")
+            catch
+            end
+            rethrow()
+        end
+    end
+    native = try nested_rethrow() catch err; err.msg end
+    interp = try finish_and_return!(JuliaInterpreter.enter_call(nested_rethrow)) catch err; (err::ErrorException).msg end
+    @test native == interp == "outer"
+
+    # rethrow() from a callee, after an inner catch completed first
+    popexc_callee() = rethrow()
+    function popexc_caller()
+        try
+            error("outer")
+        catch
+            try error("inner") catch end
+            popexc_callee()
+        end
+    end
+    @test_throws ErrorException("outer") finish_and_return!(JuliaInterpreter.enter_call(popexc_caller))
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1430,3 +1430,19 @@ end
     @test Base.invoke_in_world(w, ApplicableWorld.probe) == false
     @test finish_and_return!(JuliaInterpreter.enter_call(ApplicableWorld.probe; world=w)) == false
 end
+
+@testset "@interpret compiled fallback stays in the caller's world" begin
+    @eval world_fallback(::Any) = 1
+    m_fb = which(world_fallback, Tuple{Any})
+    push!(JuliaInterpreter.compiled_methods, m_fb)
+    try
+        function world_fallback_root()
+            @eval world_fallback(::Int) = 2
+            (@interpret(world_fallback(1)), world_fallback(1))
+        end
+        a, b = world_fallback_root()
+        @test a == b
+    finally
+        delete!(JuliaInterpreter.compiled_methods, m_fb)
+    end
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1446,3 +1446,16 @@ end
         delete!(JuliaInterpreter.compiled_methods, m_fb)
     end
 end
+
+@testset "invoke selects its method in the frame world" begin
+    @eval module InvokeWorld
+    function target end
+    probe(x) = invoke(target, Tuple{Real}, x)
+    end
+    w = Base.get_world_counter()
+    @eval InvokeWorld target(::Real) = :too_new
+    @test_throws MethodError Base.invoke_in_world(w, InvokeWorld.probe, 1)
+    @test_throws MethodError finish_and_return!(JuliaInterpreter.enter_call(InvokeWorld.probe, 1; world=w))
+    # the resolved form still works at the current world
+    @test finish_and_return!(JuliaInterpreter.enter_call(InvokeWorld.probe, 1)) === :too_new
+end

--- a/test/interpret_scopedvalues.jl
+++ b/test/interpret_scopedvalues.jl
@@ -61,4 +61,16 @@ let frame = JuliaInterpreter.enter_call(symarg_func)
     @test "abcsym" == @with sval1 => 2 JuliaInterpreter.finish_and_return!(NonRecursiveInterpreter(), frame)
 end
 
+# ScopedValue state must not leak when an exception unwinds out of an @with block
+const sval_leak = ScopedValue(1)
+sval_leak_f() = try
+    @with sval_leak => 2 begin
+        error("boom")
+    end
+catch
+    sval_leak[]
+end
+@test sval_leak_f() == 1
+@test 1 == @interpret sval_leak_f()
+
 end # module interpret_scopedvalues


### PR DESCRIPTION
Third of three PRs splitting #750 by review difficulty. These are the subtle state-semantics bugs: the interpreter's model of the active-exception stack and of world age diverging from native execution.

Each fix commit carries its own regression test in the logical test file.

**Exception-state semantics**
- Make `rethrow()` find the exception being handled in caller frames
- Restore the dynamic-scope stack when an exception unwinds (ScopedValue leakage)
- Model the active-exception stack and implement `:pop_exception`
- Pop the exception handler in debugger unwinding on Julia 1.11+

**World age**
- Pin the `applicable` builtin to the frame's world age
- Run the `@interpret` compiled fallback in the caller's world, not via `eval`
- Select `Core.invoke` methods and run compiled invoke fallbacks in the frame's world

Note: the `Core.invoke` world-age commit here is adapted relative to its #750 counterpart — on this branch it applies to the pre-existing tuple-type `invoke` path, since the `invoke(f, ::Method/::CodeInstance)` form support lives in the intermediate-tier PR. The fix logic (world-aware `whichtt` selection, `invoke_in_world` fallbacks) is the same.

Companion PRs: easy and intermediate tiers.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
