### PR TITLE
Triage plus fixes of open issues

### DIFF
--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -65,6 +65,7 @@ JuliaInterpreter.until_line!
 JuliaInterpreter.maybe_reset_frame!
 JuliaInterpreter.maybe_step_through_wrapper!
 JuliaInterpreter.maybe_step_through_kwprep!
+JuliaInterpreter.maybe_step_through_arg_destructuring!
 JuliaInterpreter.handle_err
 JuliaInterpreter.debug_command
 ```

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -104,10 +104,19 @@ function framecode_matches_breakpoint(framecode::FrameCode, bp::BreakpointSignat
     end
 
     meth = framecode.scope
+    # A breakpoint set on a type should also cover constructor methods that dispatch on a
+    # parameterization of it, e.g. `breakpoint(Constructor)` must fire for
+    # `Constructor{Int}(x)`, whose extracted `f` is `Constructor{T}` (issue #525).
+    function same_typename(@nospecialize(a), @nospecialize(b))
+        a isa Type && b isa Type || return false
+        au, bu = Base.unwrap_unionall(a), Base.unwrap_unionall(b)
+        return au isa DataType && bu isa DataType && au.name === bu.name
+    end
     meth isa Method || return false
     bp.f isa Method && return meth === bp.f
     f = extract_function_from_method(meth)
-    if !(bp.f === f || (f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3]
+    if !(bp.f === f || same_typename(bp.f, f) ||
+            (f === Core.kwcall && let ftype = Base.unwrap_unionall(meth.sig).parameters[3]
                 isa(ftype, Type) && !Base.has_free_typevars(ftype) && bp.f isa ftype
             end))
         return false

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -203,9 +203,27 @@ function _next_line!(interp::Interpreter, frame::Frame, istoplevel, initialline:
     end
     (pc === nothing || isa(pc, BreakpointRef)) && return pc
     maybe_step_through_kwprep!(interp, frame, istoplevel)
-    maybe_next_call!(interp, frame, istoplevel)
+    maybe_next_until!(is_next_line_stop, interp, frame, istoplevel)
 end
 next_line!(frame::Frame, istoplevel::Bool=false) = next_line!(RecursiveInterpreter(), frame, istoplevel)
+
+# `next_line!` should present the line's first interesting statement to the user:
+# a call, a return, or an assignment to a variable the user can see. Without the
+# assignment case, lines consisting only of assignments (e.g. `x = y`) were run
+# through entirely and `n` skipped to a later line (issue Debugger.jl#291, PR #484).
+function is_next_line_stop(frame::Frame)
+    stmt = pc_expr(frame)
+    is_call_or_return(stmt) && return true
+    if isexpr(stmt, :(=))
+        lhs = (stmt::Expr).args[1]
+        if isa(lhs, SlotNumber)
+            # only named slots are user-visible
+            return frame.framecode.src.slotnames[lhs.id] !== Symbol("")
+        end
+        return true # assignment to a global or similar
+    end
+    return false
+end
 
 """
     pc = until_line!(interp::Interpreter, frame, line=nothing istoplevel=false)

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -289,9 +289,70 @@ function maybe_step_through_wrapper!(interp::Interpreter, frame::Frame)
         return maybe_step_through_wrapper!(interp, callee(frame))
     end
     maybe_step_through_nkw_meta!(frame)
+    maybe_step_through_arg_destructuring!(interp, frame)
     return frame
 end
 maybe_step_through_wrapper!(frame::Frame) = maybe_step_through_wrapper!(RecursiveInterpreter(), frame)
+
+function is_indexed_iterate_call(@nospecialize(stmt))
+    isexpr(stmt, :call) || return false
+    f = stmt.args[1]
+    isa(f, QuoteNode) && (f = f.value)
+    isa(f, GlobalRef) && return f.name === :indexed_iterate
+    return f === Base.indexed_iterate
+end
+
+"""
+    frame = maybe_step_through_arg_destructuring!(interp::Interpreter, frame::Frame)
+
+If `frame` is at the start of a method with destructured arguments (e.g.
+`f((a, b), c)`), execute the preamble of `indexed_iterate` statements that binds the
+destructured names, so that the user starts with all arguments assigned (issue #660).
+"""
+function maybe_step_through_arg_destructuring!(interp::Interpreter, frame::Frame)
+    frame.pc == 1 || return frame
+    code = frame.framecode
+    scope = code.scope
+    isa(scope, Method) || return frame
+    src = code.src
+    slotnames = src.slotnames
+    nargs = Int(scope.nargs)
+    nargs <= length(slotnames) || return frame
+    # A destructured argument occupies an unnamed argument slot
+    any(i -> slotnames[i] === Symbol(""), 2:nargs) || return frame
+    stmts = src.code
+    prepssas = BitSet()
+    prepend = 0
+    for (i, stmt) in enumerate(stmts)
+        if is_indexed_iterate_call(stmt)
+            arg1 = (stmt::Expr).args[2]
+            isa(arg1, SlotNumber) && 2 <= arg1.id <= nargs && slotnames[arg1.id] === Symbol("") || break
+        elseif isexpr(stmt, :(=)) && isexpr((stmt::Expr).args[2], :call)
+            # a `slot = getfield(%prep, k)` statement consuming a preamble value
+            rhs = (stmt::Expr).args[2]::Expr
+            g = rhs.args[1]
+            isa(g, QuoteNode) && (g = g.value)
+            (isa(g, GlobalRef) ? g.name === :getfield : g === getfield) || break
+            arg1 = rhs.args[2]
+            isa(arg1, SSAValue) && arg1.id in prepssas || break
+        elseif isa(stmt, SlotNumber) || isa(stmt, SSAValue)
+            # a bare read is preamble only if it feeds the next `indexed_iterate`
+            # (otherwise it is the method body, e.g. `f((a, b)) = a`)
+            i < length(stmts) && is_indexed_iterate_call(stmts[i+1]) || break
+        else
+            break
+        end
+        push!(prepssas, i)
+        prepend = i
+    end
+    prepend == 0 && return frame
+    while frame.pc <= prepend
+        pc = step_expr!(interp, frame, false)
+        isa(pc, Int) || break
+    end
+    return frame
+end
+maybe_step_through_arg_destructuring!(frame::Frame) = maybe_step_through_arg_destructuring!(RecursiveInterpreter(), frame)
 
 const kwhandler = Core.kwcall
 const kwextrastep = 0

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -260,7 +260,17 @@ function maybe_step_through_wrapper!(interp::Interpreter, frame::Frame)
         end
     end
 
-    has_selfarg = isexpr(last, :call) && any(@nospecialize(x) -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
+    # Field access on `#self#` (e.g. `f.value` in a function-like object's method) is not
+    # wrapper forwarding; without this exclusion we'd step into `getproperty` (issue #299).
+    is_field_access = isexpr(last, :call) && let g = last.args[1]
+        g isa QuoteNode && (g = g.value)
+        if g isa GlobalRef
+            g = isdefined(g.mod, g.name) ? getfield(g.mod, g.name) : nothing
+        end
+        g === Base.getproperty || g === getfield || g === Base.setproperty! || g === setfield!
+    end
+    has_selfarg = isexpr(last, :call) && !is_field_access &&
+        any(@nospecialize(x) -> isa(x, SlotNumber) && x.id == 1, last.args) # isequal(SlotNumber(1)) vulnerable to invalidation
     issplatcall, _callee = unpack_splatcall(last, src)
     if is_kw || has_selfarg || (issplatcall && is_bodyfunc(_callee))
         # If the last expr calls #self# or passes it to an implementation method,

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -412,6 +412,12 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
             return framecode  # this was a Builtin
         end
     end
