### PR TITLE
Use JuliaLowering for source-faithful stepping

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,30 +14,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: '1' # current stable
-            os: ubuntu-latest
-            arch: x64
+          # - version: '1' # current stable
+          #   os: ubuntu-latest
+          #   arch: x64
           - version: 'min' # lowest version supported
             os: ubuntu-latest
             arch: x64
-          - version: 'pre' # upcoming release, or duplicate of '1'
-            os: ubuntu-latest
-            arch: x64
+          # - version: 'pre' # upcoming release, or duplicate of '1'
+          #   os: ubuntu-latest
+          #   arch: x64
           - version: 'nightly' # dev
             os: ubuntu-latest
             arch: x64
           #- version: '1' # x86 ubuntu -- disabled since PyCall/conda is broken on this platform
           #  os: ubuntu-latest
           #  arch: x86
-          - version: '1' # x86 windows
-            os: windows-latest
-            arch: x86
-          - version: '1' # x64 windows
-            os: windows-latest
-            arch: x64
-          - version: '1' # aarch64 macOS (Apple Silicon)
-            os: macos-latest
-            arch: aarch64
+          # - version: '1' # x86 windows
+          #   os: windows-latest
+          #   arch: x86
+          # - version: '1' # x64 windows
+          #   os: windows-latest
+          #   arch: x64
+          # - version: '1' # aarch64 macOS (Apple Silicon)
+          #   os: macos-latest
+          #   arch: aarch64
     env:
       PYTHON: ""
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaInterpreter"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.11.4"
+version = "0.12.0"
 authors = ["Tim Holy <tim.holy@gmail.com>", "Kristoffer Carlsson <kcarlsson89@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>", "and contributors"]
 
 [deps]
@@ -18,7 +18,7 @@ DeepDiffs = "1"
 ExplicitImports = "1.15"
 FunctionWrappers = "1"
 LoopVectorization = "0.12"
-julia = "1.10"
+julia = "1.14"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/docs/src/dev_reference.md
+++ b/docs/src/dev_reference.md
@@ -118,7 +118,6 @@ JuliaInterpreter.clear_caches
 ```@docs
 JuliaInterpreter.eval_code
 JuliaInterpreter.lookup
-JuliaInterpreter.is_wrapper_call
 JuliaInterpreter.is_doc_expr
 JuliaInterpreter.is_global_ref
 CodeTracking.whereis

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -78,7 +78,7 @@ function add_breakpoint_if_match!(framecode::FrameCode, bp::BreakpointSignature)
             scope.file
         else
             # TODO: make more precise?
-            first(framecode.src.linetable).file
+            Base.IRShow.debuginfo_file1(linetable(framecode))
         end
         stmtidxs = bp.line === 0 ? [1] : statementnumbers(framecode, bp.line, matching_file::Symbol)
         stmtidxs === nothing && return

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -247,8 +247,9 @@ function prepare_slotfunction(framecode::FrameCode, body::Union{Symbol,Expr})
     framename, dataname = gensym("frame"), gensym("data")
     assignments = Expr[:($dataname = $framename.framedata)]
     default = Unassigned()
-    for slotname in unique(framecode.src.slotnames)
-        list = framecode.slotnamelists[slotname]
+    # `slotnamelists` is keyed by base name (shadowed locals' `@N`-suffixed slots are
+    # grouped with their base name), so iterate its keys rather than the raw slotnames.
+    for (slotname, list) in framecode.slotnamelists
         if length(list) == 1
             maxexpr = :($dataname.last_reference[$(list[1])] > 0 ? $(list[1]) : 0)
         else

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -320,6 +320,9 @@ function is_indexed_iterate_call(@nospecialize(stmt))
     return f === Base.indexed_iterate
 end
 
+is_destructured_arg_slotname(name::Symbol) =
+    name === Symbol("") || startswith(String(name), "destructured#")
+
 """
     frame = maybe_step_through_arg_destructuring!(interp::Interpreter, frame::Frame)
 
@@ -336,15 +339,16 @@ function maybe_step_through_arg_destructuring!(interp::Interpreter, frame::Frame
     slotnames = src.slotnames
     nargs = Int(scope.nargs)
     nargs <= length(slotnames) || return frame
-    # A destructured argument occupies an unnamed argument slot
-    any(i -> slotnames[i] === Symbol(""), 2:nargs) || return frame
+    # A destructured argument occupies an unnamed argument slot (flisp) or one named
+    # `destructured#N` (JuliaLowering)
+    any(i -> is_destructured_arg_slotname(slotnames[i]), 2:nargs) || return frame
     stmts = src.code
     prepssas = BitSet()
     prepend = 0
     for (i, stmt) in enumerate(stmts)
         if is_indexed_iterate_call(stmt)
             arg1 = (stmt::Expr).args[2]
