### PR TITLE
Preserve module self-bindings during resolution

### DIFF
--- a/src/construct.jl
+++ b/src/construct.jl
@@ -129,12 +129,18 @@ function find_or_create_module(parentmod::Module, ex::Expr)
     if invokelatest(isdefinedglobal, parentmod, newname)
         found = invokelatest(getglobal, parentmod, newname)
         found isa Module || throw(ErrorException("invalid redefinition of constant $(newname)"))
-        # Reuse a loaded package only when it loads itself (`parentmod === Base.__toplevel__`)
-        # or when `newname` already names a genuine submodule of `parentmod` (re-revision of a
-        # module we created). A nested `module newname` that merely shares a loaded package's
-        # name is a fresh local module that shadows the package, matching `include`
-        # (Revise issue #747).
-        if parentmod === Base.__toplevel__ || parentmodule(found) === parentmod
+        # Reuse a module's self-binding (`Base.Base === Base`), a loaded package when it
+        # loads itself (`parentmod === Base.__toplevel__`), or a genuine submodule of
+        # `parentmod` (re-revision of a module we created). A nested `module newname` that
+        # merely shares a loaded package's name is a fresh local module that shadows the
+        # package, matching `include` (Revise issue #747).
+        # The self-binding reuse knowingly diverges from `include` for a genuinely nested
+        # `module A` inside `module A` (plain evaluation creates a fresh child `A.A`):
+        # that input is syntactically indistinguishable from re-interpreting `A`'s own
+        # definition, the primary use of this machinery, so we re-enter `parentmod`.
+        # Creating a fresh child here would also clobber `parentmod`'s self-binding.
+        if (found === parentmod || parentmod === Base.__toplevel__ ||
+            parentmodule(found) === parentmod)
             mod = found
         end
     elseif parentmod === Base.__toplevel__

--- a/test/toplevel.jl
+++ b/test/toplevel.jl
@@ -70,6 +70,16 @@ end
     collect(ExprSplitter(JIVisible, :(module JIInvisible f() = 1 end)))  # this looks up JIInvisible rather than create it
     @test !isdefinedglobal(Main, :JIInvisible)
     @test  isdefinedglobal(JIVisible, :JIInvisible)
+
+    # `Base` has a self-binding even though `parentmodule(Base) === Main`.
+    let mod = Module(:SelfBoundModule)
+        @test parentmodule(mod) === Main
+        @test getglobal(mod, :SelfBoundModule) === mod
+        modexs = collect(ExprSplitter(mod, :(baremodule SelfBoundModule; x = 1; end)))
+        @test first(only(modexs)) === mod
+        @test getglobal(mod, :SelfBoundModule) === mod
+    end
+
     mktempdir() do path
         push!(LOAD_PATH, path)
         open(joinpath(path, "TmpPkg1.jl"), "w") do io


### PR DESCRIPTION
Module contexts bind their own name (e.g. `Base.Base === Base`) even though their parent module differs. The nested-module resolution introduced in #740 treated these bindings as unrelated loaded modules: re-interpreting `module X ... end` with `X` itself as the parent context - the core Revise/JET revision pattern - not only returned a fresh child module but also clobbered `X`'s self-binding when the child was evaluated into `X`.

Reuse the existing module when the found binding is the parent context itself, while preserving #740's fresh-module shadowing for unrelated same-name packages (Revise issue timholy/Revise.jl#747).

This knowingly diverges from the `include` semantics for a genuinely nested `module A` inside `module A`, where plain evaluation creates a fresh child `A.A`: that input is syntactically indistinguishable from re-interpretation of `A`'s own definition, so I believe re-entering the parent (the pre-#740 behavior) is the right default for this machinery.

Add a synthetic self-binding regression test.