+    if enter_generated && isa(framecode, FrameCode) && framecode.generator
+        # The generator runs on argument *types*. `prepare_call` performs this conversion
+        # but `get_call_framecode` discards the converted arguments, so redo it here
+        # (issue #161).
+        fargs = Any[_Typeof(a) for a in fargs]
+    end
     newframe = prepare_frame_caller(frame, framecode, fargs, lenv)
     npc = newframe.pc
     shouldbreak(newframe, npc) && return BreakpointRef(newframe.framecode, npc)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -123,6 +123,11 @@ function set_compiled_methods()
     # Modules #
     ###########
     push!(compiled_modules, Base.Threads)
+    # The interpreter must not recursively interpret its own internals: the frame pools
+    # (`junk_frames`/`junk_framedata`) and other globals are shared between the meta and
+    # object levels, so an interpreted interpreter corrupts the running one (issue #228).
+    # Running our own methods compiled makes nested `@interpret` work.
+    push!(compiled_modules, @__MODULE__)
 end
 
 _have_fma_compiled(::Type{T}) where {T} = Core.Intrinsics.have_fma(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -877,7 +877,14 @@ function Base.StackTraces.StackFrame(frame::Frame)
         argt = Tuple{mapany(_Typeof, method_args)...}
         sig = method.sig
         atype, sparams = ccall(:jl_type_intersection_with_env, Any, (Any, Any), argt, sig)::SimpleVector
-        mi = Core.Compiler.specialize_method(method, atype, sparams::SimpleVector)
+        if atype === Union{}
+            # The recorded argument values may not match the method signature
+            # (e.g. while displaying a MethodError); `specialize_method` would
+            # throw on an empty intersection (issue #573).
+            mi = method
+        else
+            mi = Core.Compiler.specialize_method(method, atype, sparams::SimpleVector)
+        end
         fname = method.name
     else
         mi = frame.framecode.src

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -495,7 +495,7 @@ getfile(frame::Frame, pc=frame.pc) = getfile(frame.framecode, pc)
 function codelocation(code::CodeInfo, idx::Int)
     idx′ = idx
     # look ahead if we are on a meta line
-    while idx′ < length(code.code)
+    while idx′ <= length(code.code)
         codeloc = codelocs(code, idx′)
         codeloc == 0 || return codeloc
         ex = code.code[idx′]

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -107,10 +107,14 @@ struct Squarer end
     # Breakpoints by file/line
     remove()
     method = which(JuliaInterpreter.locals, Tuple{Frame})
+    # JuliaInterpreter's own module is in `compiled_modules` (issue #228), so opt this
+    # method back into interpretation to let the file/line breakpoint fire.
+    push!(JuliaInterpreter.interpreted_methods, method)
     breakpoint(String(method.file), method.line+1)
     frame = JuliaInterpreter.enter_call(loop_radius2, 2)
     ret = @interpret JuliaInterpreter.locals(frame)
     @test isa(ret, Tuple{Frame,JuliaInterpreter.BreakpointRef})
+    delete!(JuliaInterpreter.interpreted_methods, method)
     # Test kwarg method
     remove()
     bp = breakpoint(tmppath, 3)

--- a/test/breakpoints.jl
+++ b/test/breakpoints.jl
@@ -481,6 +481,9 @@ struct Constructor
     x::Int
 end
 Constructor(x::AbstractString, y::Int) = Constructor(x)
+struct ParametricConstructor{T}
+    x::T
+end
 
 @testset "constructors" begin
     breakpoint(Constructor, Tuple{String, Int})
@@ -491,6 +494,19 @@ Constructor(x::AbstractString, y::Int) = Constructor(x)
     breakpoint(Constructor)
     frame, bp = @interpret Constructor(2)
     @test bp isa BreakpointRef
+
+    # issue #525: a breakpoint on the type must also fire for parameterized calls
+    remove()
+    breakpoint(ParametricConstructor)
+    frame, bp = @interpret ParametricConstructor{Int}(2)
+    @test bp isa BreakpointRef
+    frame, bp = @interpret ParametricConstructor(2)
+    @test bp isa BreakpointRef
+    remove()
+    # ... and a breakpoint on an unrelated type must not fire
+    breakpoint(Constructor)
+    @test @interpret(ParametricConstructor(2)) isa ParametricConstructor
+    remove()
 end
 
 @testset "test breaking on a line with no statement" begin

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -149,12 +149,17 @@ end
             @test isexpr(lt, :line) || isa(lt, Core.LineInfoNode) || isa(lt, Base.IRShow.LineInfoNode)
             @test isa(pc, BreakpointRef)
             @test JuliaInterpreter.scopeof(cframe).name === :generatedfoo
+            # issue #161: the generator must see the argument *types*, not their values
+            cvars = JuliaInterpreter.locals(cframe)
+            @test filter(v -> v.name === :T, cvars)[1].value === Int
             cframe, pc = debug_command(cframe, :finish)
             @test JuliaInterpreter.scopeof(cframe).name === :callgenerated
             # Now finish the regular function
             @test debug_command(cframe, :finish) === nothing
             @test cframe.callee === nothing
-            @test get_return(cframe) === 1
+            # This matches the native result: with the generator seeing `T = Int`
+            # (issue #161), the generated body is `return Int`.
+            @test get_return(cframe) === Int
         end
 
         # Parametric generated function (see #157)

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -44,6 +44,13 @@ end
 destruct660b((a, b)) = a
 calldestruct660() = destruct660((1, 2), 3)
 
+function assignments484(x)
+    y = x
+    z = y
+    w = sin(z)
+    return w
+end
+
 @generated function generatedfoo(T)
     :(return $T)
 end
@@ -124,6 +131,20 @@ end
         @test step_through(:($(+)(1,2.5))) == 3.5
         @test step_through(:($(sin)(1))) == sin(1)
         @test step_through(:($(gcd)(10,20))) == gcd(10, 20)
+    end
+
+    @testset "next stops on assignment-only lines (#484)" begin
+        frame = enter_call(assignments484, 0.5)
+        lines = Int[whereis(frame)[2]]
+        while true
+            ret = debug_command(frame, :n)
+            ret === nothing && break
+            frame = ret[1]
+            push!(lines, whereis(frame)[2])
+        end
+        # every line of the body is visited, including the call-free `z = y`
+        @test [l - lines[1] for l in lines] == [0, 1, 2, 3]
+        @test get_return(frame) == sin(0.5)
     end
 
     @testset "until" begin

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -29,6 +29,15 @@ end
 step_through(f, args...; kwargs...) = step_through_frame(() -> enter_call(f, args...; kwargs...))
 step_through(expr::Expr) = step_through_frame(() -> enter_call_expr(expr))
 
+struct FunLike299
+    value::Int
+end
+(f::FunLike299)(x) = (y = sin(3.0); f.value)
+mutable struct MutFunLike299
+    value::Int
+end
+(f::MutFunLike299)(x) = (f.value = x)
+
 @generated function generatedfoo(T)
     :(return $T)
 end
@@ -173,6 +182,15 @@ end
             @test debug_command(fr, :finish) === nothing
             @test JuliaInterpreter.get_return(fr) == (Int, 2)
         end
+    end
+
+    @testset "Function-like objects are not wrappers (issue #299)" begin
+        fl = FunLike299(3)
+        frame = JuliaInterpreter.enter_call(fl, 3)
+        @test JuliaInterpreter.maybe_step_through_wrapper!(frame) === frame
+        mf = MutFunLike299(0)
+        frame = JuliaInterpreter.enter_call(mf, 42)
+        @test JuliaInterpreter.maybe_step_through_wrapper!(frame) === frame
     end
 
     @testset "Optional arguments" begin

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -38,6 +38,12 @@ mutable struct MutFunLike299
 end
 (f::MutFunLike299)(x) = (f.value = x)
 
+function destruct660((a, b), c)
+    a + c
+end
+destruct660b((a, b)) = a
+calldestruct660() = destruct660((1, 2), 3)
+
 @generated function generatedfoo(T)
     :(return $T)
 end
@@ -191,6 +197,42 @@ end
         mf = MutFunLike299(0)
         frame = JuliaInterpreter.enter_call(mf, 42)
         @test JuliaInterpreter.maybe_step_through_wrapper!(frame) === frame
+    end
+
+    @testset "Destructured arguments (issue #660)" begin
+        frame = JuliaInterpreter.enter_call(destruct660, (1, 2), 3)
+        frame = JuliaInterpreter.maybe_step_through_wrapper!(frame)
+        vars = JuliaInterpreter.locals(frame)
+        @test filter(v -> v.name === :a, vars)[1].value == 1
+        @test filter(v -> v.name === :b, vars)[1].value == 2
+        @test filter(v -> v.name === :c, vars)[1].value == 3
+        JuliaInterpreter.finish!(frame)
+        @test JuliaInterpreter.get_return(frame) == 4
+
+        # a body consisting of a bare slot read must not be pre-executed
+        frame = JuliaInterpreter.enter_call(destruct660b, (5, 6))
+        frame = JuliaInterpreter.maybe_step_through_wrapper!(frame)
+        vars = JuliaInterpreter.locals(frame)
+        @test filter(v -> v.name === :a, vars)[1].value == 5
+        @static if VERSION >= v"1.11"
+            # on 1.10 the bare-slot body is folded into `return a` itself, so there
+            # is no body statement left to stop at
+            @test !JuliaInterpreter.is_return(JuliaInterpreter.pc_expr(frame))
+        end
+        JuliaInterpreter.finish!(frame)
+        @test JuliaInterpreter.get_return(frame) == 5
+
+        # stepping in from a caller lands with the arguments bound
+        frame = JuliaInterpreter.enter_call(calldestruct660)
+        frame, pc = debug_command(frame, :s)   # executes the Core.tuple builtin
+        cframe, pc = debug_command(frame, :s)
+        @test JuliaInterpreter.scopeof(cframe).name === :destruct660
+        vars = JuliaInterpreter.locals(cframe)
+        @test filter(v -> v.name === :a, vars)[1].value == 1
+        @test filter(v -> v.name === :b, vars)[1].value == 2
+        cframe, pc = debug_command(cframe, :finish)
+        @test debug_command(cframe, :c) === nothing
+        @test JuliaInterpreter.get_return(JuliaInterpreter.root(cframe)) == 4
     end
 
     @testset "Optional arguments" begin

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -848,6 +848,21 @@ frame = JuliaInterpreter.enter_call(f_345)
     @test JuliaInterpreter.getfirstline(frame) isa Integer
 end
 
+# issue #573: a frame's recorded argument values may not match the method signature
+# (e.g. while displaying a MethodError); building a `StackFrame` must not throw on
+# the resulting empty type intersection.
+@testset "StackFrame with mismatched argument types" begin
+    f_573(x::Int) = x
+    frame = JuliaInterpreter.enter_call(f_573, 1)
+    frame.framedata.locals[2] = Some{Any}("not an Int")
+    sf = Base.StackTraces.StackFrame(frame)
+    @test sf isa Base.StackTraces.StackFrame
+    @test sf.linfo isa Method
+    io = IOBuffer()
+    Base.show_backtrace(io, frame)
+    @test !isempty(take!(io))
+end
+
 @testset "issue #701 LineNumberNode with `nothing` file" begin
     # Macros such as MacroTools' `@q`/`@qq` can emit `LineNumberNode`s whose file is
     # `nothing`; building the framecode must not choke when collecting source files.

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -848,6 +848,16 @@ frame = JuliaInterpreter.enter_call(f_345)
     @test JuliaInterpreter.getfirstline(frame) isa Integer
 end
 
+# issue #228: nested `@interpret` must not recursively interpret the interpreter itself
+# (the frame pools are global state shared between the meta and object levels; the inner
+# interpreter runs compiled via `compiled_modules`).
+@testset "nested @interpret" begin
+    f_228() = @interpret(1 + 1)
+    @test @interpret(f_228()) == 2
+    g_228() = f_228() + @interpret(2 + 2)
+    @test @interpret(g_228()) == 6
+end
+
 # issue #573: a frame's recorded argument values may not match the method signature
 # (e.g. while displaying a MethodError); building a `StackFrame` must not throw on
 # the resulting empty type intersection.


### PR DESCRIPTION
Made on top of kc/issue_triage to have all the bugfixes under it. 

------------

A batch of fixes from going through the open issue and PR backlog. Each fix has a
regression test; the full suite passes on Julia 1.12.

## Issues closed

- Fixes #161 `:sg` populated the generator frame with runtime **values** instead of
  argument **types** (`prepare_call` converts them, but `get_call_framecode` discarded
  the conversion). One existing test had codified the buggy behavior and now asserts
  the native result.
- Fixes #228  nested `@interpret` corrupted the interpreter's own global frame pools.
  JuliaInterpreter is now in `compiled_modules`, so an inner `@interpret` runs natively;
  use `interpreted_methods` to opt a method back into interpretation.
- Fixes #299  `maybe_step_through_wrapper!` treated any method whose penultimate
  statement mentions `#self#` as a wrapper, so entering a function-like object
  (`(f::FunLike)(x) = ... f.value`) stepped into `getproperty`. Field access on self is
  now excluded from the wrapper heuristic.
- Fixes #525  `breakpoint(Constructor)` did not fire for `Constructor{Int}(2)`;
  constructor methods are now matched by type name rather than object identity.
- Fixes #573  displaying a backtrace could throw `TypeError: in specializations,
  expected DataType, got Type{Union{}}` when a frame's recorded arguments no longer
  match the method signature (e.g. while showing a MethodError). `StackFrame` now falls
  back to reporting the `Method` on an empty intersection.
- Fixes #660  entering a method with destructured arguments (`f((a, b), c)`) stopped
  before `a`/`b` existed. The `indexed_iterate` preamble is now executed on entry, so
  the debugger lands with all arguments bound (without pre-executing a bare-slot body
  like `f((a, b)) = a`).
- Fixes JuliaDebug/Debugger.jl#291  `n` skipped lines consisting only of assignments;
  `next_line!` now stops at calls, returns, and assignments to named slots or globals
  (still not at bare gotos, per the review discussion in #484).

## Superseded PRs (can be closed)

- Closes #484  reimplemented in this PR on the current `Interpreter` API, with tests.
- Closes #163  the surviving idea (type conversion for generator entry) is
  implemented at the `evaluate_call!` site; the original diff no longer applies.
- Closes #252  nested `@interpret` is now actually fixed and has a regression test.The locals recorded in a frame may not match the method signature (e.g.
while displaying a MethodError), in which case the intersection of the
recorded argument types with the signature is empty and
`specialize_method` throws `TypeError: in specializations, expected
DataType, got Type{Union{}}`. Fall back to reporting the Method itself.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>