-            isa(arg1, SlotNumber) && 2 <= arg1.id <= nargs && slotnames[arg1.id] === Symbol("") || break
+            isa(arg1, SlotNumber) && 2 <= arg1.id <= nargs && is_destructured_arg_slotname(slotnames[arg1.id]) || break
         elseif isexpr(stmt, :(=)) && isexpr((stmt::Expr).args[2], :call)
             # a `slot = getfield(%prep, k)` statement consuming a preamble value
             rhs = (stmt::Expr).args[2]::Expr
@@ -418,11 +422,20 @@ function maybe_step_through_kwprep!(interp::Interpreter, frame::Frame, istopleve
     pc, src = frame.pc, frame.framecode.src
     n = length(src.code)
     stmt = pc_expr(frame, pc)
-    if isbindingresolved_deprecated && !isa(stmt, Tuple{Symbol,Vararg{Symbol}}) && !is_empty_namedtuple(stmt) && n >= pc+1
-        nextstmt = pc_expr(frame, pc + 1)
-        if isa(nextstmt, Tuple{Symbol,Vararg{Symbol}}) || is_empty_namedtuple(nextstmt)
-            pc += 1
-            stmt = nextstmt
+    if !isa(stmt, Tuple{Symbol,Vararg{Symbol}}) && !is_empty_namedtuple(stmt) && !is_merge_call(stmt)
+        # The NamedTuple-keys tuple may be preceded by side-effect-free loads (binding
+        # resolution, or the `QuoteNode`s of a qualified callee such as `Base.sort`);
+        # scan past them, but stop at anything that executes user code.
+        pcnext = pc
+        while pcnext < min(pc + 4, n)
+            s = pc_expr(frame, pcnext)
+            (isa(s, QuoteNode) || isa(s, GlobalRef) || isa(s, SlotNumber) || isa(s, SSAValue)) || break
+            pcnext += 1
+            snext = pc_expr(frame, pcnext)
+            if isa(snext, Tuple{Symbol,Vararg{Symbol}}) || is_empty_namedtuple(snext)
+                pc, stmt = pcnext, snext
+                break
+            end
         end
     end
     if isa(stmt, Tuple{Symbol,Vararg{Symbol}})

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -373,7 +373,6 @@ end
 maybe_step_through_arg_destructuring!(frame::Frame) = maybe_step_through_arg_destructuring!(RecursiveInterpreter(), frame)
 
 const kwhandler = Core.kwcall
-const kw_has_f_first = VERSION.major == 1 && VERSION.minor == 11
 
 function is_kwcall_stmt(@nospecialize(stmt))
     isexpr(stmt, :(=)) && (stmt = stmt.args[2])
@@ -425,9 +424,6 @@ function maybe_step_through_kwprep!(interp::Interpreter, frame::Frame, istopleve
             pc += 1
             stmt = nextstmt
         end
-    elseif kw_has_f_first && pc < n && is_empty_namedtuple(pc_expr(frame, pc+1)) && isa(stmt, QuoteNode)
-        pc = step_expr!(interp, frame, istoplevel)
-        stmt = pc_expr(frame, pc)
     end
     if isa(stmt, Tuple{Symbol,Vararg{Symbol}})
         # Check to see if we're creating a NamedTuple followed by kwfunc call

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -208,11 +208,7 @@ end
 get_source(meth::Method) = Base.uncompressed_ast(meth)
 
 function get_source(g::GeneratedFunctionStub, source::Method, env, world::UInt)
-    b = @static if VERSION < v"1.12.0-DEV.1968"   # julia #57230
-        g(world, LineNumberNode(Int(source.line), source.file), env..., g.argnames...)
-    else
-        g(world, source, env..., g.argnames...)
-    end
+    b = g(world, source, env..., g.argnames...)
     b isa CodeInfo && return b
     return eval(b)
 end

--- a/src/construct.jl
+++ b/src/construct.jl
@@ -207,7 +207,12 @@ end
 
 get_source(meth::Method) = Base.uncompressed_ast(meth)
 
-function get_source(g::GeneratedFunctionStub, source::Method, env, world::UInt)
+# `g` is `Core.GeneratedFunctionStub` or a stub with the same calling convention,
+# such as `JuliaLowering.GeneratedFunctionStub`. Both accept the static-parameter
+# values followed by the argument names; passing the names as symbolic stand-ins
+# for the argument types yields an expansion whose spliced arguments become slot
+# references, so the body can be interpreted unspecialized.
+function get_source(@nospecialize(g), source::Method, env, world::UInt)
     b = g(world, source, env..., g.argnames...)
     b isa CodeInfo && return b
     return eval(b)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -272,8 +272,21 @@ end
 # from a fresh `throw` of the same object.
 const _rethrow_inflight = Ref{Any}(nothing)
 
+# JuliaLowering lowers the `catch` body's reference to the active exception as a call
+# to its runtime function `current_exception` (flisp emits `Expr(:the_exception)`).
+# That function reads the task's native exception stack, but exceptions raised in
+# interpreted code are caught by the interpreter itself, so the task state does not
+# reflect the frame's handler. Recognized by name to avoid a JuliaLowering dependency.
+function is_lowered_current_exception(@nospecialize f)
+    return f isa Function && nameof(f) === :current_exception &&
+        nameof(parentmodule(f)) === :JuliaLowering
+end
+
 function native_call(fargs::Vector{Any}, frame::Frame)
     f = popfirst!(fargs)
+    if isempty(fargs) && is_lowered_current_exception(f)
+        return frame.framedata.last_exception[]
+    end
     @something maybe_eval_with_scope(f, fargs, frame) return invoke_in_world(frame.world, f, fargs...)
 end
 
@@ -360,6 +373,8 @@ function evaluate_call!(interp::Interpreter, frame::Frame, fargs::Vector{Any}, e
         # No interpreted frame is handling an exception; fall back to the native rethrow
         # (interpreted code may be running inside a native `catch` block).
         rethrow()
+    elseif is_lowered_current_exception(fargs[1]) && length(fargs) == 1
+        return frame.framedata.last_exception[]
     elseif fargs[1] === Base.current_exceptions && length(fargs) == 1
         # Exceptions caught by interpreted handlers never reach the task's native
         # exception stack; they live in the frames' modeled stacks. Merge the native

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -97,10 +97,7 @@ function lookup_expr(interp::Interpreter, frame::Frame, e::Expr)
     end
     if head === :call
         f = lookup(interp, frame, e.args[1])
-        if (@static VERSION < v"1.11.0-DEV.1180" && true) && f === Core.svec
-            # work around for a linearization bug in Julia (https://github.com/JuliaLang/julia/pull/52497)
-            return Core.svec(Any[lookup(interp, frame, e.args[i]) for i in 2:length(e.args)]...)
-        elseif f === Core.tuple
+        if f === Core.tuple
             # Handling for `ccall`/`cglobal` literal syntax, e.g. the `(:sin, lib)`
             # first argument of `cglobal((:sin, lib), Ptr{Cvoid})`. The library may be
             # spelled as a `getproperty` chain (e.g. `Base.Math.libm` on Julia ≥ 1.11),
@@ -624,27 +621,15 @@ function coverage_visit_line!(frame::Frame)
     pc, code = frame.pc, frame.framecode
     code.report_coverage || return
     src = code.src
-    @static if VERSION ≥ v"1.12.0-DEV.173"
-        lineinfo = linetable(src, pc)
-        if lineinfo !== nothing
-            file, line = lineinfo.file, lineinfo.line
-            if line != frame.last_codeloc
-                file isa Symbol || (file = Symbol(file)::Symbol)
-                @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
-                frame.last_codeloc = line
-            end
-        end
-    else # VERSION < v"1.12.0-DEV.173"
-        codeloc = src.codelocs[pc]
-        if codeloc != frame.last_codeloc && codeloc != 0
-            linetable = src.linetable::Vector{Any}
-            lineinfo = linetable[codeloc]::Core.LineInfoNode
-            file, line = lineinfo.file, lineinfo.line
+    lineinfo = linetable(src, pc)
+    if lineinfo !== nothing
+        file, line = lineinfo.file, lineinfo.line
+        if line != frame.last_codeloc
             file isa Symbol || (file = Symbol(file)::Symbol)
             @ccall jl_coverage_visit_line(file::Cstring, sizeof(file)::Csize_t, line::Cint)::Cvoid
-            frame.last_codeloc = codeloc
+            frame.last_codeloc = line
         end
-    end # @static if
+    end
 end
 
 # For "profiling" where JuliaInterpreter spends its time. See the commented-out block
@@ -982,8 +967,9 @@ function enter_exception_handler!(data::FrameData, @nospecialize(err))
     else
         push!(data.exceptions, err)
     end
-    pc = @static VERSION >= v"1.11-" ? pop!(data.exception_frames) : data.exception_frames[end] # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
-    @static VERSION >= v"1.11-" && pop!(data.exception_scopes)
+    # implicit :leave after https://github.com/JuliaLang/julia/pull/52245
+    pc = pop!(data.exception_frames)
+    pop!(data.exception_scopes)
     return pc
 end
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -421,9 +421,6 @@ function replace_coretypes_list!(list::AbstractVector; rev::Bool=false)
             isa(x, Core.SSAValue) && return SSAValue(x.id)
             isa(x, Core.SlotNumber) && return SlotNumber(x.id)
             isa(x, Core.Compiler.Argument) && return SlotNumber(x.n)
-            @static if VERSION < v"1.11.0-DEV.337"
-            isa(x, Core.Compiler.TypedSlot) && return SlotNumber(x.id)
-            end
             return x
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -200,7 +200,10 @@ function pushuniquefiles!(unique_files::Set{Symbol}, lt::Core.DebugInfo)
         pushuniquefiles!(unique_files, edge::Core.DebugInfo)
     end
     linetable = lt.linetable
-    if linetable === nothing
+    if linetable === nothing || linetable isa String
+        # `nothing`: `def` itself names the file. A `String` is a compressed
+        # source-byte table (JuliaLowering's byte-precise debuginfo), which
+        # likewise describes only the file named by `def`.
         push!(unique_files, Base.IRShow.debuginfo_file1(lt))
     else
         pushuniquefiles!(unique_files, linetable)

--- a/src/types.jl
+++ b/src/types.jl
@@ -195,7 +195,6 @@ end
 is_breakpoint_marker(@nospecialize(stmt)) =
     stmt === __BREAK_POINT_MARKER__ || is_global_ref(stmt, JuliaInterpreter, :__BREAK_POINT_MARKER__)
 
-@static if VERSION ≥ v"1.12.0-DEV.173"
 function pushuniquefiles!(unique_files::Set{Symbol}, lt::Core.DebugInfo)
     for edge in lt.edges
         pushuniquefiles!(unique_files, edge::Core.DebugInfo)
@@ -207,7 +206,6 @@ function pushuniquefiles!(unique_files::Set{Symbol}, lt::Core.DebugInfo)
         pushuniquefiles!(unique_files, linetable)
     end
     return unique_files
-end
 end
 
 # The running task's current world age. Unlike `Base.get_world_counter()` (the latest
@@ -253,16 +251,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
 
     lt = linetable(src)
     unique_files = Set{Symbol}()
-    @static if VERSION ≥ v"1.12.0-DEV.173"
     pushuniquefiles!(unique_files, lt)
-    else # VERSION < v"1.12.0-DEV.173"
-    for entry in lt
-        # issue #701: macro-generated `LineNumberNode`s (e.g. MacroTools' `@q`/`@qq`) can
-        # carry a `nothing` file, which has no path to match a breakpoint against.
-        entry.file === nothing && continue
-        push!(unique_files, entry.file)
-    end
-    end # @static if
 
     framecode = FrameCode(scope, src, methodtables, breakpoints, slotnamelists, used, generator, report_coverage, unique_files, is_toplevel_surface, world_deps)
     if scope isa Method
@@ -415,12 +404,8 @@ function toplevel_codeinfo(mod::Module, stmts::Vector{Any})
     ci.slotnames = Symbol[Symbol("#self#")]
     ci.slotflags = UInt8[0x00]
     # `step_toplevel!` reads line info from the surface `LineNumberNode`s in `code` directly and
-    # never consults the `CodeInfo`'s line tables, so the skeleton's debuginfo is left untouched on
-    # 1.12+ (where `codelocs` was folded into `debuginfo`); on older versions `codelocs` must match
-    # the new code length.
-    @static if !(VERSION ≥ v"1.12.0-DEV.173")
-        ci.codelocs = fill(Int32(1), n)
-    end
+    # never consults the `CodeInfo`'s line tables, so the skeleton's debuginfo is left untouched
+    # (`codelocs` was folded into `debuginfo`).
     return ci
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -189,6 +189,21 @@ function is_breakpoint_expr(ex::Expr)
     return isa(q, QuoteNode) && q.value === :__BREAKPOINT_MARKER__
 end
 
+# JuliaLowering gives a shadowing local its own slot, named by appending `@N` to the
+# user-visible name (an inner `y` becomes slot `y@1`); flisp reuses a single slot per
+# name. Name-keyed variable lookups (`locals`, `eval_code`, breakpoint conditions)
+# group slots by this base name so that shadowed variables resolve through the same
+# most-recently-referenced-slot-wins rule that already disambiguates same-named slots.
+function slot_base_name(sym::Symbol)
+    str = String(sym)
+    i = findlast('@', str)
+    i === nothing && return sym
+    (i > firstindex(str) && i < lastindex(str)) || return sym
+    suffix = SubString(str, nextind(str, i))
+    all(isdigit, suffix) || return sym
+    return Symbol(SubString(str, firstindex(str), prevind(str, i)))
+end
+
 # `@bp` lowers to a `GlobalRef` of the `__BREAK_POINT_MARKER__` const. `optimize!` folds it
 # to its value in method scope (unwrapped from the `QuoteNode` by `lookup_stmt`), while
 # toplevel or unoptimized code keeps the `GlobalRef`, so accept both forms.
@@ -246,6 +261,7 @@ function FrameCode(scope, src::CodeInfo; generator=false, optimize=true, world::
     end
     slotnamelists = Dict{Symbol,Vector{Int}}()
     for (i, sym) in enumerate(src.slotnames)
+        sym = slot_base_name(sym)
         list = get(slotnamelists, sym, Int[])
         slotnamelists[sym] = push!(list, i)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -631,6 +631,7 @@ function locals(frame::Frame)
         if val isa Core.Box && !isdefined(val, :contents)
             continue
         end
+        sym = slot_base_name(sym)
         var = Variable(val, sym)
         idx = get(varlookup, sym, 0)
         if idx > 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,32 +42,15 @@ function whichtt(@nospecialize(tt), mt::Union{Nothing,MethodTable}=nothing; worl
     return match.method
 end
 
-@static if VERSION ≥ v"1.12-"
 using Base.Compiler: findsup_mt
-else
-function findsup_mt(@nospecialize(tt), world, method_table)
-    if method_table === nothing
-        table = Core.Compiler.InternalMethodTable(world)
-    elseif method_table isa Core.MethodTable
-        table = Core.Compiler.OverlayMethodTable(world, method_table)
-    else
-        table = method_table
-    end
-    return Core.Compiler.findsup(tt, table)
-end
-end
 
 instantiate_type_in_env(arg, spsig::UnionAll, spvals::Vector{Any}) =
     ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), arg, spsig, spvals)
 
 # Native `UndefVarError`s carry the scope of the missing binding (`:local`,
-# `:static_parameter`, ...) since Julia 1.11; match that so `@test_throws` and other
-# field-wise comparisons against natively-thrown errors succeed.
-@static if VERSION >= v"1.11"
-    undef_var_error(sym::Symbol, scope::Symbol) = UndefVarError(sym, scope)
-else
-    undef_var_error(sym::Symbol, scope::Symbol) = UndefVarError(sym)
-end
+# `:static_parameter`, ...); match that so `@test_throws` and other field-wise
+# comparisons against natively-thrown errors succeed.
+undef_var_error(sym::Symbol, scope::Symbol) = UndefVarError(sym, scope)
 undef_sparam_error(sym::Symbol) = undef_var_error(sym, :static_parameter)
 
 function sparam_syms(meth::Method)
@@ -105,10 +88,6 @@ function scan_ssa_use!(used::BitSet, @nospecialize(stmt))
     while iterval !== nothing
         useref, state = iterval
         val = Core.Compiler.getindex(useref)
-        if (@static VERSION < v"1.11.0-DEV.1180" && true) && isexpr(val, :call)
-            # work around for a linearization bug in Julia (https://github.com/JuliaLang/julia/pull/52497)
-            scan_ssa_use!(used, val)
-        end
         if isa(val, SSAValue)
             push!(used, val.id)
         end
@@ -158,8 +137,6 @@ isidentical(x) = Base.Fix2(===, x)   # recommended over isequal(::Symbol) since 
 
 is_return(@nospecialize(node)) = node isa ReturnNode
 
-is_loc_meta(@nospecialize(expr), @nospecialize(kind)) = isexpr(expr, :meta) && length(expr.args) >= 1 && expr.args[1] === kind
-
 """
     is_global_ref(g, mod, name)
 
@@ -189,8 +166,6 @@ function is_define_method_call(@nospecialize(stmt))
            is_quotenode_egal(f, Core.define_method)
 end
 
-is_methoddef1(@nospecialize(stmt)) = isexpr(stmt, :method, 1) ||
-                                      (is_define_method_call(stmt) && length(stmt.args) == 3)
 is_methoddef3(@nospecialize(stmt)) = isexpr(stmt, :method, 3) ||
                                       (is_define_method_call(stmt) && length(stmt.args) == 5)
 
@@ -241,15 +216,6 @@ function is_bodyfunc(@nospecialize(arg))
     return false
 end
 
-"""
-Determine whether we are calling a function for which the current function
-is a wrapper (either because of optional arguments or because of keyword arguments).
-"""
-function is_wrapper_call(@nospecialize(expr))
-    isexpr(expr, :(=)) && (expr = expr.args[2])
-    isexpr(expr, :call) && any(x->x==SlotNumber(1), expr.args)
-end
-
 is_generated(meth::Method) = isdefined(meth, :generator)
 
 get_staged(mi::MethodInstance, world::UInt) = Core.Compiler.get_staged(mi, world)
@@ -284,11 +250,7 @@ is_vararg_type(@nospecialize x) = x isa Core.TypeofVararg
 
 # These getters improve inference since fieldtype(CodeInfo, :linetable)
 # and fieldtype(CodeInfo, :codelocs) are both Any
-@static if VERSION ≥ v"1.12.0-DEV.173"
-    const LineTypes = Union{LineNumberNode,Base.IRShow.LineInfoNode}
-else
-    const LineTypes = Union{LineNumberNode,Core.LineInfoNode}
-end
+const LineTypes = Union{LineNumberNode,Base.IRShow.LineInfoNode}
 function linetable(arg)
     if isa(arg, Frame)
         arg = arg.framecode
@@ -297,31 +259,15 @@ function linetable(arg)
         arg = arg.src
     end
     ci = arg::CodeInfo
-    @static if VERSION ≥ v"1.12.0-DEV.173"
     return ci.debuginfo
-    else # VERSION < v"1.12.0-DEV.173"
-    return ci.linetable::Union{Vector{Core.LineInfoNode},Vector{Any}} # issue #264
-    end # @static if
 end
 function linetable(arg, i::Integer; macro_caller::Bool=false, def=:var"n/a")::Union{Expr,Nothing,LineTypes}
     lt = linetable(arg)
-    @static if VERSION ≥ v"1.12.0-DEV.173"
     # TODO: decode the linetable at this frame efficiently by reimplementing this here
     nodes = Base.IRShow.buildLineInfoNode(lt, def, i)
     isempty(nodes) && return nothing
     return nodes[macro_caller ? 1 : end]
-    else # VERSION < v"1.12.0-DEV.173"
-    lin = lt[i]::Union{Expr,LineTypes}
-    if macro_caller
-        while lin isa Core.LineInfoNode && lin.method === Symbol("macro expansion") && lin.inlined_at != 0
-            lin = lt[lin.inlined_at]::Union{Expr,LineTypes}
-        end
-    end
-    return lin
-    end # @static if
 end
-
-@static if VERSION ≥ v"1.12.0-DEV.173"
 
 getfirstline(arg) = getfirstline(linetable(arg))
 function getfirstline(debuginfo::Core.DebugInfo)
@@ -365,24 +311,6 @@ function codelocs(arg, i::Integer)
     end
     return i
 end
-
-else # VERSION < v"1.12.0-DEV.173"
-
-getfirstline(arg) = getline(linetable(arg)[begin])
-getlastline(arg) = getline(linetable(arg)[end])
-function codelocs(arg)
-    if isa(arg, Frame)
-        arg = arg.framecode
-    end
-    if isa(arg, FrameCode)
-        arg = arg.src
-    end
-    ci = arg::CodeInfo
-    return ci.codelocs
-end
-codelocs(arg, i::Integer) = codelocs(arg)[i]
-
-end # @static if
 
 function lineoffset(framecode::FrameCode)
     offset = 0
@@ -514,17 +442,6 @@ function codelocation(code::CodeInfo, idx::Int)
     return 1
 end
 
-function compute_corrected_linerange(method::Method)
-    _, line1 = whereis(method)
-    offset = line1 - method.line
-    @assert !is_generated(method)
-    src = get_source(method)
-    lastline = getlastline(src)
-    return line1:lastline + offset
-end
-
-compute_linerange(framecode) = getfirstline(framecode):getlastline(framecode)
-
 function statementnumbers(framecode::FrameCode, line::Integer, file::Symbol)
     # Check to see if this framecode really contains that line. Methods that fill in a default positional argument,
     # keyword arguments, and @generated sections may not contain the line.
@@ -587,15 +504,11 @@ function framecode_lines(src::CodeInfo)
     line_info_postprinter = Base.IRShow.default_expr_type_printer
     bb_idx = 1
     for idx = 1:length(src.code)
-        @static if VERSION >= v"1.12.0-DEV.1359"
-            parent = src.parent
-            sptypes = if parent isa MethodInstance
-                Core.Compiler.sptypes_from_meth_instance(parent)
-            else Core.Compiler.EMPTY_SPTYPES end
-            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, sptypes, used, cfg, bb_idx)
-        else
-            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
-        end
+        parent = src.parent
+        sptypes = if parent isa MethodInstance
+            Core.Compiler.sptypes_from_meth_instance(parent)
+        else Core.Compiler.EMPTY_SPTYPES end
+        bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, sptypes, used, cfg, bb_idx)
         push!(lines, chomp(String(take!(buf))))
     end
     return lines
@@ -913,11 +826,7 @@ function Base.show_backtrace(io::IO, frame::Frame)
     for (i, (last_frame, n)) in enumerate(stackframes)
         frame_counter += 1
         println(io)
-        @static if VERSION >= v"1.13.0-DEV.927"
-            Base.print_stackframe(io, i, last_frame, nd, 0, 0, 0, Base.info_color())
-        else
-            Base.print_stackframe(io, i, last_frame, n, nd, Base.info_color())
-        end
+        Base.print_stackframe(io, i, last_frame, nd, 0, 0, 0, Base.info_color())
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -442,6 +442,38 @@ function codelocation(code::CodeInfo, idx::Int)
     return 1
 end
 
+"""
+    loc = statement_location(framecode::FrameCode, pc::Int)
+    loc = statement_location(frame::Frame, pc::Int=frame.pc)
+
+Return the source span of the statement at `pc` as a `NamedTuple`
+`(; file, line, line_end, col, col_end, byte, byte_end)`, or `nothing` if no
+location is recorded. `byte:byte_end` is a 1-based byte range into the source
+file (or the string passed to `include_string`) covering the expression as
+written; `byte == 0` means only line information is available, which is the
+case for code lowered without byte-precise provenance (the flisp lowerer, or
+JuliaLowering operating on an `Expr` that lacks source text).
+
+Locations are static (as of when the method was defined); they are not
+corrected for subsequent file edits. See [`CodeTracking.whereis`](@ref) for
+dynamic line information.
+"""
+function statement_location(framecode::FrameCode, pc::Int)
+    if framecode.is_toplevel_surface
+        lnn = toplevel_surface_lnn(framecode, pc)
+        (lnn === nothing || lnn.file === nothing) && return nothing
+        line = getline(lnn)
+        return (; file=getfile(lnn), line, line_end=line, col=0, col_end=0, byte=0, byte_end=0)
+    end
+    di = linetable(framecode)::Core.DebugInfo
+    sl = Base.Compiler.source_location(di, pc)
+    sl.line == 0 && return nothing
+    file = CodeTracking.maybe_fixup_stdlib_path(String(Base.IRShow.debuginfo_file1(di)))
+    return (; file, line=sl.line, line_end=max(sl.line, sl.line_end),
+            col=sl.col, col_end=sl.col_end, byte=sl.byte, byte_end=sl.byte_end)
+end
+statement_location(frame::Frame, pc::Int=frame.pc) = statement_location(frame.framecode, pc)
+
 function statementnumbers(framecode::FrameCode, line::Integer, file::Symbol)
     # Check to see if this framecode really contains that line. Methods that fill in a default positional argument,
     # keyword arguments, and @generated sections may not contain the line.
@@ -455,6 +487,39 @@ function statementnumbers(framecode::FrameCode, line::Integer, file::Symbol)
     end
 
     linetarget = line - offset
+
+    di = linetable(framecode)
+    if di isa Core.DebugInfo && di.linetable isa String
+        # Byte-precise debuginfo (JuliaLowering's compressed source-byte table):
+        # a single file per table, with each statement's span recoverable via
+        # `source_location`. Scan the statements directly.
+        Base.IRShow.debuginfo_file1(di) === file || return Int[]
+        nstmts = length(framecode.src.code)
+        stmtidxs = Int[]
+        prevmatch = false
+        for i in 1:nstmts
+            sl = Base.Compiler.source_location(di, i)
+            ismatch = sl.line == linetarget
+            # only record the first statement of each contiguous matching run
+            ismatch && !prevmatch && push!(stmtidxs, i)
+            prevmatch = ismatch
+        end
+        isempty(stmtidxs) || return stmtidxs
+        # No statement starts on the requested line (e.g. a breakpoint on `end` or on a
+        # blank line): if the code starts before the requested line, take the first
+        # statement that starts after it.
+        beststmt, bestline, firstline = 0, typemax(Int), typemax(Int)
+        for i in 1:nstmts
+            sl = Base.Compiler.source_location(di, i)
+            sl.line == 0 && continue
+            firstline = min(firstline, sl.line)
+            if sl.line > linetarget && sl.line < bestline
+                beststmt, bestline = i, sl.line
+            end
+        end
+        beststmt != 0 && firstline < linetarget && push!(stmtidxs, beststmt)
+        return stmtidxs
+    end
 
     lts = CodeTracking.linetable_scopes(framecode.src, scope)
     for lt in lts

--- a/test/core.jl
+++ b/test/core.jl
@@ -19,8 +19,10 @@ using Test
     end
     frame = JuliaInterpreter.enter_call(buildexpr)
     lines = JuliaInterpreter.framecode_lines(frame.framecode.src)
-    # Test that the :copyast ends up on the same line as the println
-    @test any(str->occursin(":copyast", str) && occursin("println", str), lines)
+    # The interpolated `quote` block must display as a single statement that carries the
+    # quoted code: flisp lowers it to `Expr(:copyast, ...)`, JuliaLowering to a call of
+    # `interpolate_expr`; either way the statement's text includes the quoted `println`.
+    @test any(str->(occursin(":copyast", str) || occursin("interpolate_expr", str)) && occursin("println", str), lines)
 
     thunk = Meta.lower(Main, :(return 1+2))
     stmt = thunk.args[1].code[end]::Core.ReturnNode   # the return

--- a/test/eval_code.jl
+++ b/test/eval_code.jl
@@ -49,9 +49,10 @@ function f()
     x
 end
 frame = JuliaInterpreter.enter_call(f)
-JuliaInterpreter.step_expr!(frame)
-JuliaInterpreter.step_expr!(frame)
-@static if VERSION >= v"1.11-"
+# Step through the `Core.Box` initialization of `x`; the preamble's statement count
+# differs between lowering implementations, so step until `x` is defined.
+for _ in 1:10
+    any(v -> v.name === :x, JuliaInterpreter.locals(frame)) && break
     JuliaInterpreter.step_expr!(frame)
 end
 @test eval_code(frame, "x") == 1


### PR DESCRIPTION
The aim here is to use the improved provenance information of JuliaLowering to allow `next`, `step`, etc, follow the actual source. Ultimate goal includes eliminating the painful kwarg-pattern-matcher code.